### PR TITLE
fix(helm): storage class key name

### DIFF
--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -15,7 +15,7 @@ name: kamaji
 sources:
 - https://github.com/clastix/kamaji
 type: application
-version: 0.12.7
+version: 0.12.8
 annotations:
   catalog.cattle.io/certified: partner
   catalog.cattle.io/release-name: kamaji

--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -1,6 +1,6 @@
 # kamaji
 
-![Version: 0.12.7](https://img.shields.io/badge/Version-0.12.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
+![Version: 0.12.8](https://img.shields.io/badge/Version-0.12.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.5](https://img.shields.io/badge/AppVersion-v0.3.5-informational?style=flat-square)
 
 Kamaji is a Kubernetes Control Plane Manager.
 
@@ -100,7 +100,7 @@ Here the values you can override:
 | etcd.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | etcd.persistence.customAnnotations | object | `{}` | The custom annotations to add to the PVC |
 | etcd.persistence.size | string | `"10Gi"` |  |
-| etcd.persistence.storageClass | string | `""` |  |
+| etcd.persistence.storageClassName | string | `""` |  |
 | etcd.port | int | `2379` | The client request port. |
 | etcd.serviceAccount.create | bool | `true` | Create a ServiceAccount, required to install and provision the etcd backing storage (default: true) |
 | etcd.serviceAccount.name | string | `""` | Define the ServiceAccount name to use during the setup and provision of the etcd backing storage (default: "") |

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -54,7 +54,7 @@ etcd:
     name: ""
   persistence:
     size: 10Gi
-    storageClass: ""
+    storageClassName: ""
     accessModes:
     - ReadWriteOnce
     # -- The custom annotations to add to the PVC


### PR DESCRIPTION
The name of the storageClass key is wrong in the Helm Chart, this fixes it.