### PR TITLE
fix: simplify arg parsing

### DIFF
--- a/internal/utilities/args.go
+++ b/internal/utilities/args.go
@@ -14,13 +14,7 @@ func ArgsFromSliceToMap(args []string) (m map[string]string) {
 	m = make(map[string]string)
 
 	for _, arg := range args {
-		parts := strings.SplitN(arg, "=", 2)
-
-		flag, value := parts[0], ""
-
-		if len(parts) > 1 {
-			value = parts[1]
-		}
+		flag, value, _ := strings.Cut(arg, "=")
 
 		m[flag] = value
 	}

--- a/internal/utilities/args_test.go
+++ b/internal/utilities/args_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package utilities
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestArgsFromSliceToMap(t *testing.T) {
+	tests := map[string]map[string]string{
+		"--a":     {"--a": ""},
+		"--a=":    {"--a": ""},
+		"--a=b":   {"--a": "b"},
+		"--a=b=c": {"--a": "b=c"},
+	}
+
+	got := ArgsFromSliceToMap([]string{})
+	if len(got) != 0 {
+		t.Errorf("expected empty input to result in empty map, but got %+v", got)
+	}
+
+	for arg, expect := range tests {
+		got := ArgsFromSliceToMap([]string{arg})
+		if !maps.Equal(expect, got) {
+			t.Errorf("expected input %q to result in %+v, but got %+v", arg, expect, got)
+		}
+	}
+}


### PR DESCRIPTION
strings.Cut was introduced in go 1.18