### PR TITLE
fix: silence ginkgo versions mismatch warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ helm: ## Download helm locally if necessary.
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
-	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@v2.6.0)
+	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo)
 
 KIND = $(shell pwd)/bin/kind
 kind: ## Download kind locally if necessary.


### PR DESCRIPTION
I saw the following warning in the e2e logs:

```
/home/runner/work/kamaji/kamaji/bin/ginkgo -v ./e2e
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.6.0
  Mismatched package versions found:
    2.17.1 used by e2e
```

The `go install` command will use look into the go.mod if no version is provided for a dependency.
