### PR TITLE
fix: wrong jsonpath for installed version

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -305,7 +305,7 @@ type TenantControlPlaneSpec struct {
 //+kubebuilder:subresource:scale:specpath=.spec.controlPlane.deployment.replicas,statuspath=.status.kubernetesResources.deployment.replicas,selectorpath=.status.kubernetesResources.deployment.selector
 //+kubebuilder:resource:categories=kamaji,shortName=tcp
 //+kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.kubernetes.version",description="Kubernetes version"
-//+kubebuilder:printcolumn:name="Installed Version",type="string",JSONPath=".status.kubernetes.version",description="The actual installed Kubernetes version from status"
+//+kubebuilder:printcolumn:name="Installed Version",type="string",JSONPath=".status.kubernetesResources.version.version",description="The actual installed Kubernetes version from status"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.kubernetesResources.version.status",description="Status"
 //+kubebuilder:printcolumn:name="Control-Plane endpoint",type="string",JSONPath=".status.controlPlaneEndpoint",description="Tenant Control Plane Endpoint (API server)"
 //+kubebuilder:printcolumn:name="Kubeconfig",type="string",JSONPath=".status.kubeconfig.admin.secretName",description="Secret which contains admin kubeconfig"

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -24,7 +24,7 @@ spec:
           name: Version
           type: string
         - description: The actual installed Kubernetes version from status
-          jsonPath: .status.kubernetes.version
+          jsonPath: .status.kubernetesResources.version.version
           name: Installed Version
           type: string
         - description: Status


### PR DESCRIPTION
Fixing ineffective feature introduced with #852

Prior the fix:

```
NAME      VERSION   INSTALLED VERSION   STATUS   CONTROL-PLANE ENDPOINT   KUBECONFIG                 DATASTORE     AGE
k8s-133   v1.33.0                       Ready    172.18.255.100:6443      k8s-133-admin-kubeconfig   etcd-bronze   14d
```

After the following PR:
```
NAME      VERSION   INSTALLED VERSION   STATUS   CONTROL-PLANE ENDPOINT   KUBECONFIG                 DATASTORE     AGE
k8s-133   v1.33.0   v1.33.0             Ready    172.18.255.100:6443      k8s-133-admin-kubeconfig   etcd-bronze   14d
```