### PR TITLE
feat: removes LoadBalancerIP field from service spec

### DIFF
--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -106,9 +106,6 @@ func (r *KubernetesServiceResource) mutate(ctx context.Context, tenantControlPla
 			if len(tenantControlPlane.Spec.NetworkProfile.LoadBalancerSourceRanges) > 0 {
 				r.resource.Spec.LoadBalancerSourceRanges = tenantControlPlane.Spec.NetworkProfile.LoadBalancerSourceRanges
 			}
-			if len(address) > 0 {
-				r.resource.Spec.LoadBalancerIP = address
-			}
 		case kamajiv1alpha1.ServiceTypeNodePort:
 			r.resource.Spec.Type = corev1.ServiceTypeNodePort
 			r.resource.Spec.Ports[0].NodePort = tenantControlPlane.Spec.NetworkProfile.Port


### PR DESCRIPTION
Addresses https://github.com/clastix/kamaji/issues/688 and superseeds #707, this removes the ControlPlane service's LoadBalancerIP field, as it is deprecated.