### PR TITLE
fix: Prevents setting LoadBalancerIP when AWS-specific annotations are present

### DIFF
--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -106,7 +106,10 @@ func (r *KubernetesServiceResource) mutate(ctx context.Context, tenantControlPla
 			if len(tenantControlPlane.Spec.NetworkProfile.LoadBalancerSourceRanges) > 0 {
 				r.resource.Spec.LoadBalancerSourceRanges = tenantControlPlane.Spec.NetworkProfile.LoadBalancerSourceRanges
 			}
-			if len(address) > 0 {
+
+			// hack: Load Balancer IP should not be added to avoid the AWS Load Balancer get stuck
+			_, hasLbAwsEipAllocations := r.resource.Annotations["service.beta.kubernetes.io/aws-load-balancer-eip-allocations"]
+			if len(address) > 0 && !hasLbAwsEipAllocations {
 				r.resource.Spec.LoadBalancerIP = address
 			}
 		case kamajiv1alpha1.ServiceTypeNodePort:


### PR DESCRIPTION
Addresses #688, this commit adds a check to the ControlPlane service's annotations.
If the `spec.loadBalancerIP` property is set in the service, the AWS cloud controller will complain and causes issues.

The controller now checks for the presence of these specific annotations and avoids setting the LoadBalancerIP to ensure that the service is correctly configured according to AWS requirements.