### PR TITLE
Show datastore for each TenantControlPlane

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -187,9 +187,10 @@ type TenantControlPlaneSpec struct {
 // +kubebuilder:subresource:scale:specpath=.spec.controlPlane.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
 // +kubebuilder:resource:shortName=tcp
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetes.version",description="Kubernetes version"
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Kubernetes version"
-// +kubebuilder:printcolumn:name="Control-Plane-Endpoint",type="string",JSONPath=".status.controlPlaneEndpoint",description="Tenant Control Plane Endpoint (API server)"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Status"
+// +kubebuilder:printcolumn:name="Control-Plane endpoint",type="string",JSONPath=".status.controlPlaneEndpoint",description="Tenant Control Plane Endpoint (API server)"
 // +kubebuilder:printcolumn:name="Kubeconfig",type="string",JSONPath=".status.kubeconfig.admin.secretName",description="Secret which contains admin kubeconfig"
+//+kubebuilder:printcolumn:name="Datastore",type="string",JSONPath=".status.storage.dataStoreName",description="DataStore actually used"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Age"
 
 // TenantControlPlane is the Schema for the tenantcontrolplanes API.

--- a/charts/kamaji/crds/datastore.yaml
+++ b/charts/kamaji/crds/datastore.yaml
@@ -17,9 +17,9 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: Kamaji data store driver
-      jsonPath: .spec.driver
-      name: Driver
+    - description: DataStore actually used
+      jsonPath: .status.storage.dataStoreName
+      name: Datastore
       type: string
     - description: Age
       jsonPath: .metadata.creationTimestamp

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -22,17 +22,21 @@ spec:
       jsonPath: .spec.kubernetes.version
       name: Version
       type: string
-    - description: Kubernetes version
+    - description: Status
       jsonPath: .status.kubernetesResources.version.status
       name: Status
       type: string
     - description: Tenant Control Plane Endpoint (API server)
       jsonPath: .status.controlPlaneEndpoint
-      name: Control-Plane-Endpoint
+      name: Control-Plane endpoint
       type: string
     - description: Secret which contains admin kubeconfig
       jsonPath: .status.kubeconfig.admin.secretName
       name: Kubeconfig
+      type: string
+    - description: DataStore actually used
+      jsonPath: .status.storage.dataStoreName
+      name: Datastore
       type: string
     - description: Age
       jsonPath: .metadata.creationTimestamp

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -266,17 +266,21 @@ spec:
       jsonPath: .spec.kubernetes.version
       name: Version
       type: string
-    - description: Kubernetes version
+    - description: Status
       jsonPath: .status.kubernetesResources.version.status
       name: Status
       type: string
     - description: Tenant Control Plane Endpoint (API server)
       jsonPath: .status.controlPlaneEndpoint
-      name: Control-Plane-Endpoint
+      name: Control-Plane endpoint
       type: string
     - description: Secret which contains admin kubeconfig
       jsonPath: .status.kubeconfig.admin.secretName
       name: Kubeconfig
+      type: string
+    - description: DataStore actually used
+      jsonPath: .status.storage.dataStoreName
+      name: Datastore
       type: string
     - description: Age
       jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
Closes #183.

Since these changes are at the CRD level, the CRD must be patched manually. However, on a fresh installation it works.


```
$: kubectl get tcp
NAME   VERSION   STATUS   CONTROL-PLANE ENDPOINT   KUBECONFIG              DATASTORE   AGE
test   v1.23.1   Ready    172.18.255.200:6443      test-admin-kubeconfig   default     3m28s
```