### PR TITLE
Don't assume cluster dns domain

### DIFF
--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -68,6 +68,7 @@ Here the values you can override:
 | affinity | object | `{}` | Kubernetes affinity rules to apply to Kamaji controller pods |
 | cfssl.image.repository | string | `"cfssl/cfssl"` |  |
 | cfssl.image.tag | string | `"latest"` |  |
+| clusterDomain | string | `"cluster.local"` | Domain of the Kubernetes cluster. |
 | datastore.basicAuth.passwordSecret.keyPath | string | `nil` | The Secret key where the data is stored. |
 | datastore.basicAuth.passwordSecret.name | string | `nil` | The name of the Secret containing the password used to connect to the relational database. |
 | datastore.basicAuth.passwordSecret.namespace | string | `nil` | The namespace of the Secret containing the password used to connect to the relational database. |
@@ -77,7 +78,7 @@ Here the values you can override:
 | datastore.driver | string | `"etcd"` | (string) The Kamaji Datastore driver, supported: etcd, MySQL, PostgreSQL (defaults=etcd). |
 | datastore.enabled | bool | `true` | (bool) Enable the Kamaji Datastore creation (default=true) |
 | datastore.endpoints | list | `[]` | (array) List of endpoints of the selected Datastore. When letting the Chart install the etcd datastore, this field is populated automatically. |
-| datastore.nameOverride | string | `nil` | The Datastore name override, if empty and enabled=true defaults to `default`, if enabled=false, this is the name of the Datastore to connect to.  |
+| datastore.nameOverride | string | `nil` | The Datastore name override, if empty and enabled=true defaults to `default`, if enabled=false, this is the name of the Datastore to connect to. |
 | datastore.tlsConfig.certificateAuthority.certificate.keyPath | string | `nil` | Key of the Secret which contains the content of the certificate. |
 | datastore.tlsConfig.certificateAuthority.certificate.name | string | `nil` | Name of the Secret containing the CA required to establish the mandatory SSL/TLS connection to the datastore. |
 | datastore.tlsConfig.certificateAuthority.certificate.namespace | string | `nil` | Namespace of the Secret containing the CA required to establish the mandatory SSL/TLS connection to the datastore. |

--- a/charts/kamaji/templates/_helpers_etcd.tpl
+++ b/charts/kamaji/templates/_helpers_etcd.tpl
@@ -99,7 +99,7 @@ Comma separated list of etcd endpoints, using the overrides in case of unmanaged
 {{- $list := list -}}
 {{- if .Values.etcd.deploy }}
     {{- range $count := until 3 -}}
-        {{- $list = append $list (printf "%s-%d.%s.%s.svc.cluster.local:%d" "etcd" $count ( include "etcd.serviceName" . ) $.Release.Namespace (int $.Values.etcd.port) ) -}}
+        {{- $list = append $list (printf "%s-%d.%s.%s.svc.%s:%d" "etcd" $count ( include "etcd.serviceName" . ) $.Release.Namespace $.Values.clusterDomain (int $.Values.etcd.port) ) -}}
     {{- end }}
 {{- else if .Values.etcd.overrides.endpoints }}
     {{- range $v := .Values.etcd.overrides.endpoints -}}
@@ -118,7 +118,7 @@ Key-value of the etcd peers, using the overrides in case of unmanaged etcd.
 {{- $list := list -}}
 {{- if .Values.etcd.deploy }}
     {{- range $i, $count := until 3 -}}
-        {{- $list = append $list ( printf "etcd-%d=https://%s-%d.%s.%s.svc.cluster.local:%d" $i "etcd" $count ( include "etcd.serviceName" . ) $.Release.Namespace (int $.Values.etcd.peerApiPort) ) -}}
+        {{- $list = append $list ( printf "etcd-%d=https://%s-%d.%s.%s.svc.%s:%d" $i "etcd" $count ( include "etcd.serviceName" . ) $.Release.Namespace $.Values.clusterDomain (int $.Values.etcd.peerApiPort) ) -}}
     {{- end }}
 {{- else if .Values.etcd.overrides.endpoints }}
     {{- range $k, $v := .Values.etcd.overrides.endpoints -}}

--- a/charts/kamaji/templates/certmanager_certificate.yaml
+++ b/charts/kamaji/templates/certmanager_certificate.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   dnsNames:
     - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
-    - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   issuerRef:
     kind: Issuer
     name: kamaji-selfsigned-issuer

