### PR TITLE
helm: Add missing apiVersion and kind for PVC

### DIFF
--- a/deploy/etcd/etcd-cluster.yaml
+++ b/deploy/etcd/etcd-cluster.yaml
@@ -104,7 +104,9 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: data
     spec:
       accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
- Fixes a deployment issue with CD tools like ArgoCD.
- apiVersion and kind not set in source, causing drift.
- Ensures consistent state across deployments.
![CleanShot 2025-03-09 at 20 57 41@2x](https://github.com/user-attachments/assets/dc0e8ba4-7814-48f5-8c5d-90c286ed9b2b)
