### PR TITLE
feat: automatically set dns service address

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -36,13 +36,16 @@ type NetworkProfileSpec struct {
 	// CertSANs sets extra Subject Alternative Names (SANs) for the API Server signing certificate.
 	// Use this field to add additional hostnames when exposing the Tenant Control Plane with third solutions.
 	CertSANs []string `json:"certSANs,omitempty"`
-	// Kubernetes Service
+	// CIDR for Kubernetes Services: if empty, defaulted to 10.96.0.0/16.
 	//+kubebuilder:default="10.96.0.0/16"
 	ServiceCIDR string `json:"serviceCidr,omitempty"`
-	// CIDR for Kubernetes Pods
+	// CIDR for Kubernetes Pods: if empty, defaulted to 10.244.0.0/16.
 	//+kubebuilder:default="10.244.0.0/16"
 	PodCIDR string `json:"podCidr,omitempty"`
-	//+kubebuilder:default={"10.96.0.10"}
+	// The DNS Service for internal resolution, it must match the Service CIDR.
+	// In case of an empty value, it is automatically computed according to the Service CIDR, e.g.:
+	// Service CIDR 10.96.0.0/16, the resulting DNS Service IP will be 10.96.0.10 for IPv4,
+	// for IPv6 from the CIDR 2001:db8:abcd::/64 the resulting DNS Service IP will be 2001:db8:abcd::10.
 	DNSServiceIPs []string `json:"dnsServiceIPs,omitempty"`
 }
 

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6558,8 +6558,11 @@ spec:
                         - message: changing the cluster domain is not supported
                           rule: self == oldSelf
                     dnsServiceIPs:
-                      default:
-                        - 10.96.0.10
+                      description: |-
+                        The DNS Service for internal resolution, it must match the Service CIDR.
+                        In case of an empty value, it is automatically computed according to the Service CIDR, e.g.:
+                        Service CIDR 10.96.0.0/16, the resulting DNS Service IP will be 10.96.0.10 for IPv4,
+                        for IPv6 from the CIDR 2001:db8:abcd::/64 the resulting DNS Service IP will be 2001:db8:abcd::10.
                       items:
                         type: string
                       type: array
@@ -6577,7 +6580,7 @@ spec:
                       type: array
                     podCidr:
                       default: 10.244.0.0/16
-                      description: CIDR for Kubernetes Pods
+                      description: 'CIDR for Kubernetes Pods: if empty, defaulted to 10.244.0.0/16.'
                       type: string
                     port:
                       default: 6443
@@ -6586,7 +6589,7 @@ spec:
                       type: integer
                     serviceCidr:
                       default: 10.96.0.0/16
-                      description: Kubernetes Service
+                      description: 'CIDR for Kubernetes Services: if empty, defaulted to 10.96.0.0/16.'
                       type: string
                   type: object
               required:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -13937,9 +13937,10 @@ Use this field to add additional hostnames when exposing the Tenant Control Plan
         <td><b>dnsServiceIPs</b></td>
         <td>[]string</td>
         <td>
-          <br/>
-          <br/>
-            <i>Default</i>: [10.96.0.10]<br/>
+          The DNS Service for internal resolution, it must match the Service CIDR.
+In case of an empty value, it is automatically computed according to the Service CIDR, e.g.:
+Service CIDR 10.96.0.0/16, the resulting DNS Service IP will be 10.96.0.10 for IPv4,
+for IPv6 from the CIDR 2001:db8:abcd::/64 the resulting DNS Service IP will be 2001:db8:abcd::10.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -13959,7 +13960,7 @@ Example: {"192.168.1.0/24", "10.0.0.0/8"}<br/>
         <td><b>podCidr</b></td>
         <td>string</td>
         <td>
-          CIDR for Kubernetes Pods<br/>
+          CIDR for Kubernetes Pods: if empty, defaulted to 10.244.0.0/16.<br/>
           <br/>
             <i>Default</i>: 10.244.0.0/16<br/>
         </td>
@@ -13978,7 +13979,7 @@ Example: {"192.168.1.0/24", "10.0.0.0/8"}<br/>
         <td><b>serviceCidr</b></td>
         <td>string</td>
         <td>
-          Kubernetes Service<br/>
+          CIDR for Kubernetes Services: if empty, defaulted to 10.96.0.0/16.<br/>
           <br/>
             <i>Default</i>: 10.96.0.0/16<br/>
         </td>


### PR DESCRIPTION
Closes #468, pinging the main stakeholder such as @kvaps and the IPv6 gurus @johannwagner @hexchen

When defining a different Service CIDR and an empty DNS Service one, Kamaji will automatically compute the correct value.

Once applying this Tenant Control Plane snippet:

```yaml
  networkProfile:
    serviceCidr: 10.20.0.0/16
    port: 6443
```

This is the resulting one stored in the cluster.

```yaml
  networkProfile:
    clusterDomain: cluster.local
    dnsServiceIPs:
    - 10.20.0.10
    podCidr: 10.244.0.0/16
    port: 6443
    serviceCidr: 10.20.0.0/16
```

Tested also with IPv6:

```yaml
  networkProfile:
    serviceCidr: 2002::1234:abcd:ffff:c0a8:101/64
    port: 6443
```

Defaulted values:

```yaml
    version: v1.30.0
  networkProfile:
    clusterDomain: cluster.local
    dnsServiceIPs:
    - 2002::1234:abcd:ffff:c0a8:111
    podCidr: 10.244.0.0/16
    port: 6443
    serviceCidr: 2002::1234:abcd:ffff:c0a8:101/64
```