### PR TITLE
Release v0.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= 0.1.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= clastix.io/operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= clastix/kamaji:latest
+IMG ?= clastix/kamaji:v$(VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0
+appVersion: v0.1.0
 
 home: https://github.com/clastix/kamaji
 sources: ["https://github.com/clastix/kamaji"]

--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -1,6 +1,6 @@
 # kamaji
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
 Kamaji is a tool aimed to build and operate a Managed Kubernetes Service with a fraction of the operational burden. With Kamaji, you can deploy and operate hundreds of Kubernetes clusters as a hyper-scaler.
 
@@ -110,7 +110,7 @@ Here the values you can override:
 | healthProbeBindAddress | string | `":8081"` | The address the probe endpoint binds to. (default ":8081") |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"clastix/kamaji"` | The container image of the Kamaji controller. |
-| image.tag | string | `"latest"` |  |
+| image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"healthcheck"},"initialDelaySeconds":15,"periodSeconds":20}` | The livenessProbe for the controller container |
 | loggingDevel.enable | bool | `false` | (string) Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default false) |

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -9,8 +9,8 @@ image:
   # -- The container image of the Kamaji controller.
   repository: clastix/kamaji
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag:
 
 # -- A list of extra arguments to add to the kamaji controller default ones
 extraArgs: []

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1706,7 +1706,7 @@ spec:
         - --datastore=kamaji-etcd
         command:
         - /manager
-        image: clastix/kamaji:latest
+        image: clastix/kamaji:v0.1.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: clastix/kamaji
-  newTag: latest
+  newTag: v0.1.0


### PR DESCRIPTION
# Enhancements

- Reflecting current version of the deployed Tenant Control Plane version rather then the specified one in the spec [#5]
- Moving to Docker Hub as main container registry [#8] and GH Actions workflow [#16]
- Support for Go 1.18 [#12]
- Dynamic management of Addons (kube-proxy, core-dns) [#7, #107]
- Helm Chart automatic release [#50]
- Using default values for the network profile section of Tenant Control Plane [#58]
- Remove API Machinery NewYAMLSerializer() deprecated function [#60
- Report Kamaji version and info at startup [#62]
- Adding konnectivity as Addons [#25, #93, #100, #140]
- Missing or wrong header in source files [#71]
- Utils for tenant kubernetes client [#72]
- Making optional spec.networkProfile.domain and renaming it to certSANs [#75]
- Missing handling of conflicts during reconciliation [#54]
- Set image pull policy to Always [#82]
- Provide logs for deletion of Tenant Control Planes [#83]
- Make container resources allocation configurable in Tenant Control Plane pods [#99]
- Support for additional extra arguments in TCP components [#103]
- Support for etcd storage class and size in Helm chart [#112, #114]
- Introduce support for MySQL and PostgreSQL as datastore [#22]
- DataStore API [#67, #133]
- Upgrade dependencies to Kuberentes 1.25 [#136]
- Dynamic kube-proxy addon version [#137]
- DataStore selection at the Tenant Control Plane level [#138]
- Enable topology spread constraints on tcp deployment [#142]
- Add the scale subresource in TenantControlPlane custom resource definition [#144]
- 

# Bug fix

- Tenant Control Plane kubelet configuration is not updated upon cgroup driver change [#79]
- Reconciliation of Kubeconfig upon TCP address change [#90]
- kube-proxy kubeconfig is missing address when dynamically allocation [#97]
- Update link to Capsule in README [#120]
- Wrong ServiceAccountIssuer string in kube-apiserver [#149]
- Documentation alignements [#162]