### PR TITLE
feat: Add category to CRD

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -266,7 +266,7 @@ type TenantControlPlaneSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.controlPlane.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
-// +kubebuilder:resource:shortName=tcp
+// +kubebuilder:resource:categories=kamaji,shortName=tcp
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetes.version",description="Kubernetes version"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Status"
 // +kubebuilder:printcolumn:name="Control-Plane endpoint",type="string",JSONPath=".status.controlPlaneEndpoint",description="Tenant Control Plane Endpoint (API server)"

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: kamaji.clastix.io
   names:
+    categories:
+    - kamaji
     kind: TenantControlPlane
     listKind: TenantControlPlaneList
     plural: tenantcontrolplanes

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -309,6 +309,8 @@ spec:
       - v1
   group: kamaji.clastix.io
   names:
+    categories:
+    - kamaji
     kind: TenantControlPlane
     listKind: TenantControlPlaneList
     plural: tenantcontrolplanes


### PR DESCRIPTION
This allows to view TCPs and KamajiControlPlanes (see https://github.com/clastix/cluster-api-control-plane-provider-kamaji/pull/104) with `kubectl get kamaji`.