### PR TITLE
fix: stop watches when TCP is scaled to zero

### DIFF
--- a/controllers/soot/manager.go
+++ b/controllers/soot/manager.go
@@ -136,9 +136,9 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 
 		return reconcile.Result{}, err
 	}
-	// Handling finalizer if the TenantControlPlane is marked for deletion:
+	// Handling finalizer if the TenantControlPlane is marked for deletion or scaled to zero:
 	// the clean-up function is already taking care to stop the manager, if this exists.
-	if tcp.GetDeletionTimestamp() != nil {
+	if tcp.GetDeletionTimestamp() != nil || ptr.Deref(tcp.Spec.ControlPlane.Deployment.Replicas, 0) == 0 {
 		if controllerutil.ContainsFinalizer(tcp, finalizers.SootFinalizer) {
 			return reconcile.Result{}, m.cleanup(ctx, request, tcp)
 		}


### PR DESCRIPTION
We sometimes scale down unused control planes to preserve resources. They can be scaled up on demand, so it's always meant as a transitory state.
We observed some issues in our cluster in the past. There were of course the network errors that the controller-runtime watches logged because the control plane was unavailable, but there also was a strange behavior where new control planes would not get valid certificates.
I decided to do the full cleanup with finalizer when the TCP is scaled to zero, because this mirrors what we see in our environments. Sometimes control planes are just deleted by users after they notice they were scaled down, i.e. were unused for a while.

Preliminary testing of this change in our environment looked promising, but I'll let it sit over the weekend to get more data.

Another issue we see when scaling TCPs down to 0 is that the datastore controllers keeps logging `channel is full` well after the control planes are scaled back up again.
I have yet to figure out 1) why it fills up in the first place and 2) why it stays full after the scale up.
