### PR TITLE
Add IONOS Cloud to list of adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -22,6 +22,7 @@ Feel free to open a Pull-Request to get yours listed.
 | R&D | TIM | 2024 | [link](https://www.gruppotim.it) | TIM is an Italian telecommunications company using Kamaji for experimental research and development purposes. |
 | Vendor | Ænix | 2023 | [link](https://aenix.io/) | Ænix provides consulting services for cloud providers and uses Kamaji for running Kubernetes-as-a-Service in free PaaS platform [Cozystack](https://cozystack.io). |
 | End-user | Rackspace | 2024 | [link](https://spot.rackspace.com/) | Rackspace Spot uses Kamaji to manage our instances, offering fully-managed kubernetes infrastructure, auctioned in an open market. |
+| R&D | IONOS Cloud | 2024 | [link](https://cloud.ionos.com/) | IONOS Cloud is a German Cloud Provider evaluating Kamaji for its [Managed Kubernetes platform](https://cloud.ionos.com/managed/kubernetes). |
 
 ### Adopter Types
 


### PR DESCRIPTION
Add IONOS Cloud to the list of adopters as R&D. We're evaluating the use of Kamaji in our Managed Kubernetes offering.
