### PR TITLE
fix(datastore): handling datastore with no client certificate

### DIFF
--- a/api/v1alpha1/indexer_datastore_usedsecret.go
+++ b/api/v1alpha1/indexer_datastore_usedsecret.go
@@ -52,12 +52,14 @@ func (d *DatastoreUsedSecret) ExtractValue() client.IndexerFunc {
 				res = append(res, d.namespacedName(*ds.Spec.TLSConfig.CertificateAuthority.PrivateKey.SecretRef))
 			}
 
-			if ds.Spec.TLSConfig.ClientCertificate.Certificate.SecretRef != nil {
-				res = append(res, d.namespacedName(*ds.Spec.TLSConfig.ClientCertificate.Certificate.SecretRef))
-			}
+			if ds.Spec.TLSConfig.ClientCertificate != nil {
+				if ds.Spec.TLSConfig.ClientCertificate.Certificate.SecretRef != nil {
+					res = append(res, d.namespacedName(*ds.Spec.TLSConfig.ClientCertificate.Certificate.SecretRef))
+				}
 
-			if ds.Spec.TLSConfig.ClientCertificate.PrivateKey.SecretRef != nil {
-				res = append(res, d.namespacedName(*ds.Spec.TLSConfig.ClientCertificate.PrivateKey.SecretRef))
+				if ds.Spec.TLSConfig.ClientCertificate.PrivateKey.SecretRef != nil {
+					res = append(res, d.namespacedName(*ds.Spec.TLSConfig.ClientCertificate.PrivateKey.SecretRef))
+				}
 			}
 		}
 

--- a/internal/webhook/handlers/ds_validate.go
+++ b/internal/webhook/handlers/ds_validate.go
@@ -108,12 +108,14 @@ func (d DataStoreValidation) validateTLSConfig(ctx context.Context, ds kamajiv1a
 		}
 	}
 
-	if err := d.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.Certificate); err != nil {
-		return fmt.Errorf("client certificate is not valid, %w", err)
-	}
+	if ds.Spec.TLSConfig.ClientCertificate != nil {
+		if err := d.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.Certificate); err != nil {
+			return fmt.Errorf("client certificate is not valid, %w", err)
+		}
 
-	if err := d.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.PrivateKey); err != nil {
-		return fmt.Errorf("client private key is not valid, %w", err)
+		if err := d.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.PrivateKey); err != nil {
+			return fmt.Errorf("client private key is not valid, %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #744, smoke tested with a CloudnativePG with no client certificate authentication.