### PR TITLE
fix(kubeadm): version getter must return component versions

### DIFF
--- a/internal/resources/kubeadm_upgrade.go
+++ b/internal/resources/kubeadm_upgrade.go
@@ -70,7 +70,7 @@ func (k *KubernetesUpgrade) CreateOrUpdate(ctx context.Context, tenantControlPla
 		return controllerutil.OperationResultNone, errors.Wrap(err, "cannot create REST client required for Kubernetes upgrade plan")
 	}
 
-	versionGetter := kamajiupgrade.NewKamajiKubeVersionGetter(clientSet)
+	versionGetter := kamajiupgrade.NewKamajiKubeVersionGetter(clientSet, tenantControlPlane.Status.Kubernetes.Version.Version)
 
 	if _, err = upgrade.GetAvailableUpgrades(versionGetter, false, false, clientSet, &printers.Discard{}); err != nil {
 		return controllerutil.OperationResultNone, errors.Wrap(err, "cannot retrieve available Upgrades for Kubernetes upgrade plan")

--- a/internal/upgrade/kube_version_getter.go
+++ b/internal/upgrade/kube_version_getter.go
@@ -16,12 +16,13 @@ import (
 
 type kamajiKubeVersionGetter struct {
 	upgrade.VersionGetter
+	Version string
 }
 
-func NewKamajiKubeVersionGetter(restClient kubernetes.Interface) upgrade.VersionGetter {
+func NewKamajiKubeVersionGetter(restClient kubernetes.Interface, version string) upgrade.VersionGetter {
 	kubeVersionGetter := upgrade.NewOfflineVersionGetter(upgrade.NewKubeVersionGetter(restClient), KubeadmVersion)
 
-	return &kamajiKubeVersionGetter{VersionGetter: kubeVersionGetter}
+	return &kamajiKubeVersionGetter{VersionGetter: kubeVersionGetter, Version: version}
 }
 
 func (k kamajiKubeVersionGetter) ClusterVersion() (string, *versionutil.Version, error) {
@@ -50,4 +51,10 @@ func (k kamajiKubeVersionGetter) VersionFromCILabel(ciVersionLabel, description 
 
 func (k kamajiKubeVersionGetter) KubeletVersions() (map[string][]string, error) {
 	return k.VersionGetter.KubeletVersions()
+}
+
+func (k kamajiKubeVersionGetter) ComponentVersions(string) (map[string][]string, error) {
+	return map[string][]string{
+		k.Version: {"kamaji"},
+	}, nil
 }


### PR DESCRIPTION
Fixes #447.

Must be ported to `master` branch too.