### PR TITLE
Dropping DataStore finalizer in favor of Webhook management

### DIFF
--- a/api/v1alpha1/datastore_secret_webhook.go
+++ b/api/v1alpha1/datastore_secret_webhook.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//+kubebuilder:webhook:path=/validate--v1-secret,mutating=false,failurePolicy=ignore,sideEffects=None,groups="",resources=secrets,verbs=delete,versions=v1,name=vdatastoresecrets.kb.io,admissionReviewVersions=v1
+
+type dataStoreSecretValidator struct {
+	log    logr.Logger
+	client client.Client
+}
+
+func (d *dataStoreSecretValidator) ValidateCreate(context.Context, runtime.Object) error {
+	return nil
+}
+
+func (d *dataStoreSecretValidator) ValidateUpdate(context.Context, runtime.Object, runtime.Object) error {
+	return nil
+}
+
+func (d *dataStoreSecretValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	secret := obj.(*corev1.Secret) //nolint:forcetypeassert
+
+	dsList := &DataStoreList{}
+
+	if err := d.client.List(ctx, dsList, client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(DatastoreUsedSecretNamespacedNameKey, fmt.Sprintf("%s/%s", secret.GetNamespace(), secret.GetName()))}); err != nil {
+		return err
+	}
+
+	if len(dsList.Items) > 0 {
+		var res []string
+
+		for _, ds := range dsList.Items {
+			res = append(res, ds.GetName())
+		}
+
+		return fmt.Errorf("the Secret is used by the following kamajiv1alpha1.DataStores and cannot be deleted (%s)", strings.Join(res, ", "))
+	}
+
+	return nil
+}
+
+func (d *dataStoreSecretValidator) Default(context.Context, runtime.Object) error {
+	return nil
+}

--- a/api/v1alpha1/indexer_datastore_usedsecret.go
+++ b/api/v1alpha1/indexer_datastore_usedsecret.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	DatastoreUsedSecretNamespacedNameKey = "secretRef"
+)
+
+type DatastoreUsedSecret struct{}
+
+func (d *DatastoreUsedSecret) SetupWithManager(ctx context.Context, mgr controllerruntime.Manager) error {
+	return mgr.GetFieldIndexer().IndexField(ctx, d.Object(), d.Field(), d.ExtractValue())
+}
+
+func (d *DatastoreUsedSecret) Object() client.Object {
+	return &DataStore{}
+}
+
+func (d *DatastoreUsedSecret) Field() string {
+	return DatastoreUsedSecretNamespacedNameKey
+}
+
+func (d *DatastoreUsedSecret) ExtractValue() client.IndexerFunc {
+	return func(object client.Object) (res []string) {
+		ds := object.(*DataStore) //nolint:forcetypeassert
+
+		if ds.Spec.BasicAuth != nil {
+			if ds.Spec.BasicAuth.Username.SecretRef != nil {
+				res = append(res, d.namespacedName(*ds.Spec.BasicAuth.Username.SecretRef))
+			}
+
+			if ds.Spec.BasicAuth.Password.SecretRef != nil {
+				res = append(res, d.namespacedName(*ds.Spec.BasicAuth.Password.SecretRef))
+			}
+		}
+
+		if ds.Spec.TLSConfig.CertificateAuthority.Certificate.SecretRef != nil {
+			res = append(res, d.namespacedName(*ds.Spec.TLSConfig.CertificateAuthority.Certificate.SecretRef))
+		}
+
+		if ds.Spec.TLSConfig.CertificateAuthority.PrivateKey != nil && ds.Spec.TLSConfig.CertificateAuthority.PrivateKey.SecretRef != nil {
+			res = append(res, d.namespacedName(*ds.Spec.TLSConfig.CertificateAuthority.PrivateKey.SecretRef))
+		}
+
+		if ds.Spec.TLSConfig.ClientCertificate.Certificate.SecretRef != nil {
+			res = append(res, d.namespacedName(*ds.Spec.TLSConfig.ClientCertificate.Certificate.SecretRef))
+		}
+
+		if ds.Spec.TLSConfig.ClientCertificate.PrivateKey.SecretRef != nil {
+			res = append(res, d.namespacedName(*ds.Spec.TLSConfig.ClientCertificate.PrivateKey.SecretRef))
+		}
+
+		return res
+	}
+}
+
+func (d *DatastoreUsedSecret) namespacedName(ref SecretReference) string {
+	return fmt.Sprintf("%s/%s", ref.Namespace, ref.Name)
+}

--- a/api/v1alpha1/indexer_tenantcontrolplane_useddatastore.go
+++ b/api/v1alpha1/indexer_tenantcontrolplane_useddatastore.go
@@ -1,15 +1,13 @@
 // Copyright 2022 Clastix Labs
 // SPDX-License-Identifier: Apache-2.0
 
