### PR TITLE
Support for scale subresource in Tenant Control Plane API

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_status.go
+++ b/api/v1alpha1/tenantcontrolplane_status.go
@@ -208,6 +208,8 @@ type KubernetesVersion struct {
 // KubernetesDeploymentStatus defines the status for the Tenant Control Plane Deployment in the management cluster.
 type KubernetesDeploymentStatus struct {
 	appsv1.DeploymentStatus `json:",inline"`
+	// Selector is the label selector used to group the Tenant Control Plane Pods used by the scale subresource.
+	Selector string `json:"selector"`
 	// The name of the Deployment for the given cluster.
 	Name string `json:"name"`
 	// The namespace which the Deployment for the given cluster is deployed.

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -174,6 +174,7 @@ type TenantControlPlaneSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
 // +kubebuilder:resource:shortName=tcp
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetes.version",description="Kubernetes version"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Kubernetes version"

--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji/crds/tenantcontrolplane.yaml
+++ b/charts/kamaji/crds/tenantcontrolplane.yaml
@@ -1227,6 +1227,10 @@ spec:
                           by this deployment (their labels match the selector).
                         format: int32
                         type: integer
+                      selector:
+                        description: Selector is the label selector used to group
+                          the Tenant Control Plane Pods used by the scale subresource.
+                        type: string
                       unavailableReplicas:
                         description: Total number of unavailable pods targeted by
                           this deployment. This is the total number of pods that are
@@ -1243,6 +1247,7 @@ spec:
                     required:
                     - name
                     - namespace
+                    - selector
                     type: object
                   ingress:
                     description: KubernetesIngressStatus defines the status for the
@@ -1547,4 +1552,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.kubernetesResources.deployment.selector
+        specReplicasPath: .spec.deployment.replicas
+        statusReplicasPath: .status.kubernetesResources.deployment.replicas
       status: {}

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -1227,6 +1227,10 @@ spec:
                           by this deployment (their labels match the selector).
                         format: int32
                         type: integer
+                      selector:
+                        description: Selector is the label selector used to group
+                          the Tenant Control Plane Pods used by the scale subresource.
+                        type: string
                       unavailableReplicas:
                         description: Total number of unavailable pods targeted by
                           this deployment. This is the total number of pods that are
@@ -1243,6 +1247,7 @@ spec:
                     required:
                     - name
                     - namespace
+                    - selector
                     type: object
                   ingress:
                     description: KubernetesIngressStatus defines the status for the
@@ -1547,4 +1552,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.kubernetesResources.deployment.selector
+        specReplicasPath: .spec.deployment.replicas
+        statusReplicasPath: .status.kubernetesResources.deployment.replicas
       status: {}

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -943,6 +943,9 @@ spec:
                         description: Total number of non-terminated pods targeted by this deployment (their labels match the selector).
                         format: int32
                         type: integer
+                      selector:
+                        description: Selector is the label selector used to group the Tenant Control Plane Pods used by the scale subresource.
+                        type: string
                       unavailableReplicas:
                         description: Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.
                         format: int32
@@ -954,6 +957,7 @@ spec:
                     required:
                     - name
                     - namespace
+                    - selector
                     type: object
                   ingress:
                     description: KubernetesIngressStatus defines the status for the Tenant Control Plane Ingress in the management cluster.
@@ -1172,6 +1176,10 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.kubernetesResources.deployment.selector
+        specReplicasPath: .spec.deployment.replicas
+        statusReplicasPath: .status.kubernetesResources.deployment.replicas
       status: {}
 ---
 apiVersion: v1

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -104,6 +104,7 @@ func (r *KubernetesDeploymentResource) UpdateTenantControlPlaneStatus(_ context.
 
 	tenantControlPlane.Status.Kubernetes.Deployment = kamajiv1alpha1.KubernetesDeploymentStatus{
 		DeploymentStatus: r.resource.Status,
+		Selector:         metav1.FormatLabelSelector(r.resource.Spec.Selector),
 		Name:             r.resource.GetName(),
 		Namespace:        r.resource.GetNamespace(),
 		LastUpdate:       metav1.Now(),


### PR DESCRIPTION
Closes #64.

Tested locally as follows:

```
$: kubectl scale --replicas=1 tcp/test
tenantcontrolplane.kamaji.clastix.io/test scaled
```