### PR TITLE
Allow overriding konnectivity parameters

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -189,6 +189,9 @@ type ImageOverrideTrait struct {
 }
 
 // ExtraArgs allows adding additional arguments to said component.
+// WARNING - This option can override existing konnectivity
+// parameters and cause konnectivity components to misbehave in
+// unxpected ways. Only modify if you know what you are doing.
 type ExtraArgs []string
 
 type KonnectivityServerSpec struct {

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -92,7 +92,10 @@ spec:
                         properties:
                           extraArgs:
                             description: ExtraArgs allows adding additional arguments
-                              to said component.
+                              to said component. WARNING - This option can override
+                              existing konnectivity parameters and cause konnectivity
+                              components to misbehave in unxpected ways. Only modify
+                              if you know what you are doing.
                             items:
                               type: string
                             type: array
@@ -114,7 +117,10 @@ spec:
                         properties:
                           extraArgs:
                             description: ExtraArgs allows adding additional arguments
-                              to said component.
+                              to said component. WARNING - This option can override
+                              existing konnectivity parameters and cause konnectivity
+                              components to misbehave in unxpected ways. Only modify
+                              if you know what you are doing.
                             items:
                               type: string
                             type: array

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -340,7 +340,7 @@ spec:
                           version: v0.0.32
                         properties:
                           extraArgs:
-                            description: ExtraArgs allows adding additional arguments to said component.
+                            description: ExtraArgs allows adding additional arguments to said component. WARNING - This option can override existing konnectivity parameters and cause konnectivity components to misbehave in unxpected ways. Only modify if you know what you are doing.
                             items:
                               type: string
                             type: array
@@ -360,7 +360,7 @@ spec:
                           version: v0.0.32
                         properties:
                           extraArgs:
-                            description: ExtraArgs allows adding additional arguments to said component.
+                            description: ExtraArgs allows adding additional arguments to said component. WARNING - This option can override existing konnectivity parameters and cause konnectivity components to misbehave in unxpected ways. Only modify if you know what you are doing.
                             items:
                               type: string
                             type: array

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -11304,7 +11304,7 @@ Enables the Konnectivity addon in the Tenant Cluster, required if the worker nod
         <td><b>extraArgs</b></td>
         <td>[]string</td>
         <td>
-          ExtraArgs allows adding additional arguments to said component.<br/>
+          ExtraArgs allows adding additional arguments to said component. WARNING - This option can override existing konnectivity parameters and cause konnectivity components to misbehave in unxpected ways. Only modify if you know what you are doing.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11357,7 +11357,7 @@ Enables the Konnectivity addon in the Tenant Cluster, required if the worker nod
         <td><b>extraArgs</b></td>
         <td>[]string</td>
         <td>
-          ExtraArgs allows adding additional arguments to said component.<br/>
+          ExtraArgs allows adding additional arguments to said component. WARNING - This option can override existing konnectivity parameters and cause konnectivity components to misbehave in unxpected ways. Only modify if you know what you are doing.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -164,8 +164,7 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 		r.resource.Spec.Template.Spec.Containers[0].Name = AgentName
 		r.resource.Spec.Template.Spec.Containers[0].Command = []string{"/proxy-agent"}
 
-		args := utilities.ArgsFromSliceToMap(tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.ExtraArgs)
-
+		args := make(map[string]string)
 		args["-v"] = "8"
 		args["--logtostderr"] = "true"
 		args["--ca-cert"] = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
@@ -174,6 +173,12 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 		args["--admin-server-port"] = "8133"
 		args["--health-server-port"] = "8134"
 		args["--service-account-token-path"] = "/var/run/secrets/tokens/konnectivity-agent-token"
+
+		extraArgs := utilities.ArgsFromSliceToMap(tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.ExtraArgs)
+
+		for k, v := range extraArgs {
+			args[k] = v
+		}
 
 		r.resource.Spec.Template.Spec.Containers[0].Args = utilities.ArgsFromMapToSlice(args)
 		r.resource.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{


### PR DESCRIPTION
Fixes #410 

This will allow us to override konnectivity hard-coded defaults using the existing `extraArgs` parameter.