-package indexers
+package v1alpha1
 
 import (
 	"context"
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 const (
@@ -19,7 +17,7 @@ const (
 type TenantControlPlaneStatusDataStore struct{}
 
 func (t *TenantControlPlaneStatusDataStore) Object() client.Object {
-	return &kamajiv1alpha1.TenantControlPlane{}
+	return &TenantControlPlane{}
 }
 
 func (t *TenantControlPlaneStatusDataStore) Field() string {
@@ -28,8 +26,7 @@ func (t *TenantControlPlaneStatusDataStore) Field() string {
 
 func (t *TenantControlPlaneStatusDataStore) ExtractValue() client.IndexerFunc {
 	return func(object client.Object) []string {
-		//nolint:forcetypeassert
-		tcp := object.(*kamajiv1alpha1.TenantControlPlane)
+		tcp := object.(*TenantControlPlane) //nolint:forcetypeassert
 
 		return []string{tcp.Status.Storage.DataStoreName}
 	}

--- a/charts/kamaji/templates/rbac.yaml
+++ b/charts/kamaji/templates/rbac.yaml
@@ -127,12 +127,6 @@ rules:
 - apiGroups:
     - kamaji.clastix.io
   resources:
-    - datastores/finalizers
-  verbs:
-    - update
-- apiGroups:
-    - kamaji.clastix.io
-  resources:
     - datastores/status
   verbs:
     - get

--- a/charts/kamaji/templates/validatingwebhookconfiguration.yaml
+++ b/charts/kamaji/templates/validatingwebhookconfiguration.yaml
@@ -14,6 +14,25 @@ webhooks:
       service:
         name: {{ include "kamaji.webhookServiceName" . }}
         namespace: {{ .Release.Namespace }}
+        path: /validate--v1-secret
+    failurePolicy: Ignore
+    name: vdatastoresecrets.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - secrets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "kamaji.webhookServiceName" . }}
+        namespace: {{ .Release.Namespace }}
         path: /validate-kamaji-clastix-io-v1alpha1-datastore
     failurePolicy: Fail
     name: vdatastore.kb.io
@@ -25,6 +44,7 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+          - DELETE
         resources:
           - datastores
     sideEffects: None

--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -22,7 +22,6 @@ import (
 	cmdutils "github.com/clastix/kamaji/cmd/utils"
 	"github.com/clastix/kamaji/controllers"
 	"github.com/clastix/kamaji/controllers/soot"
-	"github.com/clastix/kamaji/indexers"
 	"github.com/clastix/kamaji/internal"
 	datastoreutils "github.com/clastix/kamaji/internal/datastore/utils"
 	"github.com/clastix/kamaji/internal/webhook"
@@ -131,7 +130,13 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				return err
 			}
 
-			if err = (&indexers.TenantControlPlaneStatusDataStore{}).SetupWithManager(ctx, mgr); err != nil {
+			if err = (&kamajiv1alpha1.DatastoreUsedSecret{}).SetupWithManager(ctx, mgr); err != nil {
+				setupLog.Error(err, "unable to create indexer", "indexer", "DatastoreUsedSecret")
+
+				return err
+			}
+
+			if err = (&kamajiv1alpha1.TenantControlPlaneStatusDataStore{}).SetupWithManager(ctx, mgr); err != nil {
 				setupLog.Error(err, "unable to create indexer", "indexer", "TenantControlPlaneStatusDataStore")
 
 				return err

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -2060,12 +2060,6 @@ rules:
 - apiGroups:
   - kamaji.clastix.io
   resources:
-  - datastores/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - kamaji.clastix.io
-  resources:
   - datastores/status
   verbs:
   - get
@@ -2454,6 +2448,25 @@ webhooks:
     service:
       name: kamaji-webhook-service
       namespace: kamaji-system
+      path: /validate--v1-secret
+  failurePolicy: Ignore
+  name: vdatastoresecrets.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kamaji-webhook-service
+      namespace: kamaji-system
       path: /validate-kamaji-clastix-io-v1alpha1-datastore
   failurePolicy: Fail
   name: vdatastore.kb.io
@@ -2465,6 +2478,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - datastores
   sideEffects: None

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,12 +78,6 @@ rules:
 - apiGroups:
   - kamaji.clastix.io
   resources:
-  - datastores/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - kamaji.clastix.io
-  resources:
   - datastores/status
   verbs:
   - get

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -58,6 +58,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate--v1-secret
+  failurePolicy: Ignore
+  name: vdatastoresecrets.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-kamaji-clastix-io-v1alpha1-datastore
   failurePolicy: Fail
   name: vdatastore.kb.io
@@ -69,6 +88,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - datastores
   sideEffects: None


### PR DESCRIPTION
This is a refactoring moving the validation logic of the Secrets from the finalizer perspective to the webhook one, making the UX more compliant to the Kubernetes expected one.