### PR TITLE
Wrong path for the Scale specification path

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -174,7 +174,7 @@ type TenantControlPlaneSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
+// +kubebuilder:subresource:scale:specpath=.spec.controlPlane.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
 // +kubebuilder:resource:shortName=tcp
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetes.version",description="Kubernetes version"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Kubernetes version"

--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji/crds/tenantcontrolplane.yaml
+++ b/charts/kamaji/crds/tenantcontrolplane.yaml
@@ -1554,6 +1554,6 @@ spec:
     subresources:
       scale:
         labelSelectorPath: .status.kubernetesResources.deployment.selector
-        specReplicasPath: .spec.deployment.replicas
+        specReplicasPath: .spec.controlPlane.deployment.replicas
         statusReplicasPath: .status.kubernetesResources.deployment.replicas
       status: {}

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -1554,6 +1554,6 @@ spec:
     subresources:
       scale:
         labelSelectorPath: .status.kubernetesResources.deployment.selector
-        specReplicasPath: .spec.deployment.replicas
+        specReplicasPath: .spec.controlPlane.deployment.replicas
         statusReplicasPath: .status.kubernetesResources.deployment.replicas
       status: {}

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1178,7 +1178,7 @@ spec:
     subresources:
       scale:
         labelSelectorPath: .status.kubernetesResources.deployment.selector
-        specReplicasPath: .spec.deployment.replicas
+        specReplicasPath: .spec.controlPlane.deployment.replicas
         statusReplicasPath: .status.kubernetesResources.deployment.replicas
       status: {}
 ---


### PR DESCRIPTION
Closes #152.

```
$: k get deployments.apps,pods
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test   2/2     2            2           4m43s

NAME                        READY   STATUS    RESTARTS   AGE
pod/test-5cc697869c-8vffn   3/3     Running   0          84s
pod/test-5cc697869c-swgbs   3/3     Running   0          4m43s

$: k scale tcp/test --replicas=3
tenantcontrolplane.kamaji.clastix.io/test scaled

$: k get deployments.apps,pods
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/test   3/3     3            3           5m13s

NAME                        READY   STATUS    RESTARTS   AGE
pod/test-5cc697869c-8vffn   3/3     Running   0          114s
pod/test-5cc697869c-rp797   3/3     Running   0          12s
pod/test-5cc697869c-swgbs   3/3     Running   0          5m13s
```