### PR TITLE
feat: Make DataStore Schema (prefix) Configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,13 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 golint: golangci-lint ## Linting the code according to the styling guide.
 	$(GOLANGCI_LINT) run -c .golangci.yml
 
-test:
-	go test ./... -coverprofile cover.out
+.PHONY: test
+test: ## Run unit tests (all tests except E2E).
+	@go test \
+		./api/... \
+		./cmd/... \
+		./internal/... \
+		-coverprofile cover.out
 
 _datastore-mysql:
 	$(MAKE) NAME=$(NAME) -C deploy/kine/mysql mariadb

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -249,12 +249,19 @@ type AddonsSpec struct {
 }
 
 // TenantControlPlaneSpec defines the desired state of TenantControlPlane.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.dataStoreSchema) || has(self.dataStoreSchema)", message="unsetting the dataStoreSchema is not supported"
 type TenantControlPlaneSpec struct {
 	// DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
 	// This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
 	// Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.
-	DataStore    string       `json:"dataStore,omitempty"`
-	ControlPlane ControlPlane `json:"controlPlane"`
+	DataStore string `json:"dataStore,omitempty"`
+	// DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
+	// value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up
+	// to the user to avoid clashes between different TenantControlPlanes. If not set upon creation, Kamaji will default the
+	// DataStoreSchema by concatenating the namespace and name of the TenantControlPlane.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="changing the dataStoreSchema is not supported"
+	DataStoreSchema string       `json:"dataStoreSchema,omitempty"`
+	ControlPlane    ControlPlane `json:"controlPlane"`
 	// Kubernetes specification for tenant control plane
 	Kubernetes KubernetesSpec `json:"kubernetes"`
 	// NetworkProfile specifies how the network is

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -254,7 +254,7 @@ type AddonsSpec struct {
 type TenantControlPlaneSpec struct {
 	// DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
 	// This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-	// Migration from a different DataStore to another one is not supported, see: https://kamaji.clastix.io/guides/datastore-migration/
+	// Migration from a different DataStore to another one is supported, see: https://kamaji.clastix.io/guides/datastore-migration/
 	DataStore string `json:"dataStore,omitempty"`
 	// DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
 	// value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -254,7 +254,8 @@ type AddonsSpec struct {
 type TenantControlPlaneSpec struct {
 	// DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
 	// This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-	// Migration from a different DataStore to another one is supported, see: https://kamaji.clastix.io/guides/datastore-migration/
+	// Migration from one DataStore to another backed by the same Driver is possible. See: https://kamaji.clastix.io/guides/datastore-migration/
+	// Migration from one DataStore to another backed by a different Driver is not supported.
 	DataStore string `json:"dataStore,omitempty"`
 	// DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
 	// value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -249,11 +249,12 @@ type AddonsSpec struct {
 }
 
 // TenantControlPlaneSpec defines the desired state of TenantControlPlane.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.dataStore) || has(self.dataStore)", message="unsetting the dataStore is not supported"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.dataStoreSchema) || has(self.dataStoreSchema)", message="unsetting the dataStoreSchema is not supported"
 type TenantControlPlaneSpec struct {
 	// DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
 	// This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-	// Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.
+	// Migration from a different DataStore to another one is not supported, see: https://kamaji.clastix.io/guides/datastore-migration/
 	DataStore string `json:"dataStore,omitempty"`
 	// DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
 	// value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6415,8 +6415,18 @@ spec:
                   description: |-
                     DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
                     This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-                    Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.
+                    Migration from a different DataStore to another one is supported, see: https://kamaji.clastix.io/guides/datastore-migration/
                   type: string
+                dataStoreSchema:
+                  description: |-
+                    DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
+                    value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up
+                    to the user to avoid clashes between different TenantControlPlanes. If not set upon creation, Kamaji will default the
+                    DataStoreSchema by concatenating the namespace and name of the TenantControlPlane.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: changing the dataStoreSchema is not supported
+                      rule: self == oldSelf
                 kubernetes:
                   description: Kubernetes specification for tenant control plane
                   properties:
@@ -6563,6 +6573,11 @@ spec:
                 - controlPlane
                 - kubernetes
               type: object
+              x-kubernetes-validations:
+                - message: unsetting the dataStore is not supported
+                  rule: '!has(oldSelf.dataStore) || has(self.dataStore)'
+                - message: unsetting the dataStoreSchema is not supported
+                  rule: '!has(oldSelf.dataStoreSchema) || has(self.dataStoreSchema)'
             status:
               description: TenantControlPlaneStatus defines the observed state of TenantControlPlane.
               properties:

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6415,7 +6415,8 @@ spec:
                   description: |-
                     DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
                     This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-                    Migration from a different DataStore to another one is supported, see: https://kamaji.clastix.io/guides/datastore-migration/
+                    Migration from one DataStore to another backed by the same Driver is possible. See: https://kamaji.clastix.io/guides/datastore-migration/
+                    Migration from one DataStore to another backed by a different Driver is not supported.
                   type: string
                 dataStoreSchema:
                   description: |-

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -839,7 +839,17 @@ such as the number of Pod replicas, the Service resource, or the Ingress.<br/>
         <td>
           DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
 This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-Migration from a different DataStore to another one is not yet supported and the reconciliation will be blocked.<br/>
+Migration from a different DataStore to another one is supported, see: https://kamaji.clastix.io/guides/datastore-migration/<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>dataStoreSchema</b></td>
+        <td>string</td>
+        <td>
+          DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
+value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up
+to the user to avoid clashes between different TenantControlPlanes. If not set upon creation, Kamaji will default the
+DataStoreSchema by concatenating the namespace and name of the TenantControlPlane.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -839,7 +839,8 @@ such as the number of Pod replicas, the Service resource, or the Ingress.<br/>
         <td>
           DataStore allows to specify a DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
 This parameter is optional and acts as an override over the default one which is used by the Kamaji Operator.
-Migration from a different DataStore to another one is supported, see: https://kamaji.clastix.io/guides/datastore-migration/<br/>
+Migration from one DataStore to another backed by the same Driver is possible. See: https://kamaji.clastix.io/guides/datastore-migration/
+Migration from one DataStore to another backed by a different Driver is not supported.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -157,7 +157,7 @@ func (r *Config) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.
 
 		r.resource.Data = map[string][]byte{
 			"DB_CONNECTION_STRING": []byte(r.ConnString),
-			"DB_SCHEMA":            coalesceFn(tenantControlPlane.Status.Storage.Setup.Schema),
+			"DB_SCHEMA":            []byte(tenantControlPlane.Spec.DataStoreSchema),
 			"DB_USER":              username,
 			"DB_PASSWORD":          password,
 		}

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -157,15 +157,15 @@ func (r *Config) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.
 
 		var dataStoreSchema string
 		switch {
-		case len(tenantControlPlane.Spec.DataStoreSchema) > 0:
-			// for new TCPs, the spec field will have been provided by the user
-			// or defaulted by the defaulting webhook
-			dataStoreSchema = tenantControlPlane.Spec.DataStoreSchema
 		case len(tenantControlPlane.Status.Storage.Setup.Schema) > 0:
 			// for existing TCPs, the dataStoreSchema will be adopted from the status,
 			// as the mutating webhook only takes care of TCP creations, not updates
 			dataStoreSchema = tenantControlPlane.Status.Storage.Setup.Schema
 			tenantControlPlane.Spec.DataStoreSchema = dataStoreSchema
+		case len(tenantControlPlane.Spec.DataStoreSchema) > 0:
+			// for new TCPs, the spec field will have been provided by the user
+			// or defaulted by the defaulting webhook
+			dataStoreSchema = tenantControlPlane.Spec.DataStoreSchema
 		default:
 			// this can only happen on TCP creations when the webhook is not installed
 			return fmt.Errorf("cannot build datastore storage config, schema name must either exist in Spec or Status")

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -155,9 +155,25 @@ func (r *Config) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.
 			username = coalesceFn(tenantControlPlane.Status.Storage.Setup.User)
 		}
 
+		var dataStoreSchema string
+		switch {
+		case len(tenantControlPlane.Spec.DataStoreSchema) > 0:
+			// for new TCPs, the spec field will have been provided by the user
+			// or defaulted by the defaulting webhook
+			dataStoreSchema = tenantControlPlane.Spec.DataStoreSchema
+		case len(tenantControlPlane.Status.Storage.Setup.Schema) > 0:
+			// for existing TCPs, the dataStoreSchema will be adopted from the status,
+			// as the mutating webhook only takes care of TCP creations, not updates
+			dataStoreSchema = tenantControlPlane.Status.Storage.Setup.Schema
+			tenantControlPlane.Spec.DataStoreSchema = dataStoreSchema
+		default:
+			// this can only happen on TCP creations when the webhook is not installed
+			return fmt.Errorf("cannot build datastore storage config, schema name must either exist in Spec or Status")
+		}
+
 		r.resource.Data = map[string][]byte{
 			"DB_CONNECTION_STRING": []byte(r.ConnString),
-			"DB_SCHEMA":            []byte(tenantControlPlane.Spec.DataStoreSchema),
+			"DB_SCHEMA":            []byte(dataStoreSchema),
 			"DB_USER":              username,
 			"DB_PASSWORD":          password,
 		}

--- a/internal/resources/datastore/datastore_storage_config_test.go
+++ b/internal/resources/datastore/datastore_storage_config_test.go
@@ -1,0 +1,115 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package datastore_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/resources"
+	"github.com/clastix/kamaji/internal/resources/datastore"
+)
+
+var _ = Describe("DatastoreStorageConfig", func() {
+	var (
+		ctx context.Context
+		dsc *datastore.Config
+		tcp *kamajiv1alpha1.TenantControlPlane
+		ds  *kamajiv1alpha1.DataStore
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		tcp = &kamajiv1alpha1.TenantControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tcp",
+				Namespace: "default",
+			},
+			Spec: kamajiv1alpha1.TenantControlPlaneSpec{},
+		}
+
+		ds = &kamajiv1alpha1.DataStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "datastore",
+				Namespace: "default",
+			},
+		}
+
+		Expect(kamajiv1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(scheme).WithObjects(tcp).WithStatusSubresource(tcp).Build()
+
+		dsc = &datastore.Config{
+			Client:     fakeClient,
+			ConnString: "",
+			DataStore:  *ds,
+		}
+	})
+
+	When("TCP has no dataStoreSchema defined", func() {
+		It("should return an error", func() {
+			_, err := resources.Handle(ctx, dsc, tcp)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("TCP has dataStoreSchema set in spec", func() {
+		BeforeEach(func() {
+			tcp.Spec.DataStoreSchema = "custom-prefix"
+		})
+
+		It("should create the datastore secret with the schema name from the spec", func() {
+			op, err := resources.Handle(ctx, dsc, tcp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(op).To(Equal(controllerutil.OperationResultCreated))
+
+			secrets := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secrets)).To(Succeed())
+			Expect(secrets.Items).To(HaveLen(1))
+			Expect(secrets.Items[0].Data["DB_SCHEMA"]).To(Equal([]byte("custom-prefix")))
+		})
+	})
+
+	When("TCP has dataStoreSchema set in status, but not in spec", func() {
+		// this test case ensures that existing TCPs (created in a CRD version without
+		// the dataStoreSchema field) correctly adopt the spec field from the status.
+
+		It("should create the datastore secret with the correct schema name and update the TCP spec", func() {
+			By("updating the TCP status")
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tcp), tcp)).To(Succeed())
+			tcp.Status.Storage.Setup.Schema = "existing-schema-name"
+			Expect(fakeClient.Status().Update(ctx, tcp)).To(Succeed())
+
+			By("handling the resource")
+			op, err := resources.Handle(ctx, dsc, tcp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(op).To(Equal(controllerutil.OperationResultCreated))
+
+			By("checking the secret")
+			secrets := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secrets)).To(Succeed())
+			Expect(secrets.Items).To(HaveLen(1))
+			Expect(secrets.Items[0].Data["DB_SCHEMA"]).To(Equal([]byte("existing-schema-name")))
+
+			By("checking the TCP spec")
+			// we have to check the modified struct here (instead of retrieving the object
+			// via the fakeClient), as the TCP resource update is not done by the resources.
+			// Instead, the TCP controller will handle TCP updates after handling all resources
+			tcp.Spec.DataStoreSchema = "existing-schema-name"
+		})
+	})
+})

