### PR TITLE
Using TCP status as address source of truth

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_funcs.go
+++ b/api/v1alpha1/tenantcontrolplane_funcs.go
@@ -5,6 +5,9 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -14,7 +17,30 @@ import (
 	kamajierrors "github.com/clastix/kamaji/internal/errors"
 )
 
-func (in *TenantControlPlane) GetControlPlaneAddress(ctx context.Context, client client.Client) (string, error) {
+// AssignedControlPlaneAddress returns the announced address and port of a Tenant Control Plane.
+// In case of non-well formed values, or missing announcement, an error is returned.
+func (in *TenantControlPlane) AssignedControlPlaneAddress() (string, int32, error) {
+	if len(in.Status.ControlPlaneEndpoint) == 0 {
+		return "", 0, fmt.Errorf("the Tenant Control Plane is not yet exposed")
+	}
+
+	address, portString, err := net.SplitHostPort(in.Status.ControlPlaneEndpoint)
+	if err != nil {
+		return "", 0, errors.Wrap(err, "cannot split host port from Tenant Control Plane endpoint")
+	}
+
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		return "", 0, errors.Wrap(err, "cannot convert Tenant Control Plane port from endpoint")
+	}
+
+	return address, int32(port), nil
+}
+
+// DeclaredControlPlaneAddress returns the desired Tenant Control Plane address.
+// In case of dynamic allocation, e.g. using a Load Balancer, it queries the API Server looking for the allocated IP.
+// When an IP has not been yet assigned, or it is expected, an error is returned.
+func (in *TenantControlPlane) DeclaredControlPlaneAddress(ctx context.Context, client client.Client) (string, error) {
 	var loadBalancerStatus corev1.LoadBalancerStatus
 
 	svc := &corev1.Service{}

--- a/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
+++ b/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
@@ -5,48 +5,23 @@ metadata:
 spec:
   controlPlane:
     deployment:
-      replicas: 2
-      additionalMetadata:
-        annotations:
-          environment.clastix.io: test
-          tier.clastix.io: "0"
-        labels:
-          tenant.clastix.io: test
-          kind.clastix.io: deployment
+      replicas: 1
     service:
-      additionalMetadata:
-        annotations:
-          environment.clastix.io: test
-          tier.clastix.io: "0"
-        labels:
-          tenant.clastix.io: test
-          kind.clastix.io: service
       serviceType: LoadBalancer
     ingress:
-      enabled: true
-      hostname: kamaji.local
-      ingressClassName: nginx
-      additionalMetadata:
-        annotations:
-          kubernetes.io/ingress.allow-http: "false"
-          nginx.ingress.kubernetes.io/secure-backends: "true"
-          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+      enabled: false
   kubernetes:
     version: "v1.23.1"
     kubelet:
-      cgroupfs: systemd
+      cgroupfs: cgroupfs
     admissionControllers:
       - ResourceQuota
       - LimitRanger
   networkProfile:
-    address: "127.0.0.1"
     port: 6443
-    certSANs:
-      - "test.clastix.labs"
-    serviceCidr: "10.96.0.0/16"
-    podCidr: "10.244.0.0/16"
-    dnsServiceIPs:
-      - "10.96.0.10"
   addons:
     coreDNS: {}
     kubeProxy: {}
+    konnectivity:
+      proxyPort: 8134
+      serviceType: LoadBalancer

--- a/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
+++ b/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
@@ -5,23 +5,48 @@ metadata:
 spec:
   controlPlane:
     deployment:
-      replicas: 1
+      replicas: 2
+      additionalMetadata:
+        annotations:
+          environment.clastix.io: test
+          tier.clastix.io: "0"
+        labels:
+          tenant.clastix.io: test
+          kind.clastix.io: deployment
     service:
+      additionalMetadata:
+        annotations:
+          environment.clastix.io: test
+          tier.clastix.io: "0"
+        labels:
+          tenant.clastix.io: test
+          kind.clastix.io: service
       serviceType: LoadBalancer
     ingress:
-      enabled: false
+      enabled: true
+      hostname: kamaji.local
+      ingressClassName: nginx
+      additionalMetadata:
+        annotations:
+          kubernetes.io/ingress.allow-http: "false"
+          nginx.ingress.kubernetes.io/secure-backends: "true"
+          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   kubernetes:
     version: "v1.23.1"
     kubelet:
-      cgroupfs: cgroupfs
+      cgroupfs: systemd
     admissionControllers:
       - ResourceQuota
       - LimitRanger
   networkProfile:
+    address: "127.0.0.1"
     port: 6443
+    certSANs:
+      - "test.clastix.labs"
+    serviceCidr: "10.96.0.0/16"
+    podCidr: "10.244.0.0/16"
+    dnsServiceIPs:
+      - "10.96.0.10"
   addons:
     coreDNS: {}
     kubeProxy: {}
-    konnectivity:
-      proxyPort: 8134
-      serviceType: LoadBalancer

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -115,7 +115,6 @@ func getKubeadmConfigResources(c client.Client, tcpReconcilerConfig TenantContro
 	return []resources.Resource{
 		&resources.KubeadmConfigResource{
 			Name:                   "kubeadmconfig",
-			Port:                   tenantControlPlane.Spec.NetworkProfile.Port,
 			KubernetesVersion:      tenantControlPlane.Spec.Kubernetes.Version,
 			PodCIDR:                tenantControlPlane.Spec.NetworkProfile.PodCIDR,
 			ServiceCIDR:            tenantControlPlane.Spec.NetworkProfile.ServiceCIDR,

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -115,9 +115,6 @@ func getKubeadmConfigResources(c client.Client, tcpReconcilerConfig TenantContro
 	return []resources.Resource{
 		&resources.KubeadmConfigResource{
 			Name:                   "kubeadmconfig",
-			KubernetesVersion:      tenantControlPlane.Spec.Kubernetes.Version,
-			PodCIDR:                tenantControlPlane.Spec.NetworkProfile.PodCIDR,
-			ServiceCIDR:            tenantControlPlane.Spec.NetworkProfile.ServiceCIDR,
 			ETCDs:                  getArrayFromString(tcpReconcilerConfig.ETCDEndpoints),
 			ETCDCompactionInterval: tcpReconcilerConfig.ETCDCompactionInterval,
 			Client:                 c,

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -24,7 +24,7 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config // nolint
+	cfg       *rest.Config
 	k8sClient client.Client
 	testEnv   *envtest.Environment
 )
@@ -45,7 +45,9 @@ var _ = BeforeSuite(func() {
 		UseExistingCluster: pointer.Bool(true),
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/e2e/tenant_control_plane_ready_test.go
+++ b/e2e/tenant_control_plane_ready_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Deploy a TenantControlPlane resource", func() {
 
 	// Delete the TenantControlPlane resource after test is finished
 	JustAfterEach(func() {
+		PrintTenantControlPlaneInfo(&tcp)
 		PrintKamajiLogs()
 		Expect(k8sClient.Delete(context.Background(), &tcp)).Should(Succeed())
 	})

--- a/e2e/tenant_control_plane_ready_test.go
+++ b/e2e/tenant_control_plane_ready_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Deploy a TenantControlPlane resource", func() {
 
 	// Delete the TenantControlPlane resource after test is finished
 	JustAfterEach(func() {
+		PrintKamajiLogs()
 		Expect(k8sClient.Delete(context.Background(), &tcp)).Should(Succeed())
 	})
 

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -7,9 +7,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -4,11 +4,16 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
-
+	"fmt"
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 )
 
 func GetKindIPAddress() string {
@@ -16,4 +21,43 @@ func GetKindIPAddress() string {
 	Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: "kubernetes", Namespace: "default"}, ep)).ToNot(HaveOccurred())
 
 	return ep.Subsets[0].Addresses[0].IP
+}
+
+func PrintKamajiLogs() {
+	if CurrentGinkgoTestDescription().Failed {
+		clientset, err := kubernetes.NewForConfig(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		list, err := clientset.CoreV1().Pods("kamaji-system").List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/component=controller-manager",
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(list.Items).To(HaveLen(1))
+
+		request := clientset.CoreV1().Pods("kamaji-system").GetLogs(list.Items[0].GetName(), &corev1.PodLogOptions{
+			Container: "manager",
+			SinceSeconds: func() *int64 {
+				seconds := int64(CurrentGinkgoTestDescription().Duration.Seconds())
+
+				return &seconds
+			}(),
+			Timestamps: true,
+		})
+
+		podLogs, err := request.Stream(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+
+		defer podLogs.Close()
+
+		podBytes, err := ioutil.ReadAll(podLogs)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: retrieving Kamaji Pod logs")
+
+		for _, line := range bytes.Split(podBytes, []byte("\n")) {
+			_, _ = fmt.Fprintln(GinkgoWriter, ">>> ", string(line))
+		}
+
+		_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: end of Kamaji Pod logs")
+	}
 }

--- a/e2e/worker_kubeadm_join_test.go
+++ b/e2e/worker_kubeadm_join_test.go
@@ -92,6 +92,7 @@ var _ = Describe("starting a kind worker with kubeadm", func() {
 	})
 
 	JustAfterEach(func() {
+		PrintTenantControlPlaneInfo(&tcp)
 		PrintKamajiLogs()
 		Expect(workerContainer.Terminate(ctx)).ToNot(HaveOccurred())
 		Expect(k8sClient.Delete(ctx, &tcp)).Should(Succeed())

--- a/e2e/worker_kubeadm_join_test.go
+++ b/e2e/worker_kubeadm_join_test.go
@@ -92,8 +92,9 @@ var _ = Describe("starting a kind worker with kubeadm", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(k8sClient.Delete(ctx, &tcp)).Should(Succeed())
+		PrintKamajiLogs()
 		Expect(workerContainer.Terminate(ctx)).ToNot(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, &tcp)).Should(Succeed())
 		Expect(os.Remove(kubeconfigFile.Name())).ToNot(HaveOccurred())
 	})
 

--- a/e2e/worker_tcp_change_port_test.go
+++ b/e2e/worker_tcp_change_port_test.go
@@ -50,7 +50,7 @@ var _ = Describe("validating kubeconfig", func() {
 				},
 				NetworkProfile: kamajiv1alpha1.NetworkProfileSpec{
 					Address: GetKindIPAddress(),
-					Port:    31443,
+					Port:    30001,
 				},
 				Kubernetes: kamajiv1alpha1.KubernetesSpec{
 					Version: "v1.23.6",
@@ -75,12 +75,13 @@ var _ = Describe("validating kubeconfig", func() {
 
 	JustAfterEach(func() {
 		PrintKamajiLogs()
+		PrintTenantControlPlaneInfo(tcp)
 		Expect(k8sClient.Delete(ctx, tcp)).Should(Succeed())
 		Expect(os.Remove(kubeconfigFile.Name())).ToNot(HaveOccurred())
 	})
 
 	It("return kubernetes version", func() {
-		for _, port := range []int32{31444, 31445, 31446} {
+		for _, port := range []int32{30002, 30003, 30004} {
 			Eventually(func() string {
 				By(fmt.Sprintf("ensuring TCP port is set to %d", port), func() {
 					Eventually(func() (err error) {
@@ -158,7 +159,7 @@ var _ = Describe("validating kubeconfig", func() {
 				})
 
 				return version.GitVersion
-			}, 5*time.Minute, 5*time.Second).Should(Equal(tcp.Spec.Kubernetes.Version))
+			}, 3*time.Minute, 5*time.Second).Should(Equal(tcp.Spec.Kubernetes.Version))
 		}
 	})
 })

--- a/e2e/worker_tcp_change_port_test.go
+++ b/e2e/worker_tcp_change_port_test.go
@@ -74,6 +74,7 @@ var _ = Describe("validating kubeconfig", func() {
 	})
 
 	JustAfterEach(func() {
+		PrintKamajiLogs()
 		Expect(k8sClient.Delete(ctx, tcp)).Should(Succeed())
 		Expect(os.Remove(kubeconfigFile.Name())).ToNot(HaveOccurred())
 	})

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -58,7 +58,7 @@ func (r *KubernetesDeploymentResource) Define(_ context.Context, tenantControlPl
 
 func (r *KubernetesDeploymentResource) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
 	return func() error {
-		address, err := tenantControlPlane.GetControlPlaneAddress(ctx, r.Client)
+		address, _, err := tenantControlPlane.AssignedControlPlaneAddress()
 		if err != nil {
 			return errors.Wrap(err, "cannot create TenantControlPlane Deployment")
 		}

--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,13 @@ func (r *KubernetesServiceResource) UpdateTenantControlPlaneStatus(ctx context.C
 	tenantControlPlane.Status.Kubernetes.Service.Name = r.resource.GetName()
 	tenantControlPlane.Status.Kubernetes.Service.Namespace = r.resource.GetNamespace()
 	tenantControlPlane.Status.Kubernetes.Service.Port = r.resource.Spec.Ports[0].Port
+
+	address, err := tenantControlPlane.DeclaredControlPlaneAddress(ctx, r.Client)
+	if err != nil {
+		return err
+	}
+
+	tenantControlPlane.Status.ControlPlaneEndpoint = fmt.Sprintf("%s:%d", address, tenantControlPlane.Spec.NetworkProfile.Port)
 
 	return nil
 }

--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -68,7 +68,7 @@ func (r *KubernetesServiceResource) CreateOrUpdate(ctx context.Context, tenantCo
 func (r *KubernetesServiceResource) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
 	// We don't need to check error here: in case of dynamic external IP, the Service must be created in advance.
 	// After that, the specific cloud controller-manager will provide an IP that will be then used.
-	address, _ := tenantControlPlane.GetControlPlaneAddress(ctx, r.Client)
+	address, _ := tenantControlPlane.DeclaredControlPlaneAddress(ctx, r.Client)
 
 	return func() error {
 		var servicePort corev1.ServicePort

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -99,10 +99,14 @@ func (r *Agent) UpdateTenantControlPlaneStatus(ctx context.Context, tenantContro
 }
 
 func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
-	return func() error {
+	return func() (err error) {
 		address := tenantControlPlane.Spec.Addons.Konnectivity.ProxyHost
-		if address == "" {
-			address = tenantControlPlane.Spec.NetworkProfile.Address
+		if len(address) == 0 {
+			// In case of no explicit konnectivity proxy host, using the Tenant Control Plane one
+			address, _, err = tenantControlPlane.AssignedControlPlaneAddress()
+			if err != nil {
+				return err
+			}
 		}
 
 		r.resource.SetLabels(utilities.MergeMaps(

--- a/internal/resources/kubeadm_config.go
+++ b/internal/resources/kubeadm_config.go
@@ -70,15 +70,9 @@ func (r *KubeadmConfigResource) GetName() string {
 }
 
 func (r *KubeadmConfigResource) UpdateTenantControlPlaneStatus(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
-	address, _, err := tenantControlPlane.AssignedControlPlaneAddress()
-	if err != nil {
-		return err
-	}
-
 	tenantControlPlane.Status.KubeadmConfig.LastUpdate = metav1.Now()
 	tenantControlPlane.Status.KubeadmConfig.Checksum = r.resource.GetAnnotations()["checksum"]
 	tenantControlPlane.Status.KubeadmConfig.ConfigmapName = r.resource.GetName()
-	tenantControlPlane.Status.ControlPlaneEndpoint = r.getControlPlaneEndpoint(tenantControlPlane.Spec.ControlPlane.Ingress, address, 0)
 
 	return nil
 }

--- a/internal/resources/kubeadm_utils.go
+++ b/internal/resources/kubeadm_utils.go
@@ -24,13 +24,18 @@ func KubeadmPhaseCreate(ctx context.Context, r KubeadmPhaseResource, tenantContr
 		return controllerutil.OperationResultNone, err
 	}
 
+	address, _, err := tenantControlPlane.AssignedControlPlaneAddress()
+	if err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
 	config.Kubeconfig = *kubeconfig
 	config.Parameters = kubeadm.Parameters{
 		TenantControlPlaneName:         tenantControlPlane.GetName(),
 		TenantDNSServiceIPs:            tenantControlPlane.Spec.NetworkProfile.DNSServiceIPs,
 		TenantControlPlaneVersion:      tenantControlPlane.Spec.Kubernetes.Version,
 		TenantControlPlanePodCIDR:      tenantControlPlane.Spec.NetworkProfile.PodCIDR,
-		TenantControlPlaneAddress:      tenantControlPlane.Spec.NetworkProfile.Address,
+		TenantControlPlaneAddress:      address,
 		TenantControlPlaneCertSANs:     tenantControlPlane.Spec.NetworkProfile.CertSANs,
 		TenantControlPlanePort:         tenantControlPlane.Spec.NetworkProfile.Port,
 		TenantControlPlaneCGroupDriver: tenantControlPlane.Spec.Kubernetes.Kubelet.CGroupFS.String(),


### PR DESCRIPTION
Closes #95 and #96, performing several refactorings:

- removing redundant option struct members
- using status as the source of truth for the TCP address
- ensuring the Service status is stored upon Service creation