### PR TITLE
Owner reference should be re-reconciled if it is lost for CA secret object

### DIFF
--- a/internal/resources/ca_certificate.go
+++ b/internal/resources/ca_certificate.go
@@ -105,7 +105,7 @@ func (r *CACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 			}
 
 			if isValid {
-				return nil
+				return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 			}
 		}
 

--- a/internal/resources/front_proxy_ca_certificate.go
+++ b/internal/resources/front_proxy_ca_certificate.go
@@ -91,7 +91,7 @@ func (r *FrontProxyCACertificate) mutate(ctx context.Context, tenantControlPlane
 				logger.Info(fmt.Sprintf("%s certificate-private_key pair is not valid: %s", kubeadmconstants.FrontProxyCACertAndKeyBaseName, err.Error()))
 			}
 			if isValid {
-				return nil
+				return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 			}
 		}
 

--- a/internal/resources/sa_certificate.go
+++ b/internal/resources/sa_certificate.go
@@ -90,7 +90,7 @@ func (r *SACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 				logger.Info(fmt.Sprintf("%s public_key-private_key pair is not valid: %s", kubeadmconstants.ServiceAccountKeyBaseName, err.Error()))
 			}
 			if isValid {
-				return nil
+				return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 			}
 		}
 


### PR DESCRIPTION
When you restore Kamaji tcp from backup, such tool as Velero deletes ownerReference on objects.
This may lead to bug if third-party controller take control  under restored objects.

In my case I lost ca.crt and ca.key files in CA secret object.
[The problem is described in detail here](https://github.com/clastix/cluster-api-control-plane-provider-kamaji/pull/83)

[According to CAPI specification about owner references:](https://cluster-api.sigs.k8s.io/reference/owner_references) 
Kamaji always has to restore owner reference for it's objects.

