### PR TITLE
Controller reconcile timeout

### DIFF
--- a/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
+++ b/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: kamaji.clastix.io/v1alpha1
 kind: TenantControlPlane
 metadata:
-  name: 126-k8s
+  name: k8s-126
 spec:
   controlPlane:
     deployment:

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -56,6 +56,7 @@ type TenantControlPlaneReconciler struct {
 
 // TenantControlPlaneReconcilerConfig gives the necessary configuration for TenantControlPlaneReconciler.
 type TenantControlPlaneReconcilerConfig struct {
+	ReconcileTimeout     time.Duration
 	DefaultDataStoreName string
 	KineContainerImage   string
 	TmpBaseDirectory     string
@@ -73,6 +74,10 @@ type TenantControlPlaneReconcilerConfig struct {
 
 func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
+
+	var cancelFn context.CancelFunc
+	ctx, cancelFn = context.WithTimeout(ctx, r.Config.ReconcileTimeout)
+	defer cancelFn()
 
 	tenantControlPlane, err := r.getTenantControlPlane(ctx, req.NamespacedName)()
 	if err != nil {


### PR DESCRIPTION
Closes #335.

A CLI flag has been introduced (`--controller-reconcile-timeout`) with a default value of 30 seconds.

A CLI validation is enforced, requiring a value greater than zero.