### PR TITLE
refactor: avoid logging error and sentinel for status

### DIFF
--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -199,6 +199,12 @@ func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		if err = utils.UpdateStatus(ctx, r.Client, tenantControlPlane, resource); err != nil {
+			if kamajierrors.ShouldReconcileErrorBeIgnored(err) {
+				log.V(1).Info("sentinel error, enqueuing back request", "error", err.Error())
+
+				return ctrl.Result{Requeue: true}, nil
+			}
+
 			log.Error(err, "update of the resource failed", "resource", resource.GetName())
 
 			return ctrl.Result{}, err

--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/utilities"
@@ -42,8 +41,6 @@ func (r *KubernetesServiceResource) CleanUp(context.Context, *kamajiv1alpha1.Ten
 }
 
 func (r *KubernetesServiceResource) UpdateTenantControlPlaneStatus(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
-	logger := log.FromContext(ctx, "resource", r.GetName())
-
 	tenantControlPlane.Status.Kubernetes.Service.ServiceStatus = r.resource.Status
 	tenantControlPlane.Status.Kubernetes.Service.Name = r.resource.GetName()
 	tenantControlPlane.Status.Kubernetes.Service.Namespace = r.resource.GetNamespace()
@@ -51,8 +48,6 @@ func (r *KubernetesServiceResource) UpdateTenantControlPlaneStatus(ctx context.C
 
 	address, err := tenantControlPlane.DeclaredControlPlaneAddress(ctx, r.Client)
 	if err != nil {
-		logger.Error(err, "cannot retrieve Tenant Control Plane address")
-
 		return err
 	}
 	tenantControlPlane.Status.ControlPlaneEndpoint = net.JoinHostPort(address, strconv.FormatInt(int64(tenantControlPlane.Spec.NetworkProfile.Port), 10))


### PR DESCRIPTION
Closes #664.

The resulting logs when the LoadBalancer IP is not yet exposed:

```
2025-01-21T19:03:45+01:00       INFO    Starting Controller     {"controller": "secret", "controllerGroup": "", "controllerKind": "Secret"}
2025-01-21T19:03:45+01:00       INFO    Starting workers        {"controller": "secret", "controllerGroup": "", "controllerKind": "Secret", "worker count": 1}
2025-01-21T19:03:45+01:00       INFO    Starting Controller     {"controller": "datastore", "controllerGroup": "kamaji.clastix.io", "controllerKind": "DataStore"}
2025-01-21T19:03:45+01:00       INFO    Starting workers        {"controller": "datastore", "controllerGroup": "kamaji.clastix.io", "controllerKind": "DataStore", "worker count": 1}
2025-01-21T19:03:45+01:00       INFO    Starting Controller     {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane"}
2025-01-21T19:03:45+01:00       INFO    Starting workers        {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "worker count": 1}
2025-01-21T19:03:45+01:00       INFO    Starting Controller     {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane"}
2025-01-21T19:03:45+01:00       INFO    Starting workers        {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "worker count": 1}
2025-01-21T19:04:05+01:00       DEBUG   sentinel error, enqueuing back request  {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "TenantControlPlane": {"name":"k8s-130","namespace":"default"}, "namespace": "default", "name": "k8s-130", "reconcileID": "605841d9-1310-4b38-8eea-5e28a863ab0e", "error": "error applying TenantcontrolPlane status: cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
2025-01-21T19:04:33+01:00       DEBUG   sentinel error, enqueuing back request  {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "TenantControlPlane": {"name":"k8s-130","namespace":"default"}, "namespace": "default", "name": "k8s-130", "reconcileID": "8d17b0bf-18b9-4daf-93de-6071b55737b4", "error": "error applying TenantcontrolPlane status: cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
2025-01-21T19:04:34+01:00       DEBUG   sentinel error, enqueuing back request  {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "TenantControlPlane": {"name":"k8s-130","namespace":"default"}, "namespace": "default", "name": "k8s-130", "reconcileID": "a54ee157-8e32-4a14-9e45-1900e65c5d42", "error": "error applying TenantcontrolPlane status: cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
2025-01-21T19:04:34+01:00       DEBUG   sentinel error, enqueuing back request  {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "TenantControlPlane": {"name":"k8s-130","namespace":"default"}, "namespace": "default", "name": "k8s-130", "reconcileID": "58885d0c-fb1e-463f-805b-9015cd6fe0cc", "error": "error applying TenantcontrolPlane status: cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
2025-01-21T19:04:34+01:00       DEBUG   sentinel error, enqueuing back request  {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "TenantControlPlane": {"name":"k8s-130","namespace":"default"}, "namespace": "default", "name": "k8s-130", "reconcileID": "d66c802b-410b-487e-9dad-b69ca3531b25", "error": "error applying TenantcontrolPlane status: cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
2025-01-21T19:04:34+01:00       DEBUG   sentinel error, enqueuing back request  {"controller": "tenantcontrolplane", "controllerGroup": "kamaji.clastix.io", "controllerKind": "TenantControlPlane", "TenantControlPlane": {"name":"k8s-130","namespace":"default"}, "namespace": "default", "name": "k8s-130", "reconcileID": "2aae56ff-1444-43f0-bd21-519cd23daa19", "error": "error applying TenantcontrolPlane status: cannot retrieve the TenantControlPlane address, Service resource is not yet exposed as LoadBalancer"}
```