### PR TITLE
Resources labels consistency

### DIFF
--- a/docs/content/guides/kamaji-azure-deployment-guide.md
+++ b/docs/content/guides/kamaji-azure-deployment-guide.md
@@ -203,7 +203,7 @@ spec:
     protocol: TCP
     targetPort: ${TENANT_PORT}
   selector:
-    kamaji.clastix.io/soot: ${TENANT_NAME}
+    kamaji.clastix.io/name: ${TENANT_NAME}
   type: LoadBalancer
 EOF
 

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -785,7 +785,7 @@ func (d *Deployment) buildKine(podSpec *corev1.PodSpec, tcp *kamajiv1alpha1.Tena
 func (d *Deployment) SetSelector(deploymentSpec *appsv1.DeploymentSpec, tcp *kamajiv1alpha1.TenantControlPlane) {
 	deploymentSpec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"kamaji.clastix.io/soot": tcp.GetName(),
+			"kamaji.clastix.io/name": tcp.GetName(),
 		},
 	}
 }

--- a/internal/constants/labels.go
+++ b/internal/constants/labels.go
@@ -6,4 +6,7 @@ package constants
 const (
 	ProjectNameLabelKey   = "kamaji.clastix.io/project"
 	ProjectNameLabelValue = "kamaji"
+
+	ControlPlaneLabelKey      = "kamaji.clastix.io/name"
+	ControlPlaneLabelResource = "kamaji.clastix.io/component"
 )

