### PR TITLE
fix: prevent unnecessary copy in loop

### DIFF
--- a/controllers/datastore_controller.go
+++ b/controllers/datastore_controller.go
@@ -75,9 +75,7 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return reconcile.Result{}, err
 	}
 	// Triggering the reconciliation of the Tenant Control Plane upon a Secret change
-	for _, i := range tcpList.Items {
-		tcp := i
-
+	for _, tcp := range tcpList.Items {
 		select {
 		case r.TenantControlPlaneTrigger <- event.GenericEvent{Object: &tcp}:
 		default:


### PR DESCRIPTION
The for loop was changed in go 1.22 to no longer reuse loop variables. This means that it's now safe to take pointers of loop variables.

I scanned the repo for other occurrences, but could only find this one.
