### PR TITLE
feat (helm): make cfssl image configurable in helm values

### DIFF
--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -15,7 +15,7 @@ name: kamaji
 sources:
 - https://github.com/clastix/kamaji
 type: application
-version: 0.14.1
+version: 0.15.0
 annotations:
   catalog.cattle.io/certified: partner
   catalog.cattle.io/release-name: kamaji

--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -1,6 +1,6 @@
 # kamaji
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square)
 
 Kamaji is a Kubernetes Control Plane Manager.
 
@@ -66,6 +66,8 @@ Here the values you can override:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Kubernetes affinity rules to apply to Kamaji controller pods |
+| cfssl.image.repository | string | `"cfssl/cfssl"` |  |
+| cfssl.image.tag | string | `"latest"` |  |
 | datastore.basicAuth.passwordSecret.keyPath | string | `nil` | The Secret key where the data is stored. |
 | datastore.basicAuth.passwordSecret.name | string | `nil` | The name of the Secret containing the password used to connect to the relational database. |
 | datastore.basicAuth.passwordSecret.namespace | string | `nil` | The namespace of the Secret containing the password used to connect to the relational database. |

--- a/charts/kamaji/templates/etcd_job_preinstall.yaml
+++ b/charts/kamaji/templates/etcd_job_preinstall.yaml
@@ -19,7 +19,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: cfssl
-          image: cfssl/cfssl:latest
+          image: "{{ .Values.cfssl.image.repository }}:{{ .Values.cfssl.image.tag }}"
           command:
             - bash
             - -c

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -214,3 +214,8 @@ datastore:
         namespace:
         # -- Key of the Secret which contains the content of the private key.
         keyPath:
+
+cfssl:
+  image:
+    repository: cfssl/cfssl
+    tag: latest


### PR DESCRIPTION
Allow configuration of the cfssl image in the helm values. There's a bug in the current arm64 builds for the cfssl image -https://github.com/cloudflare/cfssl/issues/1359 - meaning I can't run Kamaji currently on arm64.

Making this image configurable allows users to build their own to get around this issue.