--- a/internal/resources/api_server_certificate.go
+++ b/internal/resources/api_server_certificate.go
@@ -138,13 +138,7 @@ func (r *APIServerCertificate) mutate(ctx context.Context, tenantControlPlane *k
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/api_server_kubelet_client_certificate.go
+++ b/internal/resources/api_server_kubelet_client_certificate.go
@@ -136,13 +136,7 @@ func (r *APIServerKubeletClientCertificate) mutate(ctx context.Context, tenantCo
 			kubeadmconstants.APIServerKubeletClientKeyName:  certificateKeyPair.PrivateKey,
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/resources/ca_certificate.go
+++ b/internal/resources/ca_certificate.go
@@ -124,13 +124,7 @@ func (r *CACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 			kubeadmconstants.CAKeyName:  ca.PrivateKey,
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/resources/datastore/datastore_certificate.go
+++ b/internal/resources/datastore/datastore_certificate.go
@@ -142,12 +142,8 @@ func (r *Certificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1al
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 
 		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
+			utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()),
 			r.resource.GetLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
 		))
 
 		return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -107,13 +107,7 @@ func (r *Config) mutate(_ context.Context, tenantControlPlane *kamajiv1alpha1.Te
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/front-proxy-client-certificate.go
+++ b/internal/resources/front-proxy-client-certificate.go
@@ -135,13 +135,7 @@ func (r *FrontProxyClientCertificate) mutate(ctx context.Context, tenantControlP
 			kubeadmconstants.FrontProxyClientKeyName:  certificateKeyPair.PrivateKey,
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/resources/front_proxy_ca_certificate.go
+++ b/internal/resources/front_proxy_ca_certificate.go
@@ -114,13 +114,7 @@ func (r *FrontProxyCACertificate) mutate(ctx context.Context, tenantControlPlane
 			kubeadmconstants.FrontProxyCAKeyName:  ca.PrivateKey,
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -76,7 +76,7 @@ func (r *KubernetesDeploymentResource) mutate(ctx context.Context, tenantControl
 			DataStore:          r.DataStore,
 			KineContainerImage: r.KineContainerImage,
 		}
-		d.SetLabels(r.resource, utilities.MergeMaps(utilities.CommonLabels(tenantControlPlane.GetName()), tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Labels))
+		d.SetLabels(r.resource, utilities.MergeMaps(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()), tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Labels))
 		d.SetAnnotations(r.resource, utilities.MergeMaps(r.resource.Annotations, tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Annotations))
 		d.SetTemplateLabels(&r.resource.Spec.Template, r.deploymentTemplateLabels(ctx, tenantControlPlane))
 		d.SetNodeSelector(&r.resource.Spec.Template.Spec, tenantControlPlane)
@@ -135,7 +135,8 @@ func (r *KubernetesDeploymentResource) deploymentTemplateLabels(ctx context.Cont
 	}
 
 	labels = map[string]string{
-		"kamaji.clastix.io/soot":                                            tenantControlPlane.GetName(),
+		"kamaji.clastix.io/name":                                            tenantControlPlane.GetName(),
+		"kamaji.clastix.io/component":                                       r.GetName(),
 		"component.kamaji.clastix.io/api-server-certificate":                hash(ctx, tenantControlPlane.GetNamespace(), tenantControlPlane.Status.Certificates.APIServer.SecretName),
 		"component.kamaji.clastix.io/api-server-kubelet-client-certificate": hash(ctx, tenantControlPlane.GetNamespace(), tenantControlPlane.Status.Certificates.APIServerKubeletClient.SecretName),
 		"component.kamaji.clastix.io/ca":                                    hash(ctx, tenantControlPlane.GetNamespace(), tenantControlPlane.Status.Certificates.CA.SecretName),

--- a/internal/resources/k8s_ingress_resource.go
+++ b/internal/resources/k8s_ingress_resource.go
@@ -69,7 +69,6 @@ func (r *KubernetesIngressResource) Define(_ context.Context, tenantControlPlane
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tenantControlPlane.GetName(),
 			Namespace: tenantControlPlane.GetNamespace(),
-			Labels:    utilities.CommonLabels(tenantControlPlane.GetName()),
 		},
 	}
 
@@ -80,7 +79,7 @@ func (r *KubernetesIngressResource) Define(_ context.Context, tenantControlPlane
 
 func (r *KubernetesIngressResource) mutate(tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
 	return func() error {
-		labels := utilities.MergeMaps(r.resource.GetLabels(), tenantControlPlane.Spec.ControlPlane.Ingress.AdditionalMetadata.Labels)
+		labels := utilities.MergeMaps(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()), tenantControlPlane.Spec.ControlPlane.Ingress.AdditionalMetadata.Labels)
 		r.resource.SetLabels(labels)
 
 		annotations := utilities.MergeMaps(r.resource.GetAnnotations(), tenantControlPlane.Spec.ControlPlane.Ingress.AdditionalMetadata.Annotations)

--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -80,14 +80,14 @@ func (r *KubernetesServiceResource) mutate(ctx context.Context, tenantControlPla
 	address, _ := tenantControlPlane.DeclaredControlPlaneAddress(ctx, r.Client)
 
 	return func() error {
-		labels := utilities.MergeMaps(utilities.CommonLabels(tenantControlPlane.GetName()), tenantControlPlane.Spec.ControlPlane.Service.AdditionalMetadata.Labels)
+		labels := utilities.MergeMaps(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()), tenantControlPlane.Spec.ControlPlane.Service.AdditionalMetadata.Labels)
 		r.resource.SetLabels(labels)
 
 		annotations := utilities.MergeMaps(r.resource.GetAnnotations(), tenantControlPlane.Spec.ControlPlane.Service.AdditionalMetadata.Annotations)
 		r.resource.SetAnnotations(annotations)
 
 		r.resource.Spec.Selector = map[string]string{
-			"kamaji.clastix.io/soot": tenantControlPlane.GetName(),
+			"kamaji.clastix.io/name": tenantControlPlane.GetName(),
 		}
 
 		if len(r.resource.Spec.Ports) == 0 {

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -109,13 +109,7 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 			return err
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"k8s-app":                         AgentName,
-				"addonmanager.kubernetes.io/mode": "Reconcile",
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		if r.resource.Spec.Selector == nil {
 			r.resource.Spec.Selector = &metav1.LabelSelector{}

--- a/internal/resources/konnectivity/certificate_resource.go
+++ b/internal/resources/konnectivity/certificate_resource.go
@@ -126,13 +126,7 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 			corev1.TLSPrivateKeyKey: privKey.Bytes(),
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/resources/konnectivity/cluster_role_binding_resource.go
+++ b/internal/resources/konnectivity/cluster_role_binding_resource.go
@@ -68,7 +68,7 @@ func (r *ClusterRoleBindingResource) Define(ctx context.Context, tenantControlPl
 
 func (r *ClusterRoleBindingResource) CreateOrUpdate(ctx context.Context, tcp *kamajiv1alpha1.TenantControlPlane) (controllerutil.OperationResult, error) {
 	if tcp.Spec.Addons.Konnectivity != nil {
-		return controllerutil.CreateOrUpdate(ctx, r.tenantClient, r.resource, r.mutate())
+		return controllerutil.CreateOrUpdate(ctx, r.tenantClient, r.resource, r.mutate(tcp))
 	}
 
 	return controllerutil.OperationResultNone, nil
@@ -93,10 +93,10 @@ func (r *ClusterRoleBindingResource) UpdateTenantControlPlaneStatus(_ context.Co
 	return nil
 }
 
-func (r *ClusterRoleBindingResource) mutate() controllerutil.MutateFn {
+func (r *ClusterRoleBindingResource) mutate(tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
 	return func() error {
 		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
+			utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()),
 			map[string]string{
 				"kubernetes.io/cluster-service":   "true",
 				"addonmanager.kubernetes.io/mode": "Reconcile",

--- a/internal/resources/konnectivity/egress_selector_configuration_resource.go
+++ b/internal/resources/konnectivity/egress_selector_configuration_resource.go
@@ -82,7 +82,7 @@ func (r *EgressSelectorConfigurationResource) UpdateTenantControlPlaneStatus(ctx
 
 func (r *EgressSelectorConfigurationResource) mutate(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) func() error {
 	return func() error {
-		r.resource.SetLabels(utilities.MergeMaps(r.resource.GetLabels(), utilities.KamajiLabels()))
+		r.resource.SetLabels(utilities.MergeMaps(r.resource.GetLabels(), utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName())))
 
 		configuration := &apiserverv1alpha1.EgressSelectorConfiguration{
 			TypeMeta: metav1.TypeMeta{

--- a/internal/resources/konnectivity/kubeconfig_resource.go
+++ b/internal/resources/konnectivity/kubeconfig_resource.go
@@ -157,13 +157,7 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/konnectivity/service_account_resource.go
+++ b/internal/resources/konnectivity/service_account_resource.go
@@ -69,7 +69,7 @@ func (r *ServiceAccountResource) Define(ctx context.Context, tenantControlPlane 
 
 func (r *ServiceAccountResource) CreateOrUpdate(ctx context.Context, tcp *kamajiv1alpha1.TenantControlPlane) (controllerutil.OperationResult, error) {
 	if tcp.Spec.Addons.Konnectivity != nil {
-		return controllerutil.CreateOrUpdate(ctx, r.tenantClient, r.resource, r.mutate())
+		return controllerutil.CreateOrUpdate(ctx, r.tenantClient, r.resource, r.mutate(tcp))
 	}
 
 	return controllerutil.OperationResultNone, nil
@@ -94,15 +94,9 @@ func (r *ServiceAccountResource) UpdateTenantControlPlaneStatus(_ context.Contex
 	return nil
 }
 
-func (r *ServiceAccountResource) mutate() controllerutil.MutateFn {
+func (r *ServiceAccountResource) mutate(tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {
 	return func() error {
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kubernetes.io/cluster-service":   "true",
-				"addonmanager.kubernetes.io/mode": "Reconcile",
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		return nil
 	}

--- a/internal/resources/kubeadm_config.go
+++ b/internal/resources/kubeadm_config.go
@@ -88,7 +88,7 @@ func (r *KubeadmConfigResource) mutate(ctx context.Context, tenantControlPlane *
 			return err
 		}
 
-		r.resource.SetLabels(utilities.KamajiLabels())
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		params := kubeadm.Parameters{
 			TenantControlPlaneAddress:     address,

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -174,13 +174,7 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 			r.KubeConfigFileName: kubeconfig,
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		r.resource.SetAnnotations(map[string]string{
 			constants.Checksum: checksum,

--- a/internal/resources/sa_certificate.go
+++ b/internal/resources/sa_certificate.go
@@ -113,13 +113,7 @@ func (r *SACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 			kubeadmconstants.ServiceAccountPrivateKeyName: sa.PrivateKey,
 		}
 
-		r.resource.SetLabels(utilities.MergeMaps(
-			utilities.KamajiLabels(),
-			map[string]string{
-				"kamaji.clastix.io/name":      tenantControlPlane.GetName(),
-				"kamaji.clastix.io/component": r.GetName(),
-			},
-		))
+		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/utilities/utilities.go
+++ b/internal/utilities/utilities.go
@@ -18,16 +18,11 @@ const (
 	separator = "-"
 )
 
-func KamajiLabels() map[string]string {
+func KamajiLabels(tcpName, resourceName string) map[string]string {
 	return map[string]string{
-		constants.ProjectNameLabelKey: constants.ProjectNameLabelValue,
-	}
-}
-
-func CommonLabels(clusterName string) map[string]string {
-	return map[string]string{
-		"kamaji.clastix.io/type":    "cluster",
-		"kamaji.clastix.io/cluster": clusterName,
+		constants.ProjectNameLabelKey:       constants.ProjectNameLabelValue,
+		constants.ControlPlaneLabelKey:      tcpName,
+		constants.ControlPlaneLabelResource: resourceName,
 	}
 }
 


### PR DESCRIPTION
This PR aims to make labels consistent across all the resources created in the admin Kuberentes cluster.

- `kamaji.clastix.io/name` refers to the Tenant Control Plane name
- `kamaji.clastix.io/component` refers to the Kamaji resource handler responsible for its reconciliation

⚠️ a deprecation occurred with the label `kamaji.clastix.io/soot`, replaced by `kamaji.clastix.io/name`:

> The label kamaji.clastix.io/soot is deprecated in favour of
> kamaji.clastix.io/name, every external resource referring to this must
> be aligned prior to updating to this version.

These are all the resources managed by Kamaji for a given Tenant Control Plane, along with the labels.

```
$: kubectl get service --show-labels
NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE    LABELS
kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP    6d3h   component=apiserver,provider=kubernetes
test         ClusterIP   10.96.181.179   <none>        6443/TCP   18s    

$: kubectl get secret --show-labels
NAME                                         TYPE                                  DATA   AGE    LABELS
default-token-dgmmd                          kubernetes.io/service-account-token   3      6d3h   <none>
test-admin-kubeconfig                        Opaque                                1      64s    kamaji.clastix.io/component=admin-kubeconfig,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-api-server-certificate                  Opaque                                2      64s    kamaji.clastix.io/component=api-server-certificate,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-api-server-kubelet-client-certificate   Opaque                                2      64s    kamaji.clastix.io/component=api-server-kubelet-client-certificate,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-ca                                      Opaque                                2      65s    kamaji.clastix.io/component=ca,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-controller-manager-kubeconfig           Opaque                                1      63s    kamaji.clastix.io/component=controller-manager-kubeconfig,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-datastore-certificate                   Opaque                                3      63s    kamaji.clastix.io/component=datastore-certificate,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-datastore-config                        Opaque                                4      63s    kamaji.clastix.io/component=datastore-config,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-front-proxy-ca-certificate              Opaque                                2      65s    kamaji.clastix.io/component=front-proxy-ca-certificate,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-front-proxy-client-certificate          Opaque                                2      64s    kamaji.clastix.io/component=front-proxy-client-certificate,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-sa-certificate                          Opaque                                2      65s    kamaji.clastix.io/component=sa-certificate,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji
test-scheduler-kubeconfig                    Opaque                                1      63s    kamaji.clastix.io/component=scheduler-kubeconfig,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji

$: kubectl get configmap --show-labels
NAME                 DATA   AGE    LABELS
kube-root-ca.crt     1      6d3h   <none>
test-kubeadmconfig   2      97s    kamaji.clastix.io/component=kubeadmconfig,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji

$: kubectl get deployments --show-labels
NAME   READY   UP-TO-DATE   AVAILABLE   AGE    LABELS
test   1/1     1            1           2m1s   kamaji.clastix.io/component=deployment,kamaji.clastix.io/name=test,kamaji.clastix.io/project=kamaji

$: kubectl get pods --show-labels
test-c954f97b9-x7vhv   3/3     Running   0          2m21s   component.kamaji.clastix.io/api-server-certificate=08e60cfe7bf04c8864f462895741d9f7,component.kamaji.clastix.io/api-server-kubelet-client-certificate=bd8b6c09d22138ed86a03e3511b40268,component.kamaji.clastix.io/ca=f2a46b6edd2fd77a38cd2f590665d4ad,component.kamaji.clastix.io/controller-manager-kubeconfig=4e4ba450d27d28c14226d655327ced16,component.kamaji.clastix.io/datastore=default,component.kamaji.clastix.io/front-proxy-ca-certificate=68123c36a716f7ba67dad88ff3c36ff6,component.kamaji.clastix.io/front-proxy-client-certificate=e078be094d02d4ad62e0e6b54adae380,component.kamaji.clastix.io/scheduler-kubeconfig=c7a4da04119a3f36fc65927a2c7e1dd2,component.kamaji.clastix.io/service-account=15596f7da3442da99d5b88dcca0136ae,kamaji.clastix.io/component=deployment,kamaji.clastix.io/name=test,pod-template-hash=c954f97b9
```