### PR TITLE
feat: releasing helm latest version

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -2,10 +2,7 @@ name: Helm Chart
 
 on:
   push:
-    branches: [ "*" ]
-    tags: [ "helm-v*" ]
-  pull_request:
-    branches: [ "*" ]
+    branches: [ "master" ]
 
 jobs:
   diff:
@@ -32,7 +29,7 @@ jobs:
       - name: Linting Chart
         run: helm lint ./charts/kamaji
   release:
-    if: startsWith(github.ref, 'refs/tags/helm-v')
+    needs: [ "lint", "diff" ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.0.0
+appVersion: latest
 description: Kamaji is the Hosted Control Plane Manager for Kubernetes.
 home: https://github.com/clastix/kamaji
 icon: https://github.com/clastix/kamaji/raw/master/assets/logo-colored.png
@@ -17,7 +17,7 @@ name: kamaji
 sources:
 - https://github.com/clastix/kamaji
 type: application
-version: 0.0.0
+version: 0.0.0+latest
 dependencies:
 - name: kamaji-etcd
   repository: https://clastix.github.io/charts
@@ -46,4 +46,5 @@ annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/operatorCapabilities: "full lifecycle"
   artifacthub.io/changes: |
-    - Using dependency chart `kamaji-etcd` as a default DataStore.
+    - kind: added
+      description: Releasing latest chart at every push

--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -1,6 +1,6 @@
 # kamaji
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.0](https://img.shields.io/badge/AppVersion-v0.0.0-informational?style=flat-square)
+![Version: 0.0.0+latest](https://img.shields.io/badge/Version-0.0.0+latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 Kamaji is the Hosted Control Plane Manager for Kubernetes.
 

--- a/docs/content/getting-started/kamaji-aws.md
+++ b/docs/content/getting-started/kamaji-aws.md
@@ -163,7 +163,7 @@ Installing Kamaji via Helm charts is the preferred way. Run the following comman
 ```bash
 helm repo add clastix https://clastix.github.io/charts
 helm repo update
-helm install kamaji clastix/kamaji -n kamaji-system --create-namespace
+helm install kamaji clastix/kamaji -n kamaji-system --create-namespace --version 0.0.0+latest
 ```
 
 ## Create Tenant Cluster

--- a/docs/content/getting-started/kamaji-generic.md
+++ b/docs/content/getting-started/kamaji-generic.md
@@ -69,17 +69,20 @@ helm install \
 
 ## Install Kamaji Controller
 
-Installing Kamaji via Helm charts is the preferred way to deploy the Kamaji controller. The Helm chart is available in the `charts` directory of the Kamaji repository.
+Installing Kamaji via Helm charts is the preferred way to deploy the Kamaji controller.
+The Helm chart is available in the `charts` directory of the Kamaji repository, or as Helm Chart versioned as `0.0.0+latest`
 
 !!! info "Stable Releases"
-    As of July 2024 [Clastix Labs](https://github.com/clastix) no longer publish stable release artifacts. Stable releases are offered on a subscription basis by [CLASTIX](https://clastix.io), the main Kamaji project contributor. 
+    As of July 2024 [Clastix Labs](https://github.com/clastix) no longer publish version pinned release artifacts.
+    Version pinned and stable releases are offered on a subscription basis by [CLASTIX](https://clastix.io), the main Kamaji project contributor. 
 
 Run the following commands to install the latest edge release of Kamaji:
 
 ```bash
-git clone https://github.com/clastix/kamaji
-cd kamaji
-helm install kamaji charts/kamaji -n kamaji-system --create-namespace \
+helm install kamaji clastix/kamaji \
+    --version 0.0.0+latest \
+    --namespace kamaji-system \
+    --create-namespace \
     --set image.tag=latest
 ```
 

--- a/docs/content/getting-started/kamaji-kind.md
+++ b/docs/content/getting-started/kamaji-kind.md
@@ -92,21 +92,14 @@ EOF
 
 ## Installing Kamaji
 
-- Clone the Kamaji repository
-
-```
-git clone https://github.com/clastix/kamaji
-cd kamaji
-```
-
 - Install Kamaji with Helm
 
 ```
-helm upgrade --install kamaji charts/kamaji \
+helm upgrade --install kamaji clastix/kamaji \
   --namespace kamaji-system \
   --create-namespace \
-  --set image.tag=latest \
-  --set 'resources=null'
+  --set 'resources=null' \
+  --version 0.0.0+latest
 ```
 
 - Watch the progress of the deployments

--- a/docs/content/guides/datastore-migration.md
+++ b/docs/content/guides/datastore-migration.md
@@ -181,7 +181,7 @@ After migrating data to the new datastore, complete the migration procedure by r
 When migrating between datastores, the Kamaji controller automatically creates a migration job to transfer data from the source to the destination datastore. By default, this job uses the same image version as the running Kamaji controller. If you need to use a different image version for the migration job, you can specify it by passing extra arguments to the controller:
 
 ```shell
-helm upgrade kamaji clastix/kamaji -n kamaji-system 
+helm upgrade kamaji clastix/kamaji --version ${CHART_VERSION} -n kamaji-system 
 --set extraArgs[0]=--migrate-image=custom/kamaji:version`
 ```
 

--- a/docs/content/reference/versioning.md
+++ b/docs/content/reference/versioning.md
@@ -29,9 +29,9 @@ They may also involve breaking changes, of course, we do our best to avoid this.
 
 Edge Releases are generally considered production ready and the project will mark specific releases as _"not recommended"_ if bugs are discovered after release.
 
-| Kamaji       | Management Cluster | Tenant Cluster       |
-|--------------|--------------------|----------------------|
-| edge-24.12.1 | v1.22+             | [v1.29.0 .. v1.31.4] |
+| Kamaji      | Management Cluster | Tenant Cluster       |
+|-------------|--------------------|----------------------|
+| edge-25.4.1 | v1.22+             | [v1.30.0 .. v1.33.0] |
 
 
 Using Edge Release artifacts and reporting bugs helps us ensure a rapid pace of development and is a great way to help maintainers.

--- a/docs/content/reference/versioning.md
+++ b/docs/content/reference/versioning.md
@@ -1,24 +1,46 @@
 # Releases and Versions
 
-[Clastix Labs](https://github.com/clastix) organization publishes Kamaji's versions that correspond to specific project milestones and sets of new features. These versions are available in different types of release artifacts.
+[Clastix Labs](https://github.com/clastix) organization publishes Kamaji's versions that correspond to specific project milestones and sets of new features.
+These versions are available in different types of release artifacts.
 
 ## Types of release artifacts
 
+### Latest Releases
+
+CI is responsible for building OCI and Helm Chart for every commit in the main branch (`master`):
+The latest artifacts are aimed for rapid development tests and evaluation process.
+
+Usage of the said artefacts is not suggested for production use-case due to missing version pinning of artefacts:
+
+- `latest` for OCI image (e.g.: `docker.io/clastix/kamaji:latest`)
+- `0.0.0+latest` for the Helm Chart managed by CLASTIX (`https://clastix.github.io/charts`)
+
 ### Edge Releases
 
-Edge Release artifacts are published on a monthly basis as part of the open source project. Versioning follows the form `edge-{year}.{month}.{incremental}` where incremental refers to the monthly release. For example, `edge-24.7.1` is the first edge release shipped in July 2024. The full list of edge release artifacts can be found on the Kamaji's GitHub [releases page](https://github.com/clastix/kamaji/releases).
+Edge Release artifacts are published on a monthly basis as part of the open source project.
+Versioning follows the form `edge-{year}.{month}.{incremental}` where incremental refers to the monthly release.
+For example, `edge-24.7.1` is the first edge release shipped in July 2024.
+The full list of edge release artifacts can be found on the Kamaji's GitHub [releases page](https://github.com/clastix/kamaji/releases).
 
-Edge Release artifacts contain the code in from the main branch at the point in time when they were cut. This means they always have the latest features and fixes, and have undergone automated testing as well as maintainer code review. Edge Releases may involve partial features that are later modified or backed out. They may also involve breaking changes, of course, we do our best to avoid this. Edge Releases are generally considered production ready, and the project will mark specific releases as “_not recommended_” if bugs are discovered after release.
+Edge Release artifacts contain the code in from the main branch at the point in time when they were cut.
+This means they always have the latest features and fixes, and have undergone automated testing as well as maintainer code review.
+Edge Releases may involve partial features that are later modified or backed out.
+They may also involve breaking changes, of course, we do our best to avoid this.
+
+Edge Releases are generally considered production ready and the project will mark specific releases as _"not recommended"_ if bugs are discovered after release.
 
 | Kamaji       | Management Cluster | Tenant Cluster       |
 |--------------|--------------------|----------------------|
 | edge-24.12.1 | v1.22+             | [v1.29.0 .. v1.31.4] |
 
 
-Using Edge Release artifacts and reporting bugs helps us ensure a rapid pace of development and is a great way to help maintainers. We publish edge release guidance as part of the release notes and strive to always provide production-ready artifacts.
+Using Edge Release artifacts and reporting bugs helps us ensure a rapid pace of development and is a great way to help maintainers.
+We publish edge release guidance as part of the release notes and strive to always provide production-ready artifacts.
 
 ### Stable Releases
 
-Stable Release artifacts of Kamaji follow semantic versioning, whereby changes in major version denote large feature additions and possible breaking changes and changes in minor versions denote safe upgrades without breaking changes. As of July 2024, [Clastix Labs](https://github.com/clastix) does no longer provide stable release artifacts.
+As of July 2024, [Clastix Labs](https://github.com/clastix) does no longer provide release artifacts following its own semantic versioning:
+this choice has been put in place to help monetize CLASTIX in the development and maintenance of the Kamaji project.
 
-Stable Release artifacts are offered now on a subscription basis by [CLASTIX](https://clastix.io), the main Kamaji project contributor. Learn more about the available [Subscription Plans](https://clastix.io/support/).
+Stable artifacts such as OCI (containers) and Helm Chart ones are available on a subscription basis maintained by [CLASTIX](https://clastix.io):
+learn more about the available [Subscription Plans](https://clastix.io/support/).


### PR DESCRIPTION
With the following changes, CI will automatically push a _latest_ Helm Chart (named `0.0.0+latest`) to simplify testing and Kamaji evaluation, considering the outdated state of the v1.0.0 release.

The latest Helm chart cannot be considered a production-grade artefact due to missing version pinning: documentation has been improved to clearly share this with the community.