--- a/internal/resources/datastore/datastore_suite_test.go
+++ b/internal/resources/datastore/datastore_suite_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package datastore_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	fakeClient client.Client
+	scheme     *runtime.Scheme = runtime.NewScheme()
+)
+
+func TestDatastore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Datastore Suite")
+}

--- a/internal/webhook/handlers/handlers_suite_test.go
+++ b/internal/webhook/handlers/handlers_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handlers Suite")
+}

--- a/internal/webhook/handlers/handlers_suite_test.go
+++ b/internal/webhook/handlers/handlers_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Clastix Labs
+// Copyright 2022 Clastix Labs
 // SPDX-License-Identifier: Apache-2.0
 
 package handlers_test

--- a/internal/webhook/handlers/tcp_defaults.go
+++ b/internal/webhook/handlers/tcp_defaults.go
@@ -42,7 +42,7 @@ func (t TenantControlPlaneDefaults) OnDelete(runtime.Object) AdmissionResponse {
 	return utils.NilOp()
 }
 
-func (t TenantControlPlaneDefaults) OnUpdate(object runtime.Object, oldObject runtime.Object) AdmissionResponse {
+func (t TenantControlPlaneDefaults) OnUpdate(runtime.Object, runtime.Object) AdmissionResponse {
 	// all immutability requirements are handled trough CEL annotations on the TenantControlPlaneSpec type
 	return utils.NilOp()
 }

--- a/internal/webhook/handlers/tcp_defaults_test.go
+++ b/internal/webhook/handlers/tcp_defaults_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
 package handlers_test
 
 import (
@@ -69,7 +72,7 @@ var _ = Describe("TCP Defaulting Webhook", func() {
 		It("should not issue any patches", func() {
 			ops, err := t.OnCreate(tcp)(ctx, admission.Request{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ops).To(HaveLen(0))
+			Expect(ops).To(BeEmpty())
 		})
 	})
 })

--- a/internal/webhook/handlers/tcp_defaults_test.go
+++ b/internal/webhook/handlers/tcp_defaults_test.go
@@ -1,0 +1,75 @@
+package handlers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/webhook/handlers"
+)
+
+var _ = Describe("TCP Defaulting Webhook", func() {
+	var (
+		ctx context.Context
+		t   handlers.TenantControlPlaneDefaults
+		tcp *kamajiv1alpha1.TenantControlPlane
+	)
+
+	BeforeEach(func() {
+		t = handlers.TenantControlPlaneDefaults{
+			DefaultDatastore: "etcd",
+		}
+		tcp = &kamajiv1alpha1.TenantControlPlane{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "tcp",
+				Namespace: "default",
+			},
+			Spec: kamajiv1alpha1.TenantControlPlaneSpec{},
+		}
+		ctx = context.Background()
+	})
+
+	Describe("fields missing", func() {
+		It("should issue all required patches", func() {
+			ops, err := t.OnCreate(tcp)(ctx, admission.Request{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ops).To(HaveLen(3))
+		})
+
+		It("should default the dataStore", func() {
+			ops, err := t.OnCreate(tcp)(ctx, admission.Request{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ops).To(ContainElement(
+				jsonpatch.Operation{Operation: "add", Path: "/spec/dataStore", Value: "etcd"},
+			))
+		})
+
+		It("should default the dataStoreSchema to the expected value", func() {
+			ops, err := t.OnCreate(tcp)(ctx, admission.Request{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ops).To(ContainElement(
+				jsonpatch.Operation{Operation: "add", Path: "/spec/dataStoreSchema", Value: "default_tcp"},
+			))
+		})
+	})
+
+	Describe("fields are already set", func() {
+		BeforeEach(func() {
+			tcp.Spec.DataStore = "etcd"
+			tcp.Spec.DataStoreSchema = "my_tcp"
+			tcp.Spec.ControlPlane.Deployment.Replicas = ptr.To(int32(2))
+		})
+
+		It("should not issue any patches", func() {
+			ops, err := t.OnCreate(tcp)(ctx, admission.Request{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ops).To(HaveLen(0))
+		})
+	})
+})

--- a/internal/webhook/handlers/tcp_defaults_test.go
+++ b/internal/webhook/handlers/tcp_defaults_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -29,7 +29,7 @@ var _ = Describe("TCP Defaulting Webhook", func() {
 			DefaultDatastore: "etcd",
 		}
 		tcp = &kamajiv1alpha1.TenantControlPlane{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tcp",
 				Namespace: "default",
 			},

--- a/internal/webhook/utils/jsonpatch.go
+++ b/internal/webhook/utils/jsonpatch.go
@@ -10,18 +10,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func JSONPatch(obj client.Object, modifierFunc func()) ([]jsonpatch.Operation, error) {
-	original, err := json.Marshal(obj)
+func JSONPatch(original, modified client.Object) ([]jsonpatch.Operation, error) {
+	originalJSON, err := json.Marshal(original)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot marshal input object")
+		return nil, errors.Wrap(err, "cannot marshal original object")
 	}
 
-	modifierFunc()
-
-	patched, err := json.Marshal(obj)
+	modifiedJSON, err := json.Marshal(modified)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot marshal patched object")
+		return nil, errors.Wrap(err, "cannot marshal modified object")
 	}
 
-	return jsonpatch.CreatePatch(original, patched)
+	return jsonpatch.CreatePatch(originalJSON, modifiedJSON)
 }


### PR DESCRIPTION
Fixes #548 

As agreed in the aforementioned discussion, this PR introduces a new `TenantControlPlaneSpec` field called `DataStoreSchema`. The field name could also be different, if desired. It allows users to control the database name or etcd prefix. If the field is unset during creation, the defaulting webhook sets the field to `<TCPNamespace>_<TCPName>`, which is the current behavior. The field is immutable.

Some remarks:

* I think I found bugs in the current behavior of the defaulting webhook:
  *  it never appended to the `operations` in the `OnCreate` function, therefore the replicas were never defaulted.
  * the `OnUpdate` function also had some early returns, so same problem there.
* Instead of using a webhook, I propose to use kubebuilder markers with CEL to ensure that the `DataStore` and `DataStoreSchema` fields can't be unset after creation. This makes the `OnUpdate` function a NoOp.
* Added some test cases for the defaulting webhook.
* Updated the doc string for the `DataStore` field. According to the docs, datastore migrations are in fact possible.