### PR TITLE
fix: prioritize InternalIP in kubelet-preferred-address-types

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -67,8 +67,8 @@ const (
 
 type KubeletSpec struct {
 	// Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
-	// Default to Hostname, InternalIP, ExternalIP.
-	//+kubebuilder:default={"Hostname","InternalIP","ExternalIP"}
+	// Default to InternalIP, ExternalIP, Hostname.
+	//+kubebuilder:default={"InternalIP","ExternalIP","Hostname"}
 	//+kubebuilder:validation:MinItems=1
 	//+listType=set
 	PreferredAddressTypes []KubeletPreferredAddressType `json:"preferredAddressTypes,omitempty"`

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6547,12 +6547,12 @@ spec:
                           type: string
                         preferredAddressTypes:
                           default:
-                            - Hostname
                             - InternalIP
                             - ExternalIP
+                            - Hostname
                           description: |-
                             Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
-                            Default to Hostname, InternalIP, ExternalIP.
+                            Default to InternalIP, ExternalIP, Hostname.
                           items:
                             enum:
                               - Hostname

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -39470,10 +39470,10 @@ https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-dri
         <td>[]enum</td>
         <td>
           Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
-Default to Hostname, InternalIP, ExternalIP.<br/>
+Default to InternalIP, ExternalIP, Hostname.<br/>
           <br/>
             <i>Enum</i>: Hostname, InternalIP, ExternalIP, InternalDNS, ExternalDNS<br/>
-            <i>Default</i>: [Hostname InternalIP ExternalIP]<br/>
+            <i>Default</i>: [InternalIP ExternalIP Hostname]<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
Switch default kubelet-preferred-address-types to "InternalIP,ExternalIP,Hostname" to avoid failures in kube-apiserver connection to kubelet when node hostnames are not resolvable by the external DNS server. This improves out-of-the-box reliability across most environments by choosing node `InternalIP` as the preferred mode to reach Kubelet.

fixes #858 