### PR TITLE
fix(webhook): wrong object for migrate route

### DIFF
--- a/internal/webhook/routes/tcp_freeze.go
+++ b/internal/webhook/routes/tcp_freeze.go
@@ -4,9 +4,8 @@
 package routes
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 type TenantControlPlaneMigrate struct{}
@@ -16,5 +15,5 @@ func (t TenantControlPlaneMigrate) GetPath() string {
 }
 
 func (t TenantControlPlaneMigrate) GetObject() runtime.Object {
-	return &kamajiv1alpha1.TenantControlPlane{}
+	return &corev1.Namespace{}
 }


### PR DESCRIPTION
Closes #313.

```
Error from server (the current Control Plane is in freezing mode due to a maintenance mode, all the changes are blocked: removing the webhook may lead to an inconsistent state upon its completion): admission webhook "catchall.migrate.kamaji.clastix.io" denied the request: the current Control Plane is in freezing mode due to a maintenance mode, all the changes are blocked: removing the webhook may lead to an inconsistent state upon its completion
```