### PR TITLE
feat(api): display status version in TenantControlPlane columns

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -305,6 +305,7 @@ type TenantControlPlaneSpec struct {
 //+kubebuilder:subresource:scale:specpath=.spec.controlPlane.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
 //+kubebuilder:resource:categories=kamaji,shortName=tcp
 //+kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetes.version",description="Kubernetes version"
+//+kubebuilder:printcolumn:name="Installed Version",type="string",JSONPath=".status.kubernetes.version",description="The actual installed Kubernetes version from status"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Status"
 //+kubebuilder:printcolumn:name="Control-Plane endpoint",type="string",JSONPath=".status.controlPlaneEndpoint",description="Tenant Control Plane Endpoint (API server)"
 //+kubebuilder:printcolumn:name="Kubeconfig",type="string",JSONPath=".status.kubeconfig.admin.secretName",description="Secret which contains admin kubeconfig"

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -23,6 +23,10 @@ spec:
           jsonPath: .spec.kubernetes.version
           name: Version
           type: string
+        - description: The actual installed Kubernetes version from status
+          jsonPath: .status.kubernetes.version
+          name: Installed Version
+          type: string
         - description: Status
           jsonPath: .status.kubernetesResources.version.status
           name: Status


### PR DESCRIPTION
This PR addresses issue #849 by enhancing the kubectl get tcp output.
Currently, the command only displays the desired version from .spec.kubernetes.version, which can be misleading during an upgrade or a failure. This change adds a new INSTALLED VERSION column to show the actual running version from .status.kubernetes.version, improving observability.

Before:
```
# kubectl get tenantcontrolplane
NAME      VERSION   STATUS   CONTROL-PLANE ENDPOINT   KUBECONFIG   DATASTORE   AGE
k8s-133   v1.33.0                                                                              
```

After:
```
# kubectl get tenantcontrolplane
NAME      VERSION   INSTALLED VERSION   STATUS   CONTROL-PLANE ENDPOINT   KUBECONFIG   DATASTORE   AGE
k8s-133   v1.33.0                                                                          
```

Fixes #849 