### PR TITLE
fix(kubeadm): let Kubelet automatically determine resolvConf

### DIFF
--- a/internal/kubeadm/uploadconfig.go
+++ b/internal/kubeadm/uploadconfig.go
@@ -89,6 +89,9 @@ func getKubeletConfigmapContent(kubeletConfiguration KubeletConfiguration) ([]by
 	// kubeadm <= v1.27 has a different type for FlushFrequency
 	// https://github.com/kubernetes/component-base/blob/55b3ab0db0081303695d641b9b43d560bf3f7a65/logs/api/v1/types.go#L42-L45
 	kc.Logging.FlushFrequency.SerializeAsString = false
+	// Restore default behaviour so Kubelet will automatically
+	// determine the resolvConf location, as reported in clastix/kamaji#581.
+	kc.ResolverConfig = nil
 
 	return utilities.EncodeToYaml(&kc)
 }


### PR DESCRIPTION
This restores the original behavior where Kubelet would automatically resolve the resolvConf file location based on conditions where Kubelet is running.

Fixes #581