### PR TITLE
Update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ With this solution, the resiliency is guaranteed by the usual `etcd` mechanism, 
 
 ## Getting started
 
-Please refer to the [getting started documentation](./docs/getting-started-with-kamaji.md) to deploy a minimal setup of Kamaji.
+Please refer to the [Getting Started guide](./docs/getting-started-with-kamaji.md) to deploy a minimal setup of Kamaji on KinD.
 
 ## Use cases
 Kamaji project has been initially started as a solution for actual and common problems such as minimizing the Total Cost of Ownership while running Kubernetes at large scale. However, it can open a wider range of use cases. Here are a few:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ A dedicated `etcd` cluster for each tenant cluster doesn’t scale well for a ma
 
 With this solution, the resiliency is guaranteed by the usual `etcd` mechanism, and the pods' count remains under control, so it solves the main goal of resiliency and costs optimization. The trade-off here is that we have to operate an external `etcd` cluster and manage the access to be sure that each tenant cluster uses only its data. Also, there are limits in size in `etcd`, defaulted to 2GB and configurable to a maximum of 8GB. We’re solving this issue by pooling multiple `etcd` and sharding the tenant control planes.
 
+## Getting started
+
+Please refer to the [getting started documentation](./docs/getting-started-with-kamaji.md) to deploy a minimal setup of Kamaji.
+
 ## Use cases
 Kamaji project has been initially started as a solution for actual and common problems such as minimizing the Total Cost of Ownership while running Kubernetes at large scale. However, it can open a wider range of use cases. Here are a few:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,16 @@
+# Deploy Kamaji
+
+## Quickstart with KinD
+
+```sh
+make -C kind
+```
+
+## Multi-tenant etcd cluster
+
+> This assumes you already have a running Kubernetes cluster and kubeconfig.
+
+```sh
+make -C etcd
+```
+

--- a/deploy/kind/Makefile
+++ b/deploy/kind/Makefile
@@ -11,7 +11,10 @@ prometheus-stack:
 	helm repo update
 	helm install prometheus-stack --create-namespace -n monitoring prometheus-community/kube-prometheus-stack
 
-kamaji: kind ingress-nginx etcd-cluster
+reqs: kind ingress-nginx etcd-cluster
+
+kamaji: reqs
+	@kubectl apply -f $(kind_path)/../../config/install.yaml
 
 destroy: kind/destroy etcd-certificates/cleanup
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,8 @@
 - [Architecture](./architecture.md)
 - [Concepts](./concepts.md)
 - [Getting started](./getting-started-with-kamaji.md)
-- [Deployment](./kamaji-deployment-guide.md)
-  - [Tenant deployment](./kamaji-tenant-deployment-guide.md)
-  - [Deployment on cloud provider: Azure](./kamaji-azure-deployment-guide.md)
+- [Kamaji Deployment](./kamaji-deployment-guide.md)
+- [Tenant deployment](./kamaji-tenant-deployment-guide.md)
+- Deployment on cloud providers:
+  - [Azure](./kamaji-azure-deployment-guide.md)
 - [Reference](./reference.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Kamaji documentation
+
+- [Architecture](./architecture.md)
+- [Concepts](./concepts.md)
+- [Getting started](./getting-started-with-kamaji.md)
+- [Deployment](./kamaji-deployment-guide.md)
+  - [Tenant deployment](./kamaji-tenant-deployment-guide.md)
+  - [Deployment on cloud provider: Azure](./kamaji-azure-deployment-guide.md)
+- [Reference](./reference.md)

--- a/docs/getting-started-with-kamaji.md
+++ b/docs/getting-started-with-kamaji.md
@@ -2,7 +2,7 @@
 
 This document explains how to deploy a minimal Kamaji setup on [KinD](https://kind.sigs.k8s.io/) for development scopes. Please refer to the [Kamaji documentation](../README.md) for understanding all the terms used in this guide, as for example: `admin cluster` and `tenant control plane`.
 
-## Tools
+## Pre-requisites
 
 We assume you have installed on your workstation:
 
@@ -23,21 +23,30 @@ The instance of Kamaji is made of a single node hosting:
 - admin worker
 - multi-tenant etcd cluster
 
+### Requisites
+
 The multi-tenant etcd cluster is deployed as statefulset into the Kamaji node.
 
-Run `make kamaji` to setup Kamaji on KinD.
+Run `make reqs` to setup Kamaji's requisites on KinD:
 
 ```bash
-cd ./deploy/kind
-make kamaji
+$ cd ./deploy/kind
+$ make reqs
 ```
 
-At this moment you will have your KinD up and running and ETCD cluster in multitenant mode. 
+At this moment you will have your KinD up and running and ETCD cluster in multitenant mode.
+
+Now you're ready to install Kamaji operator.
 
 ### Install Kamaji
 
 ```bash
 $ kubectl apply -f ../../config/install.yaml
+```
+Otherwise you can install all requisites and Kamaji operator with one single command:
+
+```bash
+$ make kamaji
 ```
 
 ### Deploy Tenant Control Plane
@@ -141,3 +150,9 @@ d2d4b468c9de   Ready    <none>   44s   v1.23.4
 > For more complex scenarios (exposing port, different version and so on), run `join-node.bash`
 
 Tenant control plane provision has been finished in a minimal Kamaji setup based on KinD. Therefore, you could develop, test and make your own experiments with Kamaji.
+
+## Cleanup
+
+```bash
+$ make destroy
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -80,7 +80,7 @@ $ make yaml-installation-file
 
 ```
 
-It will generate a yaml installation file at `config/installation.yaml`. It should be customize accordingly.
+It will generate a yaml installation file at `config/install.yaml`. It should be customize accordingly.
 
 
 ## Tenant Control Planes


### PR DESCRIPTION
This PR updates the documentation and updates the Make `kamaji` target to also install Kamaji (with `config/install.yaml` manifest).
> The previous `kamaji` target which installed requisites only for minimal setup on KinD is renamed to `reqs` (requisites). The documentation is updated accordingly.