### PR TITLE
feat: providing binary version and details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@
 FROM golang:1.18 as builder
 
 ARG TARGETARCH
+ARG GIT_HEAD_COMMIT
+ARG GIT_TAG_COMMIT
+ARG GIT_LAST_TAG
+ARG GIT_MODIFIED
+ARG GIT_REPO
+ARG BUILD_DATE
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,7 +24,9 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build \
+    -ldflags "-X github.com/clastix/kamaji/internal.GitRepo=$GIT_REPO -X github.com/clastix/kamaji/internal.GitTag=$GIT_LAST_TAG -X github.com/clastix/kamaji/internal.GitCommit=$GIT_HEAD_COMMIT -X github.com/clastix/kamaji/internal.GitDirty=$GIT_MODIFIED -X github.com/clastix/kamaji/internal.BuildTime=$BUILD_DATE" \
+    -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+var (
+	GitRepo   = ""
+	GitTag    = "dev"
+	GitCommit = ""
+	GitDirty  = "dirty"
+	BuildTime = ""
+)

--- a/main.go
+++ b/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	goRuntime "runtime"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -29,6 +31,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/controllers"
+	"github.com/clastix/kamaji/internal"
 	"github.com/clastix/kamaji/internal/config"
 )
 
@@ -49,6 +52,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading configuration.")
 	}
+
+	setupLog.Info(fmt.Sprintf("Kamaji version %s %s%s", internal.GitTag, internal.GitCommit, internal.GitDirty))
+	setupLog.Info(fmt.Sprintf("Build from: %s", internal.GitRepo))
+	setupLog.Info(fmt.Sprintf("Build date: %s", internal.BuildTime))
+	setupLog.Info(fmt.Sprintf("Go Version: %s", goRuntime.Version()))
+	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", goRuntime.GOOS, goRuntime.GOARCH))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
Closes #61.

Output in stdout at startup:

```
1.6554690552577298e+09  INFO    setup   Kamaji version 0.0.1 ab18186.dev.dirty
1.6554690552578115e+09  INFO    setup   Build from: git@github.com:prometherion/kamaji.git
1.6554690552578204e+09  INFO    setup   Build date: 2022-06-15T12:45:19
1.6554690552578237e+09  INFO    setup   Go Version: go1.18.1
1.6554690552578268e+09  INFO    setup   Go OS/Arch: linux/amd64
```