### PR TITLE
TCP kube-apiserver customization for kubelet-preferred-address-types

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -33,7 +33,23 @@ type NetworkProfileSpec struct {
 	DNSServiceIPs []string `json:"dnsServiceIPs,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=Hostname;InternalIP;ExternalIP;InternalDNS;ExternalDNS
+type KubeletPreferredAddressType string
+
+const (
+	NodeHostName    KubeletPreferredAddressType = "Hostname"
+	NodeInternalIP  KubeletPreferredAddressType = "InternalIP"
+	NodeExternalIP  KubeletPreferredAddressType = "ExternalIP"
+	NodeInternalDNS KubeletPreferredAddressType = "InternalDNS"
+	NodeExternalDNS KubeletPreferredAddressType = "ExternalDNS"
+)
+
 type KubeletSpec struct {
+	// Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
+	// Default to Hostname, InternalIP, ExternalIP.
+	// +kubebuilder:default={"Hostname","InternalIP","ExternalIP"}
+	// +kubebuilder:validation:MinItems=1
+	PreferredAddressTypes []KubeletPreferredAddressType `json:"preferredAddressTypes,omitempty"`
 	// CGroupFS defines the  cgroup driver for Kubelet
 	// https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/
 	CGroupFS CGroupDriver `json:"cgroupfs,omitempty"`

--- a/charts/kamaji/crds/tenantcontrolplane.yaml
+++ b/charts/kamaji/crds/tenantcontrolplane.yaml
@@ -1000,6 +1000,22 @@ spec:
                             - systemd
                             - cgroupfs
                           type: string
+                        preferredAddressTypes:
+                          default:
+                            - Hostname
+                            - InternalIP
+                            - ExternalIP
+                          description: Ordered list of the preferred NodeAddressTypes to use for kubelet connections. Default to Hostname, InternalIP, ExternalIP.
+                          items:
+                            enum:
+                              - Hostname
+                              - InternalIP
+                              - ExternalIP
+                              - InternalDNS
+                              - ExternalDNS
+                            type: string
+                          minItems: 1
+                          type: array
                       type: object
                     version:
                       description: Kubernetes Version for the tenant control plane

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -1676,6 +1676,24 @@ spec:
                         - systemd
                         - cgroupfs
                         type: string
+                      preferredAddressTypes:
+                        default:
+                        - Hostname
+                        - InternalIP
+                        - ExternalIP
+                        description: Ordered list of the preferred NodeAddressTypes
+                          to use for kubelet connections. Default to Hostname, InternalIP,
+                          ExternalIP.
+                        items:
+                          enum:
+                          - Hostname
+                          - InternalIP
+                          - ExternalIP
+                          - InternalDNS
+                          - ExternalDNS
+                          type: string
+                        minItems: 1
+                        type: array
                     type: object
                   version:
                     description: Kubernetes Version for the tenant control plane

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1245,6 +1245,22 @@ spec:
                         - systemd
                         - cgroupfs
                         type: string
+                      preferredAddressTypes:
+                        default:
+                        - Hostname
+                        - InternalIP
+                        - ExternalIP
+                        description: Ordered list of the preferred NodeAddressTypes to use for kubelet connections. Default to Hostname, InternalIP, ExternalIP.
+                        items:
+                          enum:
+                          - Hostname
+                          - InternalIP
+                          - ExternalIP
+                          - InternalDNS
+                          - ExternalDNS
+                          type: string
+                        minItems: 1
+                        type: array
                     type: object
                   version:
                     description: Kubernetes Version for the tenant control plane

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2937,6 +2937,15 @@ Kubernetes specification for tenant control plane
             <i>Enum</i>: systemd, cgroupfs<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>preferredAddressTypes</b></td>
+        <td>[]enum</td>
+        <td>
+          Ordered list of the preferred NodeAddressTypes to use for kubelet connections. Default to Hostname, InternalIP, ExternalIP.<br/>
+          <br/>
+            <i>Default</i>: [Hostname InternalIP ExternalIP]<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/e2e/tcp_validation_preferredkubeletaddresstypes_test.go
+++ b/e2e/tcp_validation_preferredkubeletaddresstypes_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+)
+
+var _ = Describe("Deploy a TenantControlPlane with wrong preferred kubelet address type entries", func() {
+	It("should fail when using duplicates", func() {
+		Consistently(func() error {
+			tcp := &kamajiv1alpha1.TenantControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicated-kubelet-preferred-address-type",
+					Namespace: "default",
+				},
+				Spec: kamajiv1alpha1.TenantControlPlaneSpec{
+					DataStore: "default",
+					ControlPlane: kamajiv1alpha1.ControlPlane{
+						Deployment: kamajiv1alpha1.DeploymentSpec{
+							Replicas: 1,
+						},
+						Service: kamajiv1alpha1.ServiceSpec{
+							ServiceType: "ClusterIP",
+						},
+					},
+					Kubernetes: kamajiv1alpha1.KubernetesSpec{
+						Version: "v1.23.6",
+						Kubelet: kamajiv1alpha1.KubeletSpec{
+							PreferredAddressTypes: []kamajiv1alpha1.KubeletPreferredAddressType{
+								kamajiv1alpha1.NodeHostName,
+								kamajiv1alpha1.NodeInternalIP,
+								kamajiv1alpha1.NodeExternalIP,
+								kamajiv1alpha1.NodeHostName,
+							},
+							CGroupFS: "cgroupfs",
+						},
+					},
+				},
+			}
+
+			return k8sClient.Create(context.Background(), tcp)
+		}, 10*time.Second, time.Second).ShouldNot(Succeed())
+	})
+
+	It("should fail when using non valid entries", func() {
+		Consistently(func() error {
+			tcp := &kamajiv1alpha1.TenantControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicated-kubelet-preferred-address-type",
+					Namespace: "default",
+				},
+				Spec: kamajiv1alpha1.TenantControlPlaneSpec{
+					DataStore: "default",
+					ControlPlane: kamajiv1alpha1.ControlPlane{
+						Deployment: kamajiv1alpha1.DeploymentSpec{
+							Replicas: 1,
+						},
+						Service: kamajiv1alpha1.ServiceSpec{
+							ServiceType: "ClusterIP",
+						},
+					},
+					Kubernetes: kamajiv1alpha1.KubernetesSpec{
+						Version: "v1.23.6",
+						Kubelet: kamajiv1alpha1.KubeletSpec{
+							PreferredAddressTypes: []kamajiv1alpha1.KubeletPreferredAddressType{
+								kamajiv1alpha1.NodeHostName,
+								kamajiv1alpha1.NodeInternalIP,
+								kamajiv1alpha1.NodeExternalIP,
+								"Foo",
+							},
+							CGroupFS: "cgroupfs",
+						},
+					},
+				},
+			}
+
+			return k8sClient.Create(context.Background(), tcp)
+		}, 10*time.Second, time.Second).ShouldNot(Succeed())
+	})
+})

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -555,6 +555,12 @@ func (d *Deployment) buildKubeAPIServerCommand(tenantControlPlane *kamajiv1alpha
 		extraArgs = utilities.ArgsFromSliceToMap(tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs.APIServer)
 	}
 
+	kubeletPreferredAddressTypes := make([]string, 0, len(tenantControlPlane.Spec.Kubernetes.Kubelet.PreferredAddressTypes))
+
+	for _, addressType := range tenantControlPlane.Spec.Kubernetes.Kubelet.PreferredAddressTypes {
+		kubeletPreferredAddressTypes = append(kubeletPreferredAddressTypes, string(addressType))
+	}
+
 	desiredArgs := map[string]string{
 		"--allow-privileged":                   "true",
 		"--authorization-mode":                 "Node,RBAC",
@@ -565,7 +571,7 @@ func (d *Deployment) buildKubeAPIServerCommand(tenantControlPlane *kamajiv1alpha
 		"--service-cluster-ip-range":           tenantControlPlane.Spec.NetworkProfile.ServiceCIDR,
 		"--kubelet-client-certificate":         path.Join(v1beta3.DefaultCertificatesDir, constants.APIServerKubeletClientCertName),
 		"--kubelet-client-key":                 path.Join(v1beta3.DefaultCertificatesDir, constants.APIServerKubeletClientKeyName),
-		"--kubelet-preferred-address-types":    "Hostname,InternalIP,ExternalIP",
+		"--kubelet-preferred-address-types":    strings.Join(kubeletPreferredAddressTypes, ","),
 		"--proxy-client-cert-file":             path.Join(v1beta3.DefaultCertificatesDir, constants.FrontProxyClientCertName),
 		"--proxy-client-key-file":              path.Join(v1beta3.DefaultCertificatesDir, constants.FrontProxyClientKeyName),
 		"--requestheader-allowed-names":        constants.FrontProxyClientCertCommonName,


### PR DESCRIPTION
Closes #245.

Tested from a previous Kamaji installation and the defaults are inherited by the previous TCP instances.

Furthermore, keeping the default value we used, although not respecting the default by Kubernetes, and can be fixed once release v0.2.0.

Added tests, and validation to avoid duplicates, and added API documentation.