### PR TITLE
feat: wait for pods to be deleted to report version ready

### DIFF
--- a/internal/resources/k8s_deployment_resource.go
+++ b/internal/resources/k8s_deployment_resource.go
@@ -127,6 +127,15 @@ func (r *KubernetesDeploymentResource) isProgressingUpgrade() bool {
 		return true
 	}
 
+	if ptr.Deref(r.resource.Status.TerminatingReplicas, 0) > 0 {
+		// NOTE: This is currently an alpha field, so on clusters where the DeploymentPodReplacementPolicy
+		// feature gate isn't enabled this condition will always be false.
+		// Due to its alpha state the semantics may change over time, but the goal here should always be
+		// to wait until all old Pods were deleted.
+		// See: https://github.com/kubernetes/enhancements/issues/3973
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
I was looking through the 1.33 release notes and saw that [KEP 3973](https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/3973-consider-terminating-pods-deployment/README.md) had been included in alpha state.
I was trying to find an easy to get this to work in #718, as noted by my comment describing what the conditions were, but there weren't many options. The KEP looks to be the solution I was looking for.
For context: we observed that the apiserver requests sometimes failed immediately after the TCP reported "Ready" after an update. There could be several reasons in our own setup for this (I'm actually thinking about taking a closer look at our loadbalancers) but given that the duration of the probe failures strongly correlate with the duration that terminating pods are still present, I suppose just waiting a bit longer until things settle down is a reasonable approach.
