### PR TITLE
CLI flag to specify Kine container image

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -248,6 +248,7 @@ func getKubernetesDeploymentResources(c client.Client, tcpReconcilerConfig Tenan
 			ETCDEndpoints:          getArrayFromString(tcpReconcilerConfig.ETCDEndpoints),
 			ETCDCompactionInterval: tcpReconcilerConfig.ETCDCompactionInterval,
 			ETCDStorageType:        tcpReconcilerConfig.ETCDStorageType,
+			KineContainerImage:     tcpReconcilerConfig.KineContainerImage,
 		},
 	}
 }

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -51,6 +51,7 @@ type TenantControlPlaneReconcilerConfig struct {
 	KineMySQLSecretNamespace  string
 	KineMySQLHost             string
 	KineMySQLPort             int
+	KineContainerImage        string
 }
 
 //+kubebuilder:rbac:groups=kamaji.clastix.io,resources=tenantcontrolplanes,verbs=get;list;watch;create;update;patch;delete

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -52,6 +52,7 @@ type Deployment struct {
 	ETCDEndpoints          []string
 	ETCDCompactionInterval string
 	ETCDStorageType        types.ETCDStorageType
+	KineContainerImage     string
 }
 
 func (d *Deployment) SetContainers(podSpec *corev1.PodSpec, tcp *kamajiv1alpha1.TenantControlPlane, address string) {
@@ -636,7 +637,7 @@ func (d *Deployment) buildKine(podSpec *corev1.PodSpec, tcp *kamajiv1alpha1.Tena
 		args["--key-file"] = "/kine/server.key"
 
 		podSpec.Containers[kineIndex].Name = kineContainerName
-		podSpec.Containers[kineIndex].Image = fmt.Sprintf("%s:%s", "rancher/kine", "v0.9.2-amd64") // TODO: parameter.
+		podSpec.Containers[kineIndex].Image = d.KineContainerImage
 		podSpec.Containers[kineIndex].Command = []string{"/bin/kine"}
 		podSpec.Containers[kineIndex].Args = utilities.ArgsFromMapToSlice(args)
 		podSpec.Containers[kineIndex].VolumeMounts = []corev1.VolumeMount{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ const (
 	defaultKineMySQLSecretNamespace  = "kamaji-system"
 	defaultKineMySQLHost             = "localhost"
 	defaultKineMySQLPort             = 3306
+	defaultKineImage                 = "rancher/kine:v0.9.2-amd64"
 )
 
 func InitConfig() (*viper.Viper, error) {
@@ -57,6 +58,7 @@ func InitConfig() (*viper.Viper, error) {
 	flag.String("kine-mysql-secret-namespace", defaultKineMySQLSecretNamespace, "Name of the namespace where the secret which contains MySQL (Kine) configuration.")
 	flag.String("kine-mysql-host", defaultKineMySQLHost, "Host where MySQL (Kine) is working")
 	flag.Int("kine-mysql-port", defaultKineMySQLPort, "Port where MySQL (Kine) is working")
+	flag.String("kine-image", defaultKineImage, "Container image along with tag to use for the Kine sidecar container (used only if etcd-storage-type is set to one of kine strategies)")
 
 	// Setup zap configuration
 	opts := zap.Options{
@@ -118,6 +120,9 @@ func InitConfig() (*viper.Viper, error) {
 		return nil, err
 	}
 	if err := config.BindEnv("kine-mysql-port", fmt.Sprintf("%s_KINE_MYSQL_PORT", envPrefix)); err != nil {
+		return nil, err
+	}
+	if err := config.BindEnv("kine-image", fmt.Sprintf("%s_KINE_IMAGE", envPrefix)); err != nil {
 		return nil, err
 	}
 

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -25,6 +25,7 @@ type KubernetesDeploymentResource struct {
 	ETCDEndpoints          []string
 	ETCDCompactionInterval string
 	Name                   string
+	KineContainerImage     string
 }
 
 func (r *KubernetesDeploymentResource) isStatusEqual(tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {
@@ -68,6 +69,7 @@ func (r *KubernetesDeploymentResource) mutate(ctx context.Context, tenantControl
 			ETCDEndpoints:          r.ETCDEndpoints,
 			ETCDCompactionInterval: r.ETCDCompactionInterval,
 			ETCDStorageType:        r.ETCDStorageType,
+			KineContainerImage:     r.KineContainerImage,
 		}
 		d.SetLabels(r.resource, utilities.MergeMaps(utilities.CommonLabels(tenantControlPlane.GetName()), tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Labels))
 		d.SetAnnotations(r.resource, utilities.MergeMaps(r.resource.Annotations, tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Annotations))

--- a/kamaji.yaml
+++ b/kamaji.yaml
@@ -13,3 +13,4 @@ kine-mysql-secret-name: "mysql-config"
 kine-mysql-secret-namespace: kamaji-system
 kine-mysql-host: localhost
 kine-mysql-port: 3306
+kine-image: rancher/kine:v0.9.2-amd64

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 			KineMySQLSecretNamespace:  conf.GetString("kine-mysql-secret-namespace"),
 			KineMySQLHost:             conf.GetString("kine-mysql-host"),
 			KineMySQLPort:             conf.GetInt("kine-mysql-port"),
+			KineContainerImage:        conf.GetString("kine-image"),
 		},
 	}
 


### PR DESCRIPTION
Closes #102.

A new CLI flag (`--kine-container`) has been introduced, with the default value of `rancher/kine:v0.9.2-amd64`. It can be overridden also using the kamaji configuration file (`kamaji.yaml`) using the key `kine-image`.