### PR TITLE
feat: logging resource deletion

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -45,10 +45,10 @@ func GetResources(config GroupResourceBuilderConfiguration) []resources.Resource
 	return getDefaultResources(config)
 }
 
-// GetDeleteableResources returns a list of resources that have to be deleted when tenant control planes are deleted
+// GetDeletableResources returns a list of resources that have to be deleted when tenant control planes are deleted
 // Currently there is only a default approach
 // TODO: the idea of this function is to become a factory to return the group of deleteable resources according to the given configuration.
-func GetDeleteableResources(config GroupDeleteableResourceBuilderConfiguration) []resources.DeleteableResource {
+func GetDeletableResources(config GroupDeleteableResourceBuilderConfiguration) []resources.DeleteableResource {
 	return getDefaultDeleteableResources(config)
 }
 


### PR DESCRIPTION
Closes #29.

Output presented in the logs with the following changes.

```
1.6575292343504794e+09  INFO    controller.tenantcontrolplane   marked for deletion, performing clean-up        {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default"}
1.6575292343881516e+09  INFO    controller.tenantcontrolplane   removing finalizer      {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default"}
1.6575292343985453e+09  INFO    controller.tenantcontrolplane   resource has completed clean-up {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default"}
```