### PR TITLE
Datastore deletion and collision fixes

### DIFF
--- a/internal/datastore/etcd.go
+++ b/internal/datastore/etcd.go
@@ -170,6 +170,6 @@ func (e *EtcdClient) Driver() string {
 	return string(kamajiv1alpha1.EtcdDriver)
 }
 
-func (e *EtcdClient) buildKey(roleName string) string {
-	return fmt.Sprintf("/%s/", roleName)
+func (e *EtcdClient) buildKey(key string) string {
+	return fmt.Sprintf("/%s/", key)
 }

--- a/internal/datastore/etcd.go
+++ b/internal/datastore/etcd.go
@@ -128,9 +128,8 @@ func (e *EtcdClient) DeleteUser(ctx context.Context, user string) error {
 }
 
 func (e *EtcdClient) DeleteDB(ctx context.Context, dbName string) error {
-	withRange := etcdclient.WithRange(rangeEnd)
 	prefix := e.buildKey(dbName)
-	if _, err := e.Client.Delete(ctx, prefix, withRange); err != nil {
+	if _, err := e.Client.Delete(ctx, prefix, etcdclient.WithPrefix()); err != nil {
 		return errors.NewCannotDeleteDatabaseError(err)
 	}
 

--- a/internal/resources/datastore/datastore_certificate.go
+++ b/internal/resources/datastore/datastore_certificate.go
@@ -110,7 +110,7 @@ func (r *Certificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1al
 				return err
 			}
 
-			crt, key, err = crypto.GenerateCertificatePrivateKeyPair(crypto.NewCertificateTemplate(tenantControlPlane.GetName()), ca, privateKey)
+			crt, key, err = crypto.GenerateCertificatePrivateKeyPair(crypto.NewCertificateTemplate(fmt.Sprintf("%s_%s", tenantControlPlane.GetNamespace(), tenantControlPlane.GetName())), ca, privateKey)
 			if err != nil {
 				logger.Error(err, "unable to generate certificate and private key")
 

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -5,6 +5,7 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -88,8 +89,8 @@ func (r *Config) mutate(_ context.Context, tenantControlPlane *kamajiv1alpha1.Te
 
 		r.resource.Data = map[string][]byte{
 			"DB_CONNECTION_STRING": []byte(r.ConnString),
-			"DB_SCHEMA":            []byte(tenantControlPlane.GetName()),
-			"DB_USER":              []byte(tenantControlPlane.GetName()),
+			"DB_SCHEMA":            []byte(fmt.Sprintf("%s_%s", tenantControlPlane.GetNamespace(), tenantControlPlane.GetName())),
+			"DB_USER":              []byte(fmt.Sprintf("%s_%s", tenantControlPlane.GetNamespace(), tenantControlPlane.GetName())),
 			"DB_PASSWORD":          password,
 		}
 


### PR DESCRIPTION
Closes #201.

Along with the said issue, this PR solves a problem with a potential collision with the schema names: if a TCP named `test` was created in the namespace `foo`, and another one named `test` too in another namespace named `bar`, there would have been a collision in the Datastore with the already created user, schema, and grants.