### PR TITLE
fix(helm): pull secrets to sa instead of deployment

### DIFF
--- a/charts/kamaji/templates/controller.yaml
+++ b/charts/kamaji/templates/controller.yaml
@@ -19,10 +19,6 @@ spec:
       labels:
         {{- include "kamaji.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "kamaji.serviceAccountName" . }}

--- a/charts/kamaji/templates/rbac.yaml
+++ b/charts/kamaji/templates/rbac.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This change is required for the enterprise offering where the Kamaji stable image is hosted in a container registry with authentication and can't be pulled with no credentials: when a migrate job is spun up it resuses the same Kamaji controller ServiceAccount which will offer its image pull credentials.