### PR TITLE
Supporting Tenant Control Plane to Kubernetes 1.28

### DIFF
--- a/docs/content/reference/versioning.md
+++ b/docs/content/reference/versioning.md
@@ -10,4 +10,5 @@ In Kamaji, there are different components that might require independent version
 | v0.3.0 | v1.22+        | [v1.21.0 .. v1.27.0] |
 | v0.3.1 | v1.22+        | [v1.21.0 .. v1.27.3] |
 | v0.3.2 | v1.22+        | [v1.21.0 .. v1.27.3] |
-| v0.3.2 | v1.22+        | [v1.21.0 .. v1.27.3] |
+| v0.3.3 | v1.22+        | [v1.21.0 .. v1.27.3] |
+| v0.3.4 | v1.22+        | [v1.21.0 .. v1.28.0] |

--- a/internal/upgrade/kubeadm_version.go
+++ b/internal/upgrade/kubeadm_version.go
@@ -4,5 +4,5 @@
 package upgrade
 
 const (
-	KubeadmVersion = "v1.27.3"
+	KubeadmVersion = "v1.28.0"
 )


### PR DESCRIPTION
Closes #348.