--- a/charts/kamaji/templates/etcd_cm.yaml
+++ b/charts/kamaji/templates/etcd_cm.yaml
@@ -57,9 +57,9 @@ data:
       },
       "hosts": [
 {{- range $count := until 3 -}}
-        {{ printf "\"etcd-%d.%s.%s.svc.cluster.local\"," $count (include "etcd.serviceName" .) $.Release.Namespace }}
+        {{ printf "\"etcd-%d.%s.%s.svc.%s\"," $count (include "etcd.serviceName" .) $.Release.Namespace $.Values.clusterDomain }}
 {{- end }}
-        "etcd-server.{{ .Release.Namespace }}.svc.cluster.local",
+        "etcd-server.{{ .Release.Namespace }}.svc.{{ $.Values.clusterDomain }}",
         "etcd-server.{{ .Release.Namespace }}.svc",
         "etcd-server",
         "127.0.0.1"
@@ -77,7 +77,7 @@ data:
         {{ printf "\"etcd-%d\"," $count }}
         {{ printf "\"etcd-%d.%s\"," $count (include "etcd.serviceName" .) }}
         {{ printf "\"etcd-%d.%s.%s.svc\"," $count (include "etcd.serviceName" .) $.Release.Namespace }}
-        {{ printf "\"etcd-%d.%s.%s.svc.cluster.local\"," $count (include "etcd.serviceName" .) $.Release.Namespace }}
+        {{ printf "\"etcd-%d.%s.%s.svc.%s\"," $count (include "etcd.serviceName" .) $.Release.Namespace $.Values.clusterDomain }}
 {{- end }}
         "127.0.0.1"
       ]

--- a/charts/kamaji/templates/etcd_job_postinstall.yaml
+++ b/charts/kamaji/templates/etcd_job_postinstall.yaml
@@ -41,7 +41,7 @@ spec:
               fi
           env:
             - name: ETCDCTL_ENDPOINTS
-              value: https://etcd-0.{{ include "etcd.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:2379
+              value: https://etcd-0.{{ include "etcd.serviceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:2379
             - name: ETCDCTL_CACERT
               value: /opt/certs/ca/ca.crt
             - name: ETCDCTL_CERT

--- a/charts/kamaji/templates/etcd_sts.yaml
+++ b/charts/kamaji/templates/etcd_sts.yaml
@@ -46,8 +46,8 @@ spec:
             - --name=$(POD_NAME)
             - --initial-cluster-state=new
             - --initial-cluster={{ include "etcd.initialCluster" . }}
-            - --initial-advertise-peer-urls=https://$(POD_NAME).etcd.$(POD_NAMESPACE).svc.cluster.local:2380
-            - --advertise-client-urls=https://$(POD_NAME).etcd.$(POD_NAMESPACE).svc.cluster.local:2379
+            - --initial-advertise-peer-urls=https://$(POD_NAME).etcd.$(POD_NAMESPACE).svc.{{ .Values.clusterDomain }}:2380
+            - --advertise-client-urls=https://$(POD_NAME).etcd.$(POD_NAMESPACE).svc.{{ .Values.clusterDomain }}:2379
             - --initial-cluster-token=kamaji
             - --listen-client-urls=https://0.0.0.0:2379
             - --listen-metrics-urls=http://0.0.0.0:2381

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -15,6 +15,8 @@ image:
 # -- A list of extra arguments to add to the kamaji controller default ones
 extraArgs: []
 
+# -- Domain of the Kubernetes cluster.
+clusterDomain: "cluster.local"
 
 serviceMonitor:
   # -- Toggle the ServiceMonitor true if you have Prometheus Operator installed and configured
@@ -56,11 +58,11 @@ etcd:
     size: 10Gi
     storageClassName: ""
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     # -- The custom annotations to add to the PVC
     customAnnotations: {}
     #  volumeType: local
-  
+
   # -- (array) Kubernetes affinity rules to apply to Kamaji etcd pods
   tolerations: []
 
@@ -162,7 +164,7 @@ loggingDevel:
 datastore:
   # -- (bool) Enable the Kamaji Datastore creation (default=true)
   enabled: true
-  # -- (string) The Datastore name override, if empty and enabled=true defaults to `default`, if enabled=false, this is the name of the Datastore to connect to. 
+  # -- (string) The Datastore name override, if empty and enabled=true defaults to `default`, if enabled=false, this is the name of the Datastore to connect to.
   nameOverride:
   # -- (string) The Kamaji Datastore driver, supported: etcd, MySQL, PostgreSQL (defaults=etcd).
   driver: etcd


### PR DESCRIPTION
Adds a `clusterDomain` helm chart value defaulted to `cluster.local`, allowing users to override the default Kubernetes DNS domain.

Fixes #433