### PR TITLE
DataStore selection at the Tenant Control Plane level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY internal/ internal/
+COPY indexers/ indexers/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build \

--- a/api/v1alpha1/tenantcontrolplane_status.go
+++ b/api/v1alpha1/tenantcontrolplane_status.go
@@ -75,10 +75,11 @@ type DataStoreSetupStatus struct {
 
 // StorageStatus defines the observed state of StorageStatus.
 type StorageStatus struct {
-	Driver      string                     `json:"driver,omitempty"`
-	Config      DataStoreConfigStatus      `json:"config,omitempty"`
-	Setup       DataStoreSetupStatus       `json:"setup,omitempty"`
-	Certificate DataStoreCertificateStatus `json:"certificate,omitempty"`
+	Driver        string                     `json:"driver,omitempty"`
+	DataStoreName string                     `json:"dataStoreName,omitempty"`
+	Config        DataStoreConfigStatus      `json:"config,omitempty"`
+	Setup         DataStoreSetupStatus       `json:"setup,omitempty"`
+	Certificate   DataStoreCertificateStatus `json:"certificate,omitempty"`
 }
 
 // KubeconfigStatus contains information about the generated kubeconfig.

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -144,6 +144,10 @@ type AddonsSpec struct {
 
 // TenantControlPlaneSpec defines the desired state of TenantControlPlane.
 type TenantControlPlaneSpec struct {
+	// DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
+	// This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
+	// Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.
+	DataStore    string       `json:"dataStore,omitempty"`
 	ControlPlane ControlPlane `json:"controlPlane"`
 	// Kubernetes specification for tenant control plane
 	Kubernetes KubernetesSpec `json:"kubernetes"`

--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji/crds/tenantcontrolplane.yaml
+++ b/charts/kamaji/crds/tenantcontrolplane.yaml
@@ -328,6 +328,14 @@ spec:
                 required:
                 - service
                 type: object
+              dataStore:
+                description: DataStore allows to specify a DataStore that should be
+                  used to store the Kubernetes data for the given Tenant Control Plane.
+                  This parameter is optional and acts as an override over the default
+                  one which is used by the Kamaji Operator. Migration from a different
+                  DataStore to another one is not yet supported and the reconciliation
+                  will be blocked.
+                type: string
               kubernetes:
                 description: Kubernetes specification for tenant control plane
                 properties:
@@ -1308,6 +1316,8 @@ spec:
                       secretName:
                         type: string
                     type: object
+                  dataStoreName:
+                    type: string
                   driver:
                     type: string
                   setup:

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -328,6 +328,14 @@ spec:
                 required:
                 - service
                 type: object
+              dataStore:
+                description: DataStore allows to specify a DataStore that should be
+                  used to store the Kubernetes data for the given Tenant Control Plane.
+                  This parameter is optional and acts as an override over the default
+                  one which is used by the Kamaji Operator. Migration from a different
+                  DataStore to another one is not yet supported and the reconciliation
+                  will be blocked.
+                type: string
               kubernetes:
                 description: Kubernetes specification for tenant control plane
                 properties:
@@ -1308,6 +1316,8 @@ spec:
                       secretName:
                         type: string
                     type: object
+                  dataStoreName:
+                    type: string
                   driver:
                     type: string
                   setup:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -280,6 +280,9 @@ spec:
                 required:
                 - service
                 type: object
+              dataStore:
+                description: DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane. This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator. Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.
+                type: string
               kubernetes:
                 description: Kubernetes specification for tenant control plane
                 properties:
@@ -1068,6 +1071,8 @@ spec:
                       secretName:
                         type: string
                     type: object
+                  dataStoreName:
+                    type: string
                   driver:
                     type: string
                   setup:

--- a/controllers/datastore_controller.go
+++ b/controllers/datastore_controller.go
@@ -116,6 +116,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err := r.client.List(ctx, &tcpList, client.MatchingFieldsSelector{
 		Selector: fields.OneTermEqualSelector(indexers.TenantControlPlaneUsedDataStoreKey, ds.GetName()),
 	}); err != nil {
+		log.Error(err, "cannot retrieve list of the Tenant Control Plane using the following instance")
+
 		return reconcile.Result{}, err
 	}
 	// Updating the status with the list of Tenant Control Plane using the following Data Source
@@ -127,6 +129,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 	ds.Status.UsedBy = tcpSets.List()
 
 	if err := r.client.Status().Update(ctx, ds); err != nil {
+		log.Error(err, "cannot update the status for the given instance")
+
 		return reconcile.Result{}, err
 	}
 	// Triggering the reconciliation of the Tenant Control Plane upon a Secret change

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -175,7 +175,7 @@ func getKubernetesStorageResources(c client.Client, dbConnection datastore.Conne
 		&ds.Config{
 			Client:     c,
 			ConnString: dbConnection.GetConnectionString(),
-			Driver:     dbConnection.Driver(),
+			DataStore:  datastore,
 		},
 		&ds.Setup{
 			Client:     c,

--- a/indexers/indexer.go
+++ b/indexers/indexer.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package indexers
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+type Indexer interface {
+	Object() client.Object
+	Field() string
+	ExtractValue() client.IndexerFunc
+}

--- a/indexers/tcp_useddatastore.go
+++ b/indexers/tcp_useddatastore.go
@@ -1,0 +1,40 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package indexers
+
+import (
+	"context"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+)
+
+const (
+	TenantControlPlaneUsedDataStoreKey = "status.storage.dataStoreName"
+)
+
+type TenantControlPlaneStatusDataStore struct{}
+
+func (t *TenantControlPlaneStatusDataStore) Object() client.Object {
+	return &kamajiv1alpha1.TenantControlPlane{}
+}
+
+func (t *TenantControlPlaneStatusDataStore) Field() string {
+	return TenantControlPlaneUsedDataStoreKey
+}
+
+func (t *TenantControlPlaneStatusDataStore) ExtractValue() client.IndexerFunc {
+	return func(object client.Object) []string {
+		//nolint:forcetypeassert
+		tcp := object.(*kamajiv1alpha1.TenantControlPlane)
+
+		return []string{tcp.Status.Storage.DataStoreName}
+	}
+}
+
+func (t *TenantControlPlaneStatusDataStore) SetupWithManager(ctx context.Context, mgr controllerruntime.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, t.Object(), t.Field(), t.ExtractValue())
+}

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -20,12 +20,12 @@ type Config struct {
 	resource   *corev1.Secret
 	Client     client.Client
 	ConnString string
-	Driver     string
+	DataStore  kamajiv1alpha1.DataStore
 }
 
 func (r *Config) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {
 	return tenantControlPlane.Status.Storage.Config.Checksum != r.resource.GetAnnotations()["checksum"] ||
-		tenantControlPlane.Status.Storage.Driver != r.Driver
+		tenantControlPlane.Status.Storage.DataStoreName != r.DataStore.GetName()
 }
 
 func (r *Config) ShouldCleanup(*kamajiv1alpha1.TenantControlPlane) bool {
@@ -64,7 +64,8 @@ func (r *Config) GetName() string {
 }
 
 func (r *Config) UpdateTenantControlPlaneStatus(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
-	tenantControlPlane.Status.Storage.Driver = r.Driver
+	tenantControlPlane.Status.Storage.Driver = string(r.DataStore.Spec.Driver)
+	tenantControlPlane.Status.Storage.DataStoreName = r.DataStore.GetName()
 	tenantControlPlane.Status.Storage.Config.SecretName = r.resource.GetName()
 	tenantControlPlane.Status.Storage.Config.Checksum = r.resource.GetAnnotations()["checksum"]
 

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -27,6 +27,7 @@ type Resource interface {
 }
 
 type DeleteableResource interface {
+	GetName() string
 	Define(context.Context, *kamajiv1alpha1.TenantControlPlane) error
 	Delete(context.Context, *kamajiv1alpha1.TenantControlPlane) error
 }


### PR DESCRIPTION
This is a feature proposal not yet tracked in an issue, eager to get feedback.

Actually, Kamaji is expecting to persist all the Tenant Control Plane data in a unique DataStore that could be backed by different drivers. However, there's no way to pick a different DataStore that could have different resources and tiering for a specific set of Tenant Control Plane instances.

This feature adds a new field in the TCP definition (_JSON path_: `spec.dataStore`) that is used to reference an existing `DataStore` resource. This field is optional and in case of an empty value, the default datastore used by Kamaji (and referenced using the CLI flag `--datastore`) will be used.

Example of the resulting TCP manifest:

```yaml
apiVersion: kamaji.clastix.io/v1alpha1
kind: TenantControlPlane
metadata:
  name: test
spec:
  dataStore: tier-gold
  controlPlane:
    deployment:
      replicas: 1
    service:
      serviceType: LoadBalancer
  kubernetes:
    version: "v1.23.1"
    kubelet:
      cgroupfs: cgroupfs
    admissionControllers:
      - ResourceQuota
      - LimitRanger
  networkProfile:
    port: 6443
  addons:
    coreDNS: {}
    kubeProxy: {}
```

In case of referencing a non-existing `DataStore`, the controller won't process the `TenantControlPlane` object, unless it exists.

```
1.6617771905436206e+09  ERROR   controller.tenantcontrolplane   Reconciler error        {"reconciler group": "kamaji.clastix.io", "reconciler kind": "TenantControlPlane", "name": "test", "namespace": "default", "error": "cannot retrieve kamajiv1alpha.DataStore object: DataStore.kamaji.clastix.io \"notfound\" not found", "errorVerbose": "DataStore.kamaji.clastix.io \"notfound\" not found\ncannot retrieve kamajiv1alpha.DataStore object\ngithub.com/clastix/kamaji/controllers.(*TenantControlPlaneReconciler).dataStore\n\t/home/prometherion/Documents/clastix/kamaji/controllers/tenantcontrolplane_controller.go:244\ngithub.com/clastix/kamaji/controllers.(*TenantControlPlaneReconciler).Reconcile\n\t/home/prometherion/Documents/clastix/kamaji/controllers/tenantcontrolplane_controller.go:78\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/prometherion/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/prometherion/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/prometherion/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/prometherion/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571"}
```

Furthermore, since the `DataStore` object could be referenced by many `TenantControlPlane` resources, the deletion is blocked with a finalizer until all the `TCP` that are using it as a source of truth has been deleted.

```yaml
apiVersion: kamaji.clastix.io/v1alpha1
kind: DataStore
metadata:
  finalizers:
  - finalizer.kamaji.clastix.io/datastore
  name: default
spec:
  driver: etcd
  endpoints:
  - etcd-0.etcd.kamaji-system.svc.cluster.local:2379
  - etcd-1.etcd.kamaji-system.svc.cluster.local:2379
  - etcd-2.etcd.kamaji-system.svc.cluster.local:2379
  tlsConfig:
    certificateAuthority:
      certificate:
        secretReference:
          keyPath: ca.crt
          name: etcd-certs
          namespace: kamaji-system
      privateKey:
        secretReference:
          keyPath: ca.key
          name: etcd-certs
          namespace: kamaji-system
    clientCertificate:
      certificate:
        secretReference:
          keyPath: tls.crt
          name: root-client-certs
          namespace: kamaji-system
      privateKey:
        secretReference:
          keyPath: tls.key
          name: root-client-certs
          namespace: kamaji-system
status:
  usedBy:
  - default/test
```

> The state of the `TenantControlPlane` instances using the referenced `DataStore` is stored in the `status` subresource, key `usedBy`.