### PR TITLE
docs: update kamaji-kind.md to install Clastix Helm repo

### DIFF
--- a/docs/content/getting-started/kamaji-kind.md
+++ b/docs/content/getting-started/kamaji-kind.md
@@ -91,6 +91,11 @@ EOF
 ```
 
 ## Installing Kamaji
+- Add the Clastix Repo to the Helm Manager.
+
+```
+helm repo add clastix https://clastix.github.io/charts
+```
 
 - Install Kamaji with Helm
 


### PR DESCRIPTION
A step is missing : need to install helm repo of Clastix before tryinrg to install the Helm chart