### PR TITLE
reorg: marking loadbalancer errors as debug

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_funcs.go
+++ b/api/v1alpha1/tenantcontrolplane_funcs.go
@@ -5,12 +5,13 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kamajierrors "github.com/clastix/kamaji/internal/errors"
 )
 
 func (in *TenantControlPlane) GetAddress(ctx context.Context, client client.Client) (string, error) {
@@ -29,7 +30,7 @@ func (in *TenantControlPlane) GetAddress(ctx context.Context, client client.Clie
 	case svc.Spec.Type == corev1.ServiceTypeLoadBalancer:
 		loadBalancerStatus = svc.Status.LoadBalancer
 		if len(loadBalancerStatus.Ingress) == 0 {
-			return "", fmt.Errorf("cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer")
+			return "", kamajierrors.NonExposedLoadBalancerError{}
 		}
 
 		for _, lb := range loadBalancerStatus.Ingress {
@@ -39,5 +40,5 @@ func (in *TenantControlPlane) GetAddress(ctx context.Context, client client.Clie
 		}
 	}
 
-	return "", fmt.Errorf("the actual resource doesn't have yet a valid IP address")
+	return "", kamajierrors.MissingValidIPError{}
 }

--- a/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
+++ b/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
@@ -21,7 +21,7 @@ spec:
         labels:
           tenant.clastix.io: test
           kind.clastix.io: service
-      serviceType: ClusterIP
+      serviceType: LoadBalancer
     ingress:
       enabled: true
       hostname: kamaji.local

--- a/deploy/kind/kind-kamaji.yaml
+++ b/deploy/kind/kind-kamaji.yaml
@@ -10,6 +10,10 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
+  ## required for Cluster API local development
+  extraMounts:
+    - hostPath: /var/run/docker.sock
+      containerPath: /var/run/docker.sock
   extraPortMappings:
     ## expose port 80 of the node to port 80 on the host
   - containerPort: 80
@@ -27,4 +31,3 @@ nodes:
   - containerPort: 6443
     hostPort: 8443
     protocol: TCP
-

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+type NonExposedLoadBalancerError struct{}
+
+func (n NonExposedLoadBalancerError) Error() string {
+	return "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"
+}
+
+type MissingValidIPError struct{}
+
+func (m MissingValidIPError) Error() string {
+	return "the actual resource doesn't have yet a valid IP address"
+}

--- a/internal/errors/utils_controllers.go
+++ b/internal/errors/utils_controllers.go
@@ -1,0 +1,10 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import "github.com/pkg/errors"
+
+func ShouldReconcileErrorBeIgnored(err error) bool {
+	return errors.As(err, &NonExposedLoadBalancerError{}) || errors.As(err, &MissingValidIPError{})
+}


### PR DESCRIPTION
Fixes #31.

Output of the controller:

```
1.6537525872623112e+09  INFO    controller.tenantcontrolplane   Starting EventSource    {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "source": "kind source: *v1alpha1.TenantControlPlane"}
1.6537525872624443e+09  INFO    controller.tenantcontrolplane   Starting EventSource    {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "source": "kind source: *v1.Secret"}
1.6537525872624831e+09  INFO    controller.tenantcontrolplane   Starting EventSource    {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "source": "kind source: *v1.ConfigMap"}
1.6537525872624989e+09  INFO    controller.tenantcontrolplane   Starting EventSource    {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "source": "kind source: *v1.Deployment"}
1.6537525872625122e+09  INFO    controller.tenantcontrolplane   Starting EventSource    {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "source": "kind source: *v1.Service"}
1.653752587262527e+09   INFO    controller.tenantcontrolplane   Starting EventSource    {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "source": "kind source: *v1.Ingress"}
1.6537525872625387e+09  INFO    controller.tenantcontrolplane   Starting Controller     {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane"}
1.6537525873642886e+09  INFO    controller.tenantcontrolplane   Starting workers        {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "worker count": 1}
1.65375263595738e+09    DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526421039848e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526421045406e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526421157293e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.653752642157156e+09   DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526422384698e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526424000342e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526427211761e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.653752643362897e+09   DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.6537526446443973e+09  DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
1.653752647206421e+09   DEBUG   controller.tenantcontrolplane   sentinel error, enqueuing back request  {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
```

Please, note the `DEBUG` level that can be easily ignored.