### PR TITLE
feat!: introducing sleeping status

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_status.go
+++ b/api/v1alpha1/tenantcontrolplane_status.go
@@ -183,11 +183,12 @@ type KubernetesStatus struct {
 	Ingress    *KubernetesIngressStatus   `json:"ingress,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Provisioning;CertificateAuthorityRotating;Upgrading;Migrating;Ready;NotReady
+// +kubebuilder:validation:Enum=Provisioning;CertificateAuthorityRotating;Upgrading;Migrating;Ready;NotReady;Sleeping
 type KubernetesVersionStatus string
 
 var (
 	VersionProvisioning KubernetesVersionStatus = "Provisioning"
+	VersionSleeping     KubernetesVersionStatus = "Sleeping"
 	VersionCARotating   KubernetesVersionStatus = "CertificateAuthorityRotating"
 	VersionUpgrading    KubernetesVersionStatus = "Upgrading"
 	VersionMigrating    KubernetesVersionStatus = "Migrating"

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -7379,6 +7379,7 @@ spec:
                             - Migrating
                             - Ready
                             - NotReady
+                            - Sleeping
                           type: string
                         version:
                           description: Version is the running Kubernetes version of the Tenant Control Plane.

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -81,7 +82,7 @@ func (m *TelemetryController) collectStats(ctx context.Context, uid string) {
 
 	for _, tcp := range tcpList.Items {
 		switch {
-		case tcp.Spec.ControlPlane.Deployment.Replicas == nil || *tcp.Spec.ControlPlane.Deployment.Replicas == 0:
+		case ptr.Deref(tcp.Status.Kubernetes.Version.Status, kamajiv1alpha1.VersionProvisioning) == kamajiv1alpha1.VersionSleeping:
 			stats.TenantControlPlanes.Sleeping++
 		case tcp.Status.Kubernetes.Version.Status != nil && *tcp.Status.Kubernetes.Version.Status == kamajiv1alpha1.VersionNotReady:
 			stats.TenantControlPlanes.NotReady++

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -16199,7 +16199,7 @@ KubernetesVersion contains the information regarding the running Kubernetes vers
         <td>
           Status returns the current status of the Kubernetes version, such as its provisioning state, or completed upgrade.<br/>
           <br/>
-            <i>Enum</i>: Provisioning, CertificateAuthorityRotating, Upgrading, Migrating, Ready, NotReady<br/>
+            <i>Enum</i>: Provisioning, CertificateAuthorityRotating, Upgrading, Migrating, Ready, NotReady, Sleeping<br/>
             <i>Default</i>: Provisioning<br/>
         </td>
         <td>false</td>

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -76,6 +76,8 @@ func (r *KubernetesDeploymentResource) GetName() string {
 
 func (r *KubernetesDeploymentResource) UpdateTenantControlPlaneStatus(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
 	switch {
+	case ptr.Deref(tenantControlPlane.Spec.ControlPlane.Deployment.Replicas, 2) == 0:
+		tenantControlPlane.Status.Kubernetes.Version.Status = &kamajiv1alpha1.VersionSleeping
 	case !r.isProgressingUpgrade():
 		tenantControlPlane.Status.Kubernetes.Version.Status = &kamajiv1alpha1.VersionReady
 		tenantControlPlane.Status.Kubernetes.Version.Version = tenantControlPlane.Spec.Kubernetes.Version


### PR DESCRIPTION
Kamaji already offers a scale-to-zero feature, which had some bugs prior to #771.

A TenantControlPlane, although scaled to zer,o was always marked as `Ready` even tho this was inaccurate, bringing some errors when scaling back to a positive amount of replicas, and logging false positive errors since the API Server wasn't yet ready from the Soot manager due to new pods being rolled out.

This PR introduces the new status enum `Sleeping`, useful to inform operators if a Tenant Control Plane is scaled to zero.

Marking the commit as important since a Custom Resource Definition update must be applied.