### PR TITLE
Add Ænix to the Adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,3 +4,15 @@ This is a list of companies that have adopted Kamaji.
 Feel free to open a Pull-Request to get yours listed.
 
 ### Adopter list (alphabetically)
+
+| Type | Name | Since | Website | Use-Case |
+|:-|:-|:-|:-|:-|
+| Vendor | Ænix | 2023 | [link](https://aenix.io/) | Ænix provides consulting services for cloud providers and uses Kamaji for running Kubernetes-as-a-Service in free PaaS platform [Cozystack](https://cozystack.io). |
+
+### Adopter Types
+
+**End-user**: The organization runs Kamaji in production in some way.
+
+**Integration**: The organization has a product that integrates with Kamaji, but does not contain Kamaji.
+
+**Vendor**: The organization packages Kamaji in their product and sells it as part of their product.


### PR DESCRIPTION
Hi, we utilize Kamaji as control-plane manager for running Kubernetes-as-a-Service in our free PaaS platform [Cozystack](https://cozystack.io).

We'd like to share this information :)