### PR TITLE
feat(metrics): exposing resource handlers time bucket

### DIFF
--- a/internal/resources/addons/coredns.go
+++ b/internal/resources/addons/coredns.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -35,6 +36,12 @@ type CoreDNS struct {
 	clusterRole        *rbacv1.ClusterRole
 	clusterRoleBinding *rbacv1.ClusterRoleBinding
 	serviceAccount     *corev1.ServiceAccount
+}
+
+func (c *CoreDNS) GetHistogram() prometheus.Histogram {
+	coreDNSCollector = resources.LazyLoadHistogramFromResource(coreDNSCollector, c)
+
+	return coreDNSCollector
 }
 
 func (c *CoreDNS) Define(context.Context, *kamajiv1alpha1.TenantControlPlane) error {

--- a/internal/resources/addons/kube_proxy.go
+++ b/internal/resources/addons/kube_proxy.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -37,6 +38,12 @@ type KubeProxy struct {
 	roleBinding        *rbacv1.RoleBinding
 	configMap          *corev1.ConfigMap
 	daemonSet          *appsv1.DaemonSet
+}
+
+func (k *KubeProxy) GetHistogram() prometheus.Histogram {
+	kubeProxyCollector = resources.LazyLoadHistogramFromResource(kubeProxyCollector, k)
+
+	return kubeProxyCollector
 }
 
 func (k *KubeProxy) Define(context.Context, *kamajiv1alpha1.TenantControlPlane) error {

--- a/internal/resources/addons/metrics.go
+++ b/internal/resources/addons/metrics.go
@@ -1,0 +1,13 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package addons
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	kubeProxyCollector prometheus.Histogram
+	coreDNSCollector   prometheus.Histogram
+)

--- a/internal/resources/api_server_certificate.go
+++ b/internal/resources/api_server_certificate.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -29,6 +30,12 @@ type APIServerCertificate struct {
 	resource     *corev1.Secret
 	Client       client.Client
 	TmpDirectory string
+}
+
+func (r *APIServerCertificate) GetHistogram() prometheus.Histogram {
+	apiservercertificateCollector = LazyLoadHistogramFromResource(apiservercertificateCollector, r)
+
+	return apiservercertificateCollector
 }
 
 func (r *APIServerCertificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/api_server_kubelet_client_certificate.go
+++ b/internal/resources/api_server_kubelet_client_certificate.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -28,6 +29,12 @@ type APIServerKubeletClientCertificate struct {
 	resource     *corev1.Secret
 	Client       client.Client
 	TmpDirectory string
+}
+
+func (r *APIServerKubeletClientCertificate) GetHistogram() prometheus.Histogram {
+	clientcertificateCollector = LazyLoadHistogramFromResource(clientcertificateCollector, r)
+
+	return clientcertificateCollector
 }
 
 func (r *APIServerKubeletClientCertificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/ca_certificate.go
+++ b/internal/resources/ca_certificate.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -28,6 +29,12 @@ type CACertificate struct {
 
 	Client       client.Client
 	TmpDirectory string
+}
+
+func (r *CACertificate) GetHistogram() prometheus.Histogram {
+	certificateauthorityCollector = LazyLoadHistogramFromResource(certificateauthorityCollector, r)
+
+	return certificateauthorityCollector
 }
 
 func (r *CACertificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/datastore/datastore_certificate.go
+++ b/internal/resources/datastore/datastore_certificate.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,6 +19,7 @@ import (
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/constants"
 	"github.com/clastix/kamaji/internal/crypto"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -26,6 +28,12 @@ type Certificate struct {
 	Client    client.Client
 	Name      string
 	DataStore kamajiv1alpha1.DataStore
+}
+
+func (r *Certificate) GetHistogram() prometheus.Histogram {
+	certificateCollector = resources.LazyLoadHistogramFromResource(certificateCollector, r)
+
+	return certificateCollector
 }
 
 func (r *Certificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/datastore/datastore_migrate.go
+++ b/internal/resources/datastore/datastore_migrate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,6 +35,12 @@ type Migrate struct {
 	job              *batchv1.Job
 
 	inProgress bool
+}
+
+func (d *Migrate) GetHistogram() prometheus.Histogram {
+	migrateCollector = resources.LazyLoadHistogramFromResource(migrateCollector, d)
+
+	return migrateCollector
 }
 
 func (d *Migrate) Define(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {

--- a/internal/resources/datastore/datastore_setup.go
+++ b/internal/resources/datastore/datastore_setup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,6 +19,7 @@ import (
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/controllers/finalizers"
 	"github.com/clastix/kamaji/internal/datastore"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/resources/utils"
 )
 
@@ -32,6 +34,12 @@ type Setup struct {
 	Client     client.Client
 	Connection datastore.Connection
 	DataStore  kamajiv1alpha1.DataStore
+}
+
+func (r *Setup) GetHistogram() prometheus.Histogram {
+	setupCollector = resources.LazyLoadHistogramFromResource(setupCollector, r)
+
+	return setupCollector
 }
 
 func (r *Setup) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/controllers/finalizers"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -30,6 +32,12 @@ type Config struct {
 	Client     client.Client
 	ConnString string
 	DataStore  kamajiv1alpha1.DataStore
+}
+
+func (r *Config) GetHistogram() prometheus.Histogram {
+	storageCollector = resources.LazyLoadHistogramFromResource(storageCollector, r)
+
+	return storageCollector
 }
 
 func (r *Config) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/datastore/metrics.go
+++ b/internal/resources/datastore/metrics.go
@@ -1,0 +1,16 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package datastore
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	certificateCollector  prometheus.Histogram
+	migrateCollector      prometheus.Histogram
+	multiTenancyCollector prometheus.Histogram
+	setupCollector        prometheus.Histogram
+	storageCollector      prometheus.Histogram
+)

--- a/internal/resources/front-proxy-client-certificate.go
+++ b/internal/resources/front-proxy-client-certificate.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -28,6 +29,12 @@ type FrontProxyClientCertificate struct {
 	resource     *corev1.Secret
 	Client       client.Client
 	TmpDirectory string
+}
+
+func (r *FrontProxyClientCertificate) GetHistogram() prometheus.Histogram {
+	frontproxycertificateCollector = LazyLoadHistogramFromResource(frontproxycertificateCollector, r)
+
+	return frontproxycertificateCollector
 }
 
 func (r *FrontProxyClientCertificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/front_proxy_ca_certificate.go
+++ b/internal/resources/front_proxy_ca_certificate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -25,6 +26,12 @@ type FrontProxyCACertificate struct {
 	resource     *corev1.Secret
 	Client       client.Client
 	TmpDirectory string
+}
+
+func (r *FrontProxyCACertificate) GetHistogram() prometheus.Histogram {
+	frontproxycaCollector = LazyLoadHistogramFromResource(frontproxycaCollector, r)
+
+	return frontproxycaCollector
 }
 
 func (r *FrontProxyCACertificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -21,7 +21,6 @@ type KubernetesDeploymentResource struct {
 	resource           *appsv1.Deployment
 	Client             client.Client
 	DataStore          kamajiv1alpha1.DataStore
-	Name               string
 	KineContainerImage string
 }
 
@@ -49,8 +48,6 @@ func (r *KubernetesDeploymentResource) Define(_ context.Context, tenantControlPl
 		},
 	}
 
-	r.Name = "deployment"
-
 	return nil
 }
 
@@ -71,7 +68,7 @@ func (r *KubernetesDeploymentResource) CreateOrUpdate(ctx context.Context, tenan
 }
 
 func (r *KubernetesDeploymentResource) GetName() string {
-	return r.Name
+	return "deployment"
 }
 
 func (r *KubernetesDeploymentResource) UpdateTenantControlPlaneStatus(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {

--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -22,6 +23,12 @@ type KubernetesDeploymentResource struct {
 	Client             client.Client
 	DataStore          kamajiv1alpha1.DataStore
 	KineContainerImage string
+}
+
+func (r *KubernetesDeploymentResource) GetHistogram() prometheus.Histogram {
+	deploymentCollector = LazyLoadHistogramFromResource(deploymentCollector, r)
+
+	return deploymentCollector
 }
 
 func (r *KubernetesDeploymentResource) isStatusEqual(tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/k8s_ingress_resource.go
+++ b/internal/resources/k8s_ingress_resource.go
@@ -22,7 +22,6 @@ import (
 type KubernetesIngressResource struct {
 	resource *networkingv1.Ingress
 	Client   client.Client
-	Name     string
 }
 
 func (r *KubernetesIngressResource) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {
@@ -140,8 +139,6 @@ func (r *KubernetesIngressResource) Define(_ context.Context, tenantControlPlane
 		},
 	}
 
-	r.Name = "ingress"
-
 	return nil
 }
 
@@ -211,5 +208,5 @@ func (r *KubernetesIngressResource) CreateOrUpdate(ctx context.Context, tenantCo
 }
 
 func (r *KubernetesIngressResource) GetName() string {
-	return r.Name
+	return "ingress"
 }

--- a/internal/resources/k8s_ingress_resource.go
+++ b/internal/resources/k8s_ingress_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,12 @@ import (
 type KubernetesIngressResource struct {
 	resource *networkingv1.Ingress
 	Client   client.Client
+}
+
+func (r *KubernetesIngressResource) GetHistogram() prometheus.Histogram {
+	ingressCollector = LazyLoadHistogramFromResource(ingressCollector, r)
+
+	return ingressCollector
 }
 
 func (r *KubernetesIngressResource) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -24,6 +25,12 @@ import (
 type KubernetesServiceResource struct {
 	resource *corev1.Service
 	Client   client.Client
+}
+
+func (r *KubernetesServiceResource) GetHistogram() prometheus.Histogram {
+	serviceCollector = LazyLoadHistogramFromResource(serviceCollector, r)
+
+	return serviceCollector
 }
 
 func (r *KubernetesServiceResource) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +20,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/constants"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -26,6 +28,12 @@ type Agent struct {
 	resource     *appsv1.DaemonSet
 	Client       client.Client
 	tenantClient client.Client
+}
+
+func (r *Agent) GetHistogram() prometheus.Histogram {
+	agentCollector = resources.LazyLoadHistogramFromResource(agentCollector, r)
+
+	return agentCollector
 }
 
 func (r *Agent) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/certificate_resource.go
+++ b/internal/resources/konnectivity/certificate_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,12 +22,19 @@ import (
 	"github.com/clastix/kamaji/internal/constants"
 	"github.com/clastix/kamaji/internal/crypto"
 	"github.com/clastix/kamaji/internal/kubeadm"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
 type CertificateResource struct {
 	resource *corev1.Secret
 	Client   client.Client
+}
+
+func (r *CertificateResource) GetHistogram() prometheus.Histogram {
+	certificateCollector = resources.LazyLoadHistogramFromResource(certificateCollector, r)
+
+	return certificateCollector
 }
 
 func (r *CertificateResource) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/cluster_role_binding_resource.go
+++ b/internal/resources/konnectivity/cluster_role_binding_resource.go
@@ -6,6 +6,7 @@ package konnectivity
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +16,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/constants"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -23,6 +25,12 @@ type ClusterRoleBindingResource struct {
 
 	resource     *rbacv1.ClusterRoleBinding
 	tenantClient client.Client
+}
+
+func (r *ClusterRoleBindingResource) GetHistogram() prometheus.Histogram {
+	clusterrolebindingCollector = resources.LazyLoadHistogramFromResource(clusterrolebindingCollector, r)
+
+	return clusterrolebindingCollector
 }
 
 func (r *ClusterRoleBindingResource) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/deployment_resource.go
+++ b/internal/resources/konnectivity/deployment_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,6 +16,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	builder "github.com/clastix/kamaji/internal/builders/controlplane"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -23,6 +25,12 @@ type KubernetesDeploymentResource struct {
 
 	Builder builder.Konnectivity
 	Client  client.Client
+}
+
+func (r *KubernetesDeploymentResource) GetHistogram() prometheus.Histogram {
+	deploymentCollector = resources.LazyLoadHistogramFromResource(deploymentCollector, r)
+
+	return deploymentCollector
 }
 
 func (r *KubernetesDeploymentResource) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/egress_selector_configuration_resource.go
+++ b/internal/resources/konnectivity/egress_selector_configuration_resource.go
@@ -6,6 +6,7 @@ package konnectivity
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,12 +17,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
 type EgressSelectorConfigurationResource struct {
 	resource *corev1.ConfigMap
 	Client   client.Client
+}
+
+func (r *EgressSelectorConfigurationResource) GetHistogram() prometheus.Histogram {
+	egressCollector = resources.LazyLoadHistogramFromResource(egressCollector, r)
+
+	return egressCollector
 }
 
 func (r *EgressSelectorConfigurationResource) Define(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {

--- a/internal/resources/konnectivity/kubeconfig_resource.go
+++ b/internal/resources/konnectivity/kubeconfig_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,12 +21,19 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/constants"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
 type KubeconfigResource struct {
 	resource *corev1.Secret
 	Client   client.Client
+}
+
+func (r *KubeconfigResource) GetHistogram() prometheus.Histogram {
+	kubeconfigCollector = resources.LazyLoadHistogramFromResource(kubeconfigCollector, r)
+
+	return kubeconfigCollector
 }
 
 func (r *KubeconfigResource) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/metrics.go
+++ b/internal/resources/konnectivity/metrics.go
@@ -1,0 +1,19 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package konnectivity
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	agentCollector              prometheus.Histogram
+	certificateCollector        prometheus.Histogram
+	clusterrolebindingCollector prometheus.Histogram
+	deploymentCollector         prometheus.Histogram
+	egressCollector             prometheus.Histogram
+	kubeconfigCollector         prometheus.Histogram
+	serviceaccountCollector     prometheus.Histogram
+	serviceCollector            prometheus.Histogram
+)

--- a/internal/resources/konnectivity/service_account_resource.go
+++ b/internal/resources/konnectivity/service_account_resource.go
@@ -6,6 +6,7 @@ package konnectivity
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +16,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/constants"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -23,6 +25,12 @@ type ServiceAccountResource struct {
 
 	resource     *corev1.ServiceAccount
 	tenantClient client.Client
+}
+
+func (r *ServiceAccountResource) GetHistogram() prometheus.Histogram {
+	serviceaccountCollector = resources.LazyLoadHistogramFromResource(serviceaccountCollector, r)
+
+	return serviceaccountCollector
 }
 
 func (r *ServiceAccountResource) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/konnectivity/service_resource.go
+++ b/internal/resources/konnectivity/service_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -15,12 +16,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/resources"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
 type ServiceResource struct {
 	resource *corev1.Service
 	Client   client.Client
+}
+
+func (r *ServiceResource) GetHistogram() prometheus.Histogram {
+	serviceCollector = resources.LazyLoadHistogramFromResource(serviceCollector, r)
+
+	return serviceCollector
 }
 
 func (r *ServiceResource) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/kubeadm_config.go
+++ b/internal/resources/kubeadm_config.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,6 +26,12 @@ type KubeadmConfigResource struct {
 	Client       client.Client
 	ETCDs        []string
 	TmpDirectory string
+}
+
+func (r *KubeadmConfigResource) GetHistogram() prometheus.Histogram {
+	kubeadmconfigCollector = LazyLoadHistogramFromResource(kubeadmconfigCollector, r)
+
+	return kubeadmconfigCollector
 }
 
 func (r *KubeadmConfigResource) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/kubeadm_phases.go
+++ b/internal/resources/kubeadm_phases.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,6 +44,29 @@ type KubeadmPhase struct {
 	Client   client.Client
 	Phase    kubeadmPhase
 	checksum string
+}
+
+func (r *KubeadmPhase) GetHistogram() prometheus.Histogram {
+	switch r.Phase {
+	case PhaseUploadConfigKubeadm:
+		kubeadmphaseUploadConfigKubeadmCollector = LazyLoadHistogramFromResource(kubeadmphaseUploadConfigKubeadmCollector, r)
+
+		return kubeadmphaseUploadConfigKubeadmCollector
+	case PhaseUploadConfigKubelet:
+		kubeadmphaseUploadConfigKubeletCollector = LazyLoadHistogramFromResource(kubeadmphaseUploadConfigKubeletCollector, r)
+
+		return kubeadmphaseUploadConfigKubeletCollector
+	case PhaseBootstrapToken:
+		kubeadmphaseBootstrapTokenCollector = LazyLoadHistogramFromResource(kubeadmphaseBootstrapTokenCollector, r)
+
+		return kubeadmphaseBootstrapTokenCollector
+	case PhaseClusterAdminRBAC:
+		kubeadmphaseClusterAdminRBACCollector = LazyLoadHistogramFromResource(kubeadmphaseClusterAdminRBACCollector, r)
+
+		return kubeadmphaseClusterAdminRBACCollector
+	default:
+		panic("should not happen")
+	}
 }
 
 func (r *KubeadmPhase) GetWatchedObject() client.Object {

--- a/internal/resources/kubeadm_upgrade.go
+++ b/internal/resources/kubeadm_upgrade.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +25,12 @@ type KubernetesUpgrade struct {
 	upgrade upgrade.Upgrade
 
 	inProgress bool
+}
+
+func (k *KubernetesUpgrade) GetHistogram() prometheus.Histogram {
+	kubeadmupgradeCollector = LazyLoadHistogramFromResource(kubeadmupgradeCollector, k)
+
+	return kubeadmupgradeCollector
 }
 
 func (k *KubernetesUpgrade) Define(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -37,6 +38,12 @@ type KubeconfigResource struct {
 	Name               string
 	KubeConfigFileName string
 	TmpDirectory       string
+}
+
+func (r *KubeconfigResource) GetHistogram() prometheus.Histogram {
+	kubeconfigCollector = LazyLoadHistogramFromResource(kubeconfigCollector, r)
+
+	return kubeconfigCollector
 }
 
 func (r *KubeconfigResource) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	apiservercertificateCollector      prometheus.Histogram
+	clientcertificateCollector         prometheus.Histogram
+	certificateauthorityCollector      prometheus.Histogram
+	frontproxycertificateCollector     prometheus.Histogram
+	frontproxycaCollector              prometheus.Histogram
+	deploymentCollector                prometheus.Histogram
+	ingressCollector                   prometheus.Histogram
+	serviceCollector                   prometheus.Histogram
+	kubeadmconfigCollector             prometheus.Histogram
+	kubeadmupgradeCollector            prometheus.Histogram
+	kubeconfigCollector                prometheus.Histogram
+	serviceaccountcertificateCollector prometheus.Histogram
+
+	kubeadmphaseUploadConfigKubeadmCollector prometheus.Histogram
+	kubeadmphaseUploadConfigKubeletCollector prometheus.Histogram
+	kubeadmphaseBootstrapTokenCollector      prometheus.Histogram
+	kubeadmphaseClusterAdminRBACCollector    prometheus.Histogram
+)
+
+func LazyLoadHistogramFromResource(collector prometheus.Histogram, resource Resource) prometheus.Histogram {
+	n := resource.GetName()
+
+	if collector == nil {
+		c := prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: "kamaji",
+			Subsystem: "handler",
+			Name:      n + "_time_seconds",
+			Help:      "Bucket time requested for the given handler to complete its handling.",
+			Buckets: []float64{
+				0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+				1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60,
+			},
+		})
+
+		metrics.Registry.MustRegister(c)
+
+		return c
+	}
+
+	return collector
+}

--- a/internal/resources/sa_certificate.go
+++ b/internal/resources/sa_certificate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -26,6 +27,12 @@ type SACertificate struct {
 	Client       client.Client
 	Name         string
 	TmpDirectory string
+}
+
+func (r *SACertificate) GetHistogram() prometheus.Histogram {
+	serviceaccountcertificateCollector = LazyLoadHistogramFromResource(serviceaccountcertificateCollector, r)
+
+	return serviceaccountcertificateCollector
 }
 
 func (r *SACertificate) ShouldStatusBeUpdated(_ context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) bool {


### PR DESCRIPTION
Registering the Kamaji resource handlers into the `controller-runtime` metrics registry: this extends the observability of the Kamaji operator, identifying bottlenecks or deadlocks.

e.g. of metrics exposed:

```
# HELP kamaji_handler_konnectivity_sa_time_seconds Bucket time requested for the given handler to complete its handling.
# TYPE kamaji_handler_konnectivity_sa_time_seconds histogram
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.005"} 0
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.01"} 2
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.025"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.05"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.1"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.15"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.2"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.25"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.3"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.35"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.4"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.45"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.5"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.6"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.7"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.8"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="0.9"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="1"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="1.25"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="1.5"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="1.75"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="2"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="2.5"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="3"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="3.5"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="4"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="4.5"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="5"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="6"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="7"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="8"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="9"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="10"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="15"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="20"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="25"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="30"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="40"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="50"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="60"} 3
kamaji_handler_konnectivity_sa_time_seconds_bucket{le="+Inf"} 3
kamaji_handler_konnectivity_sa_time_seconds_sum 0.034669085
kamaji_handler_konnectivity_sa_time_seconds_count 3
```