### PR TITLE
chore: update default konnectivity version

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -204,7 +204,7 @@ type KonnectivityServerSpec struct {
 	// The port which Konnectivity server is listening to.
 	Port int32 `json:"port"`
 	// Container image version of the Konnectivity server.
-	// +kubebuilder:default=v0.0.32
+	// +kubebuilder:default=v0.28.6
 	Version string `json:"version,omitempty"`
 	// Container image used by the Konnectivity server.
 	// +kubebuilder:default=registry.k8s.io/kas-network-proxy/proxy-server
@@ -219,7 +219,7 @@ type KonnectivityAgentSpec struct {
 	// +kubebuilder:default=registry.k8s.io/kas-network-proxy/proxy-agent
 	Image string `json:"image,omitempty"`
 	// Version for Konnectivity agent.
-	// +kubebuilder:default=v0.0.32
+	// +kubebuilder:default=v0.28.6
 	Version string `json:"version,omitempty"`
 	// Tolerations for the deployed agent.
 	// Can be customized to start the konnectivity-agent even if the nodes are not ready or tainted.
@@ -230,9 +230,9 @@ type KonnectivityAgentSpec struct {
 
 // KonnectivitySpec defines the spec for Konnectivity.
 type KonnectivitySpec struct {
-	// +kubebuilder:default={version:"v0.0.32",image:"registry.k8s.io/kas-network-proxy/proxy-server",port:8132}
+	// +kubebuilder:default={version:"v0.28.6",image:"registry.k8s.io/kas-network-proxy/proxy-server",port:8132}
 	KonnectivityServerSpec KonnectivityServerSpec `json:"server,omitempty"`
-	// +kubebuilder:default={version:"v0.0.32",image:"registry.k8s.io/kas-network-proxy/proxy-agent"}
+	// +kubebuilder:default={version:"v0.28.6",image:"registry.k8s.io/kas-network-proxy/proxy-agent"}
 	KonnectivityAgentSpec KonnectivityAgentSpec `json:"agent,omitempty"`
 }
 

--- a/charts/kamaji/crds/tenantcontrolplane.yaml
+++ b/charts/kamaji/crds/tenantcontrolplane.yaml
@@ -104,7 +104,7 @@ spec:
                         agent:
                           default:
                             image: registry.k8s.io/kas-network-proxy/proxy-agent
-                            version: v0.0.32
+                            version: v0.28.6
                           properties:
                             extraArgs:
                               description: |-
@@ -165,7 +165,7 @@ spec:
                                 type: object
                               type: array
                             version:
-                              default: v0.0.32
+                              default: v0.28.6
                               description: Version for Konnectivity agent.
                               type: string
                           type: object
@@ -173,7 +173,7 @@ spec:
                           default:
                             image: registry.k8s.io/kas-network-proxy/proxy-server
                             port: 8132
-                            version: v0.0.32
+                            version: v0.28.6
                           properties:
                             extraArgs:
                               description: |-
@@ -252,7 +252,7 @@ spec:
                                   type: object
                               type: object
                             version:
-                              default: v0.0.32
+                              default: v0.28.6
                               description: Container image version of the Konnectivity
                                 server.
                               type: string

--- a/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/config/crd/bases/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -95,7 +95,7 @@ spec:
                       agent:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-agent
-                          version: v0.0.32
+                          version: v0.28.6
                         properties:
                           extraArgs:
                             description: |-
@@ -156,7 +156,7 @@ spec:
                               type: object
                             type: array
                           version:
-                            default: v0.0.32
+                            default: v0.28.6
                             description: Version for Konnectivity agent.
                             type: string
                         type: object
@@ -164,7 +164,7 @@ spec:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-server
                           port: 8132
-                          version: v0.0.32
+                          version: v0.28.6
                         properties:
                           extraArgs:
                             description: |-
@@ -243,7 +243,7 @@ spec:
                                 type: object
                             type: object
                           version:
-                            default: v0.0.32
+                            default: v0.28.6
                             description: Container image version of the Konnectivity
                               server.
                             type: string

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -394,7 +394,7 @@ spec:
                       agent:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-agent
-                          version: v0.0.32
+                          version: v0.28.6
                         properties:
                           extraArgs:
                             description: |-
@@ -454,7 +454,7 @@ spec:
                               type: object
                             type: array
                           version:
-                            default: v0.0.32
+                            default: v0.28.6
                             description: Version for Konnectivity agent.
                             type: string
                         type: object
@@ -462,7 +462,7 @@ spec:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-server
                           port: 8132
-                          version: v0.0.32
+                          version: v0.28.6
                         properties:
                           extraArgs:
                             description: |-
@@ -537,7 +537,7 @@ spec:
                                 type: object
                             type: object
                           version:
-                            default: v0.0.32
+                            default: v0.28.6
                             description: Container image version of the Konnectivity server.
                             type: string
                         required:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -13509,7 +13509,7 @@ Enables the Konnectivity addon in the Tenant Cluster, required if the worker nod
         <td>
           <br/>
           <br/>
-            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-agent version:v0.0.32]<br/>
+            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-agent version:v0.28.6]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13518,7 +13518,7 @@ Enables the Konnectivity addon in the Tenant Cluster, required if the worker nod
         <td>
           <br/>
           <br/>
-            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-server port:8132 version:v0.0.32]<br/>
+            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-server port:8132 version:v0.28.6]<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13575,7 +13575,7 @@ Can be customized to start the konnectivity-agent even if the nodes are not read
         <td>
           Version for Konnectivity agent.<br/>
           <br/>
-            <i>Default</i>: v0.0.32<br/>
+            <i>Default</i>: v0.28.6<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -13704,7 +13704,7 @@ unxpected ways. Only modify if you know what you are doing.<br/>
         <td>
           Container image version of the Konnectivity server.<br/>
           <br/>
-            <i>Default</i>: v0.0.32<br/>
+            <i>Default</i>: v0.28.6<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
With the EOL of 1.27, apiserver-network-proxy installation should use the minor versions of their cluster's version.
So the recommended konnectivity version for a 1.29.X Kubernetes cluster is 0.29.Y.

See: https://github.com/kubernetes-sigs/apiserver-network-proxy?tab=readme-ov-file#versioning-and-releases

Increase the default version for konnectivity to v0.28.6, which corresponds to the next EOL Kubernetes minor version.
