### PR TITLE
feat: add custom advertiseaddress support

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -27,6 +27,9 @@ type NetworkProfileSpec struct {
 	// Address where API server of will be exposed.
 	// In case of LoadBalancer Service, this can be empty in order to use the exposed IP provided by the cloud controller manager.
 	Address string `json:"address,omitempty"`
+	// AdvertiseAdress is the address that will be advertise by the API server inside the cluster.
+	// If not set, will be set to the address assigned to the Tenant Control Plane.
+	AdvertiseAdress *string `json:"advertiseAdress,omitempty"`
 	// The default domain name used for DNS resolution within the cluster.
 	//+kubebuilder:default="cluster.local"
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="changing the cluster domain is not supported"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1110,6 +1110,16 @@ func (in *NetworkProfileSpec) DeepCopyInto(out *NetworkProfileSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.LoadBalancerClass != nil {
+		in, out := &in.LoadBalancerClass, &out.LoadBalancerClass
+		*out = new(string)
+		**out = **in
+	}
+	if in.AdvertiseAdress != nil {
+		in, out := &in.AdvertiseAdress, &out.AdvertiseAdress
+		*out = new(string)
+		**out = **in
+	}
 	if in.CertSANs != nil {
 		in, out := &in.CertSANs, &out.CertSANs
 		*out = make([]string, len(*in))

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6539,6 +6539,11 @@ spec:
                         Address where API server of will be exposed.
                         In case of LoadBalancer Service, this can be empty in order to use the exposed IP provided by the cloud controller manager.
                       type: string
+                    advertiseAdress:
+                      description: |-
+                        AdvertiseAdress is the address that will be advertise by the API server inside the cluster.
+                        If not set, will be set to the address assigned to the Tenant Control Plane.
+                      type: string
                     allowAddressAsExternalIP:
                       description: |-
                         AllowAddressAsExternalIP will include tenantControlPlane.Spec.NetworkProfile.Address in the section of


### PR DESCRIPTION
Allow to set a custom AdvertiseAddress in the APIServer flag instead of the K8S service IP 