### PR TITLE
Allow overriding secretKey for kubeadm kubeconfig

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -28,9 +28,10 @@ func (c CGroupDriver) String() string {
 }
 
 const (
-	ServiceTypeLoadBalancer = (ServiceType)(corev1.ServiceTypeLoadBalancer)
-	ServiceTypeClusterIP    = (ServiceType)(corev1.ServiceTypeClusterIP)
-	ServiceTypeNodePort     = (ServiceType)(corev1.ServiceTypeNodePort)
+	ServiceTypeLoadBalancer       = (ServiceType)(corev1.ServiceTypeLoadBalancer)
+	ServiceTypeClusterIP          = (ServiceType)(corev1.ServiceTypeClusterIP)
+	ServiceTypeNodePort           = (ServiceType)(corev1.ServiceTypeNodePort)
+	KubeconfigSecretKeyAnnotation = "kamaji.clastix.io/kubeconfig-secret-key"
 )
 
 // +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer

--- a/internal/utilities/tenant_client.go
+++ b/internal/utilities/tenant_client.go
@@ -44,7 +44,13 @@ func GetTenantKubeconfig(ctx context.Context, client client.Client, tenantContro
 		return nil, err
 	}
 
-	return DecodeKubeconfig(*secretKubeconfig, kubeadmconstants.SuperAdminKubeConfigFileName)
+	secretKey := kubeadmconstants.SuperAdminKubeConfigFileName
+	v, ok := tenantControlPlane.GetAnnotations()[kamajiv1alpha1.KubeconfigSecretKeyAnnotation]
+	if ok && v != "" {
+		secretKey = v
+	}
+
+	return DecodeKubeconfig(*secretKubeconfig, secretKey)
 }
 
 func GetRESTClientConfig(ctx context.Context, client client.Client, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) (*restclient.Config, error) {


### PR DESCRIPTION
follow up https://github.com/clastix/cluster-api-control-plane-provider-kamaji/pull/78

During reconciliation, the bootstrap provider copies the content from the secret provided by Kamaji, named `<cluster>-admin-kubeconfig` into a `cluster-info` configmap of tenant cluster, which then used by kubeadm to join nodes.

This change introduces a new annotation, `kamaji.clastix.io/kubeconfig-secret-key`, for the TenantControlPlane resource. This annotation instructs kamaji to read the kubeconfig from a specific key (the default one is super-admin.conf).

Example:

```
kamaji.clastix.io/kubeconfig-secret-key: super-admin.svc
```

This will instruct the system to use `super-admin.svc` a kubeconfig with a local service FQDN (introduced by https://github.com/clastix/kamaji/pull/403).

