### PR TITLE
Collapsing TCP and Konnectivity Service in a single resource

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -105,11 +105,6 @@ type AddonSpec struct{}
 type KonnectivitySpec struct {
 	// Port of Konnectivity proxy server.
 	ProxyPort int32 `json:"proxyPort"`
-	// Host of Konnectivity proxy server.
-	ProxyHost                string `json:"proxyHost,omitempty"`
-	AllowAddressAsExternalIP bool   `json:"allowAddressAsExternalIP,omitempty"`
-	// ServiceType allows specifying how to expose the Konnectivity Proxy Server.
-	ServiceType ServiceType `json:"serviceType"`
 	// Version for Konnectivity server and agent.
 	// +kubebuilder:default=v0.0.31
 	Version string `json:"version,omitempty"`

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -74,11 +74,6 @@ spec:
                         description: AgentImage defines the container image for Konnectivity's
                           agent.
                         type: string
-                      allowAddressAsExternalIP:
-                        type: boolean
-                      proxyHost:
-                        description: Host of Konnectivity proxy server.
-                        type: string
                       proxyPort:
                         description: Port of Konnectivity proxy server.
                         format: int32
@@ -116,21 +111,12 @@ spec:
                         description: ServerImage defines the container image for Konnectivity's
                           server.
                         type: string
-                      serviceType:
-                        description: ServiceType allows specifying how to expose the
-                          Konnectivity Proxy Server.
-                        enum:
-                        - ClusterIP
-                        - NodePort
-                        - LoadBalancer
-                        type: string
                       version:
                         default: v0.0.31
                         description: Version for Konnectivity server and agent.
                         type: string
                     required:
                     - proxyPort
-                    - serviceType
                     type: object
                   kubeProxy:
                     description: AddonSpec defines the spec for every addon.

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -73,11 +73,6 @@ spec:
                         default: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
                         description: AgentImage defines the container image for Konnectivity's agent.
                         type: string
-                      allowAddressAsExternalIP:
-                        type: boolean
-                      proxyHost:
-                        description: Host of Konnectivity proxy server.
-                        type: string
                       proxyPort:
                         description: Port of Konnectivity proxy server.
                         format: int32
@@ -108,20 +103,12 @@ spec:
                         default: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-server
                         description: ServerImage defines the container image for Konnectivity's server.
                         type: string
-                      serviceType:
-                        description: ServiceType allows specifying how to expose the Konnectivity Proxy Server.
-                        enum:
-                        - ClusterIP
-                        - NodePort
-                        - LoadBalancer
-                        type: string
                       version:
                         default: v0.0.31
                         description: Version for Konnectivity server and agent.
                         type: string
                     required:
                     - proxyPort
-                    - serviceType
                     type: object
                   kubeProxy:
                     description: AddonSpec defines the spec for every addon.

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os/exec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os/exec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/helm/kamaji/crds/tenantcontrolplane.yaml
+++ b/helm/kamaji/crds/tenantcontrolplane.yaml
@@ -74,11 +74,6 @@ spec:
                         description: AgentImage defines the container image for Konnectivity's
                           agent.
                         type: string
-                      allowAddressAsExternalIP:
-                        type: boolean
-                      proxyHost:
-                        description: Host of Konnectivity proxy server.
-                        type: string
                       proxyPort:
                         description: Port of Konnectivity proxy server.
                         format: int32
@@ -116,21 +111,12 @@ spec:
                         description: ServerImage defines the container image for Konnectivity's
                           server.
                         type: string
-                      serviceType:
-                        description: ServiceType allows specifying how to expose the
-                          Konnectivity Proxy Server.
-                        enum:
-                        - ClusterIP
-                        - NodePort
-                        - LoadBalancer
-                        type: string
                       version:
                         default: v0.0.31
                         description: Version for Konnectivity server and agent.
                         type: string
                     required:
                     - proxyPort
-                    - serviceType
                     type: object
                   kubeProxy:
                     description: AddonSpec defines the spec for every addon.

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -100,13 +100,9 @@ func (r *Agent) UpdateTenantControlPlaneStatus(ctx context.Context, tenantContro
 
 func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
 	return func() (err error) {
-		address := tenantControlPlane.Spec.Addons.Konnectivity.ProxyHost
-		if len(address) == 0 {
-			// In case of no explicit konnectivity proxy host, using the Tenant Control Plane one
-			address, _, err = tenantControlPlane.AssignedControlPlaneAddress()
-			if err != nil {
-				return err
-			}
+		address, _, err := tenantControlPlane.AssignedControlPlaneAddress()
+		if err != nil {
+			return err
 		}
 
 		r.resource.SetLabels(utilities.MergeMaps(


### PR DESCRIPTION
Closes #98.

With the following PR, when Konnectivity addon is enabled, just a single Service will be used exposing different ports.