### PR TITLE
feat: validating api server cert sans

### DIFF
--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -219,6 +219,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 					},
 				},
 				routes.TenantControlPlaneValidate{}: {
+					handlers.TenantControlPlaneCertSANs{},
 					handlers.TenantControlPlaneName{},
 					handlers.TenantControlPlaneVersion{},
 					handlers.TenantControlPlaneKubeletAddresses{},

--- a/internal/resources/api_server_certificate.go
+++ b/internal/resources/api_server_certificate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/clastix/kamaji/internal/crypto"
 	"github.com/clastix/kamaji/internal/kubeadm"
 	"github.com/clastix/kamaji/internal/utilities"
+	"github.com/clastix/kamaji/internal/webhook/handlers"
 )
 
 type APIServerCertificate struct {
@@ -66,6 +67,10 @@ func (r *APIServerCertificate) GetTmpDirectory() string {
 }
 
 func (r *APIServerCertificate) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) (res controllerutil.OperationResult, err error) {
+	if err = (handlers.TenantControlPlaneCertSANs{}).ValidateCertSANs(tenantControlPlane); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
 	return utilities.CreateOrUpdateWithConflict(ctx, r.Client, r.resource, r.mutate(ctx, tenantControlPlane))
 }
 

--- a/internal/webhook/handlers/tcp_certsans.go
+++ b/internal/webhook/handlers/tcp_certsans.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/webhook/utils"
+)
+
+type TenantControlPlaneCertSANs struct{}
+
+func (t TenantControlPlaneCertSANs) ValidateCertSANs(tcp *kamajiv1alpha1.TenantControlPlane) error {
+	if len(tcp.Spec.NetworkProfile.CertSANs) == 0 {
+		return nil
+	}
+
+	if err := validation.ValidateCertSANs(tcp.Spec.NetworkProfile.CertSANs, field.NewPath("spec.networkProfile.certSANs")); err != nil {
+		return err.ToAggregate()
+	}
+
+	return nil
+}
+
+func (t TenantControlPlaneCertSANs) OnCreate(obj runtime.Object) AdmissionResponse {
+	return func(context.Context, admission.Request) ([]jsonpatch.JsonPatchOperation, error) {
+		tcp := obj.(*kamajiv1alpha1.TenantControlPlane) //nolint:forcetypeassert
+
+		return nil, t.ValidateCertSANs(tcp)
+	}
+}
+
+func (t TenantControlPlaneCertSANs) OnDelete(runtime.Object) AdmissionResponse {
+	return utils.NilOp()
+}
+
+func (t TenantControlPlaneCertSANs) OnUpdate(newObject runtime.Object, prevObject runtime.Object) AdmissionResponse {
+	return func(context.Context, admission.Request) ([]jsonpatch.JsonPatchOperation, error) {
+		tcp := newObject.(*kamajiv1alpha1.TenantControlPlane) //nolint:forcetypeassert
+
+		return nil, t.ValidateCertSANs(tcp)
+	}
+}


### PR DESCRIPTION
Closing #679 providing further validation of certificate SANs: `kubeadm` wasn't complaining about malformed values, causing a reconciliation loop due to a mismatch of values.

Validation is enforced at the webhook level and relies on the Kubernetes code base rather than a validation pattern at the OAPI level.