### PR TITLE
fix(ipv6): Use net.JoinHostPort instead of fmt.Sprintf

### DIFF
--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -23,7 +23,7 @@ type ConnectionEndpoint struct {
 }
 
 func (r ConnectionEndpoint) String() string {
-	return fmt.Sprintf("%s:%d", r.Host, r.Port)
+	return net.JoinHostPort(r.Host, strconv.FormatInt(int64(r.Port), 10))
 }
 
 type ConnectionConfig struct {

--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -5,7 +5,8 @@ package resources
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,8 +54,7 @@ func (r *KubernetesServiceResource) UpdateTenantControlPlaneStatus(ctx context.C
 
 		return err
 	}
-
-	tenantControlPlane.Status.ControlPlaneEndpoint = fmt.Sprintf("%s:%d", address, tenantControlPlane.Spec.NetworkProfile.Port)
+	tenantControlPlane.Status.ControlPlaneEndpoint = net.JoinHostPort(address, strconv.FormatInt(int64(tenantControlPlane.Spec.NetworkProfile.Port), 10))
 
 	return nil
 }

--- a/internal/resources/kubeadm_config.go
+++ b/internal/resources/kubeadm_config.go
@@ -5,7 +5,8 @@ package resources
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,7 +75,7 @@ func (r *KubeadmConfigResource) getControlPlaneEndpoint(ingress *kamajiv1alpha1.
 		address, port = utilities.GetControlPlaneAddressAndPortFromHostname(ingress.Hostname, port)
 	}
 
-	return fmt.Sprintf("%s:%d", address, port)
+	return net.JoinHostPort(address, strconv.FormatInt(int64(port), 10))
 }
 
 func (r *KubeadmConfigResource) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) controllerutil.MutateFn {


### PR DESCRIPTION
We ran into some issues regarding the handling of IPv6 addresses.
This PR rectifies those problems by utilizing net.JoinHostPort instead of fmt.Sprintf for joining IP addresses with ports.

If you have an IPv6 address, it adds braces, e.g. `[xxx]`, around the IP. Otherwise the result is an invalid IPv6 address. 