### PR TITLE
feat: toggable cleanup schema prior migration

### DIFF
--- a/docs/content/guides/datastore-migration.md
+++ b/docs/content/guides/datastore-migration.md
@@ -172,6 +172,11 @@ After a while, depending on the amount of data to migrate, the Tenant Control Pl
 !!! info "Leftover"
     Please, note the datastore migration leaves the data on the default datastore, so you have to remove it manually.
 
+!!! info "Avoiding stale DataStore content"
+    When migrating `TenantControlPlane` across DataStore, a collision with the __schema__ name could happen,
+    leading to unexpected results such as old data still available.
+    The annotation `kamaji.clastix.io/cleanup-prior-migration=true` allows to enforce the clean-up of the target `DataStore` schema in case of collision.
+
 ## Post migration
 After migrating data to the new datastore, complete the migration procedure by restarting the `kubelet.service` on all the tenant worker nodes.
 

--- a/internal/resources/datastore/datastore_migrate.go
+++ b/internal/resources/datastore/datastore_migrate.go
@@ -6,6 +6,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
@@ -120,6 +121,11 @@ func (d *Migrate) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamaji
 			"migrate",
 			fmt.Sprintf("--tenant-control-plane=%s/%s", tenantControlPlane.GetNamespace(), tenantControlPlane.GetName()),
 			fmt.Sprintf("--target-datastore=%s", tenantControlPlane.Spec.DataStore),
+		}
+
+		if tenantControlPlane.GetAnnotations() != nil {
+			v, _ := strconv.ParseBool(tenantControlPlane.GetAnnotations()["kamaji.clastix.io/cleanup-prior-migration"])
+			d.job.Spec.Template.Spec.Containers[0].Args = append(d.job.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--cleanup-prior-migration=%t", v))
 		}
 
 		return nil


### PR DESCRIPTION
When a `TenantControlPlane` is migrated between DataStore, it could end up with stale resources which shouldn't be there.

Giving an example with a timeline:

- `t0` in `etcd-default`: Namespace `foo` is available
- `t1` migrated to `etcd-bronze`: Namespace `foo` is migrated and available
- `t3` in `etcd-bronze`: Namespace `foo` is deleted
- `t4` migrated to `etcd-default`: although Namespace `foo` was deleted, the data in `etcd-default` is not cleaned up upon Migration, leading to an inconsistent state

By introducing the annotation `TenantControlPlane` annotation `kamaji.clastix.io/cleanup-prior-migration`, it's possible to clean up the schema on target DataStore upon migration automatically.

Default value is kept as `false` to preserve consistent behaviour with previous releases.