### PR TITLE
fix(docs): missing labels field in cluster-autoscaler.md

### DIFF
--- a/docs/content/cluster-api/cluster-autoscaler.md
+++ b/docs/content/cluster-api/cluster-autoscaler.md
@@ -64,6 +64,7 @@ Such labels must be set on the workload cluster, in the `Cluster` and `MachineDe
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
+  labels:
     cluster.x-k8s.io/cluster-name: sample
     # Cluster Autoscaler labels
     autoscaling: enabled


### PR DESCRIPTION
A label is missing in the Cluster Autoscaler YAML configuration.