### PR TITLE
fix(coredns): preserving externally managed coredns addon

### DIFF
--- a/internal/resources/addons/managed_labels.go
+++ b/internal/resources/addons/managed_labels.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package addons
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/clastix/kamaji/internal/constants"
+	"github.com/clastix/kamaji/internal/utilities"
+)
+
+func setKamajiManagedLabels(obj client.Object) {
+	obj.SetLabels(utilities.MergeMaps(obj.GetLabels(), map[string]string{
+		constants.ProjectNameLabelKey: constants.ProjectNameLabelValue,
+	}))
+}


### PR DESCRIPTION
A bug has been introduced with #527 which doesn't handle properly all the required business logic, such as the application of customised labels, as well as the handling of the controller Resource.