### PR TITLE
feat: rotating certificates via annotation

### DIFF
--- a/controllers/certificate_lifecycle_controller.go
+++ b/controllers/certificate_lifecycle_controller.go
@@ -64,12 +64,12 @@ func (s *CertificateLifecycle) Reconcile(ctx context.Context, request reconcile.
 	var crt *x509.Certificate
 
 	switch checkType {
-	case "x509":
+	case utilities.CertificateX509Label:
 		crt, err = s.extractCertificateFromBareSecret(secret)
-	case "kubeconfig":
+	case utilities.CertificateKubeconfigLabel:
 		crt, err = s.extractCertificateFromKubeconfig(secret)
 	default:
-		err = fmt.Errorf("unsupported strategy, %s", checkType)
+		return reconcile.Result{}, fmt.Errorf("unsupported strategy, %q", checkType)
 	}
 
 	if err != nil {
@@ -144,7 +144,7 @@ func (s *CertificateLifecycle) extractCertificateFromKubeconfig(secret corev1.Se
 func (s *CertificateLifecycle) SetupWithManager(mgr controllerruntime.Manager) error {
 	s.client = mgr.GetClient()
 
-	supportedStrategies := sets.New[string]("x509", "kubeconfig")
+	supportedStrategies := sets.New[string](utilities.CertificateX509Label, utilities.CertificateKubeconfigLabel)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/docs/content/guides/certs-lifecycle.md
+++ b/docs/content/guides/certs-lifecycle.md
@@ -19,50 +19,44 @@ All the certificates are created with the `kubeadm` defaults, thus their validit
 
 ## How to rotate certificates
 
-If you need to manually rotate one of these certificates, the required operation is the deletion for the given Secret.
+All certificates can be rotated at the same time, or one by one: this is possible by annotating resources using
+the well-known annotation `certs.kamaji.clastix.io/rotate`.
 
 ```
 $: kubectl get secret
 NAME                                            TYPE                DATA   AGE
-k8s-126-admin-kubeconfig                        Opaque              1      12m
-k8s-126-api-server-certificate                  Opaque              2      12m
-k8s-126-api-server-kubelet-client-certificate   Opaque              2      3h45m
-k8s-126-ca                                      Opaque              4      3h45m
-k8s-126-controller-manager-kubeconfig           Opaque              1      3h45m
-k8s-126-datastore-certificate                   Opaque              3      3h45m
-k8s-126-datastore-config                        Opaque              4      3h45m
-k8s-126-front-proxy-ca-certificate              Opaque              2      3h45m
-k8s-126-front-proxy-client-certificate          Opaque              2      3h45m
-k8s-126-konnectivity-certificate                kubernetes.io/tls   2      3h45m
-k8s-126-konnectivity-kubeconfig                 Opaque              1      3h45m
-k8s-126-sa-certificate                          Opaque              2      3h45m
-k8s-126-scheduler-kubeconfig                    Opaque              1      3h45m
+k8s-133-admin-kubeconfig                        Opaque              1      12m
+k8s-133-api-server-certificate                  Opaque              2      12m
+k8s-133-api-server-kubelet-client-certificate   Opaque              2      3h45m
+k8s-133-ca                                      Opaque              4      3h45m
+k8s-133-controller-manager-kubeconfig           Opaque              1      3h45m
+k8s-133-datastore-certificate                   Opaque              3      3h45m
+k8s-133-datastore-config                        Opaque              4      3h45m
+k8s-133-front-proxy-ca-certificate              Opaque              2      3h45m
+k8s-133-front-proxy-client-certificate          Opaque              2      3h45m
+k8s-133-konnectivity-certificate                kubernetes.io/tls   2      3h45m
+k8s-133-konnectivity-kubeconfig                 Opaque              1      3h45m
+k8s-133-sa-certificate                          Opaque              2      3h45m
+k8s-133-scheduler-kubeconfig                    Opaque              1      3h45m
 ```
 
-Once this operation is performed, Kamaji will be notified of the missing certificate, and it will create it back.
+Once this operation is performed, Kamaji will trigger a certificate renewal,
+reporting the rotation date time as the annotation `certs.kamaji.clastix.io/rotate` value.
 
 ```
-$: kubectl delete secret -l kamaji.clastix.io/certificate_lifecycle_controller=x509
-secret "k8s-126-api-server-certificate" deleted
-secret "k8s-126-api-server-kubelet-client-certificate" deleted
-secret "k8s-126-front-proxy-client-certificate" deleted
-secret "k8s-126-konnectivity-certificate" deleted
+$: kubectl annotate secret -l kamaji.clastix.io/certificate_lifecycle_controller=x509 certs.kamaji.clastix.io/rotate=""
+secret/k8s-133-api-server-certificate annotated
+secret/k8s-133-api-server-kubelet-client-certificate annotated
+secret/k8s-133-datastore-certificate annotated
+secret/k8s-133-front-proxy-client-certificate annotated
+secret/k8s-133-konnectivity-certificate annotated
 
-$: kubectl delete secret -l kamaji.clastix.io/certificate_lifecycle_controller=x509
-NAME                                            TYPE                DATA   AGE
-k8s-126-admin-kubeconfig                        Opaque              1      15m
-k8s-126-api-server-certificate                  Opaque              2      12s
-k8s-126-api-server-kubelet-client-certificate   Opaque              2      12s
-k8s-126-ca                                      Opaque              4      3h48m
-k8s-126-controller-manager-kubeconfig           Opaque              1      3h48m
-k8s-126-datastore-certificate                   Opaque              3      3h48m
-k8s-126-datastore-config                        Opaque              4      3h48m
-k8s-126-front-proxy-ca-certificate              Opaque              2      3h48m
-k8s-126-front-proxy-client-certificate          Opaque              2      12s
-k8s-126-konnectivity-certificate                kubernetes.io/tls   2      11s
-k8s-126-konnectivity-kubeconfig                 Opaque              1      3h48m
-k8s-126-sa-certificate                          Opaque              2      3h48m
-k8s-126-scheduler-kubeconfig                    Opaque              1      3h48m
+$: kubectl get secrets -l kamaji.clastix.io/certificate_lifecycle_controller=x509 -ojson | jq -r '.items[] | "\(.metadata.name) rotated at \(.metadata.annotations["certs.kamaji.clastix.io/rotate"])"'
+k8s-133-api-server-certificate rotated at 2025-07-15 15:15:08.842191367 +0200 CEST m=+325.785000014
+k8s-133-api-server-kubelet-client-certificate rotated at 2025-07-15 15:15:10.468139865 +0200 CEST m=+327.410948506
+k8s-133-datastore-certificate rotated at 2025-07-15 15:15:15.454468752 +0200 CEST m=+332.397277417
+k8s-133-front-proxy-client-certificate rotated at 2025-07-15 15:15:13.279920467 +0200 CEST m=+330.222729097
+k8s-133-konnectivity-certificate rotated at 2025-07-15 15:15:17.361431671 +0200 CEST m=+334.304240277
 ```
 
 You can notice the secrets have been automatically created back, as well as a TenantControlPlane rollout with the updated certificates.
@@ -70,23 +64,24 @@ You can notice the secrets have been automatically created back, as well as a Te
 ```
 $: kubectl get pods
 NAME                       READY   STATUS    RESTARTS   AGE
-k8s-126-76768bdf89-82w8g   4/4     Running   0          58s
-k8s-126-76768bdf89-fwltl   4/4     Running   0          58s
+k8s-133-67bf496c8c-27bmp   4/4     Running   0          4m52s
+k8s-133-67bf496c8c-x4t76   4/4     Running   0          4m52s
 ```
 
 The same occurs with the `kubeconfig` ones.
 
 ```
-$: kubectl delete secret -l kamaji.clastix.io/certificate_lifecycle_controller=kubeconfig
-secret "k8s-126-admin-kubeconfig" deleted
-secret "k8s-126-controller-manager-kubeconfig" deleted
-secret "k8s-126-konnectivity-kubeconfig" deleted
-secret "k8s-126-scheduler-kubeconfig" deleted
+$: kubectl annotate secret -l kamaji.clastix.io/certificate_lifecycle_controller=kubeconfig certs.kamaji.clastix.io/rotate=""
+secret/k8s-133-admin-kubeconfig annotated
+secret/k8s-133-controller-manager-kubeconfig annotated
+secret/k8s-133-konnectivity-kubeconfig annotated
+secret/k8s-133-scheduler-kubeconfig annotated
 
-$: kubectl get pods
-NAME                       READY   STATUS    RESTARTS   AGE
-k8s-126-576c775b5d-2gr9h   4/4     Running   0          50s
-k8s-126-576c775b5d-jmvlm   4/4     Running   0          50s
+$: kubectl get secrets -l kamaji.clastix.io/certificate_lifecycle_controller=kubeconfig -ojson | jq -r '.items[] | "\(.metadata.name) rotated at \(.metadata.annotations["certs.kamaji.clastix.io/rotate"])"'
+k8s-133-admin-kubeconfig rotated at 2025-07-15 15:20:41.688181782 +0200 CEST m=+658.630990441
+k8s-133-controller-manager-kubeconfig rotated at 2025-07-15 15:20:42.712211056 +0200 CEST m=+659.655019677
+k8s-133-konnectivity-kubeconfig rotated at 2025-07-15 15:20:46.405567865 +0200 CEST m=+663.348376504
+k8s-133-scheduler-kubeconfig rotated at 2025-07-15 15:20:46.333718563 +0200 CEST m=+663.276527216
 ```
 
 ## Automatic certificates rotation
@@ -108,11 +103,11 @@ e.g.: set the value `7d` to trigger the renewal a week before the effective expi
 
 Kamaji is also taking care of your Tenant Clusters Certificate Authority.
 
-This can be rotated manually by deleting the following secret.
+This can be rotated manually like other certificates by using the annotation `certs.kamaji.clastix.io/rotate`
 
 ```
-$: kubectl delete secret k8s-126-ca
-secret "k8s-126-ca" deleted
+$: kubectl annotate secret k8s-133-ca certs.kamaji.clastix.io/rotate="" 
+secret/k8s-133-ca annotated
 ```
 
 Once this occurs the TenantControlPlane will enter in the `CertificateAuthorityRotating` status.
@@ -120,26 +115,26 @@ Once this occurs the TenantControlPlane will enter in the `CertificateAuthorityR
 ```
 $: kubectl get tcp -w
 NAME      VERSION   STATUS   CONTROL-PLANE ENDPOINT   KUBECONFIG                 DATASTORE   AGE
-k8s-126   v1.26.0   Ready    172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   Ready                          172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   Ready                          172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   Ready                          172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   Ready                          172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
-k8s-126   v1.26.0   Ready                          172.18.255.200:6443      k8s-126-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   Ready    172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   CertificateAuthorityRotating   172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   Ready                          172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   Ready                          172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   Ready                          172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   Ready                          172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
+k8s-133   v1.33.0   Ready                          172.18.255.200:6443      k8s-133-admin-kubeconfig   default     3h58m
 ```
 
-This operation is intended to be performed manually since a new Certificate Authority requires the restart of all the components, as well as of the nodes:
-in such case, you will need to distribute the new Certificate Authority and the new nodes certificates.
+This operation is intended to be performed manually since a new Certificate Authority requires the restart of all the components,
+as well as of the nodes: in such a case, you will need to distribute the new Certificate Authority and the new nodes certificates.
 
 Given the sensibility of such operation, the `Secret` controller will not check the _CA_, which is offering validity of 10 years as `kubeadm` default values. 

--- a/internal/kubeadm/kubeconfig.go
+++ b/internal/kubeadm/kubeconfig.go
@@ -4,6 +4,7 @@
 package kubeadm
 
 import (
+	"bytes"
 	"os"
 	"path"
 	"path/filepath"
@@ -44,6 +45,21 @@ func CreateKubeconfig(kubeconfigName string, ca CertificatePrivateKeyPair, confi
 	path := filepath.Join(config.InitConfiguration.CertificatesDir, kubeconfigName)
 
 	return os.ReadFile(path)
+}
+
+func IsKubeconfigCAValid(in, caCrt []byte) bool {
+	kc, err := utilities.DecodeKubeconfigYAML(in)
+	if err != nil {
+		return false
+	}
+
+	for _, cluster := range kc.Clusters {
+		if !bytes.Equal(cluster.Cluster.CertificateAuthorityData, caCrt) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func IsKubeconfigValid(bytes []byte) bool {

--- a/internal/resources/api_server_kubelet_client_certificate.go
+++ b/internal/resources/api_server_kubelet_client_certificate.go
@@ -104,7 +104,7 @@ func (r *APIServerKubeletClientCertificate) mutate(ctx context.Context, tenantCo
 		r.resource.SetLabels(utilities.MergeMaps(
 			utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()),
 			map[string]string{
-				constants.ControllerLabelResource: "x509",
+				constants.ControllerLabelResource: utilities.CertificateX509Label,
 			},
 		))
 
@@ -114,7 +114,9 @@ func (r *APIServerKubeletClientCertificate) mutate(ctx context.Context, tenantCo
 			return err
 		}
 
-		if checksum := tenantControlPlane.Status.Certificates.APIServerKubeletClient.Checksum; len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) || len(r.resource.UID) > 0 {
+		isRotationRequested := utilities.IsRotationRequested(r.resource)
+
+		if checksum := tenantControlPlane.Status.Certificates.APIServerKubeletClient.Checksum; !isRotationRequested && (len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) || len(r.resource.UID) > 0) {
 			isCAValid, err := crypto.VerifyCertificate(r.resource.Data[kubeadmconstants.APIServerKubeletClientCertName], secretCA.Data[kubeadmconstants.CACertName], x509.ExtKeyUsageClientAuth)
 			if err != nil {
 				logger.Info(fmt.Sprintf("certificate-authority verify failed: %s", err.Error()))
@@ -150,6 +152,10 @@ func (r *APIServerKubeletClientCertificate) mutate(ctx context.Context, tenantCo
 			logger.Error(err, "cannot generate certificate and private key")
 
 			return err
+		}
+
+		if isRotationRequested {
+			utilities.SetLastRotationTimestamp(r.resource)
 		}
 
 		r.resource.Data = map[string][]byte{

--- a/internal/resources/ca_certificate.go
+++ b/internal/resources/ca_certificate.go
@@ -96,7 +96,9 @@ func (r *CACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 	return func() error {
 		logger := log.FromContext(ctx, "resource", r.GetName())
 
-		if checksum := tenantControlPlane.Status.Certificates.CA.Checksum; len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) || len(r.resource.UID) > 0 {
+		isRotationRequested := utilities.IsRotationRequested(r.resource)
+
+		if checksum := tenantControlPlane.Status.Certificates.CA.Checksum; !isRotationRequested && (len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) || len(r.resource.UID) > 0) {
 			isValid, err := crypto.CheckCertificateAndPrivateKeyPairValidity(
 				r.resource.Data[kubeadmconstants.CACertName],
 				r.resource.Data[kubeadmconstants.CAKeyName],
@@ -114,6 +116,10 @@ func (r *CACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 			if isValid {
 				return ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
 			}
+		}
+
+		if isRotationRequested {
+			utilities.SetLastRotationTimestamp(r.resource)
 		}
 
 		if tenantControlPlane.Status.Kubernetes.Version.Status != nil && *tenantControlPlane.Status.Kubernetes.Version.Status != kamajiv1alpha1.VersionProvisioning {

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -185,9 +185,10 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 
 		var shouldCreate bool
 
-		shouldCreate = shouldCreate || r.resource.Data == nil                                            // Missing data key
-		shouldCreate = shouldCreate || len(r.resource.Data) == 0                                         // Missing data key
-		shouldCreate = shouldCreate || len(r.resource.Data[r.KubeConfigFileName]) == 0                   // Missing kubeconfig file, must be generated
+		shouldCreate = shouldCreate || r.resource.Data == nil                          // Missing data key
+		shouldCreate = shouldCreate || len(r.resource.Data) == 0                       // Missing data key
+		shouldCreate = shouldCreate || len(r.resource.Data[r.KubeConfigFileName]) == 0 // Missing kubeconfig file, must be generated
+		shouldCreate = shouldCreate || !kubeadm.IsKubeconfigCAValid(r.resource.Data[r.KubeConfigFileName], caCertificatesSecret.Data[kubeadmconstants.CACertName])
 		shouldCreate = shouldCreate || !kubeadm.IsKubeconfigValid(r.resource.Data[r.KubeConfigFileName]) // invalid kubeconfig, or expired client certificate
 		shouldCreate = shouldCreate || status.Checksum != checksum || len(r.resource.UID) == 0           // Wrong checksum
 

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -172,10 +172,10 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 		r.resource.SetLabels(utilities.MergeMaps(
 			utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()),
 			map[string]string{
-				constants.ControllerLabelResource: "kubeconfig",
+				constants.ControllerLabelResource: utilities.CertificateKubeconfigLabel,
 			},
 		))
-		r.resource.SetAnnotations(map[string]string{constants.Checksum: checksum})
+		r.resource.SetAnnotations(utilities.MergeMaps(r.resource.GetAnnotations(), map[string]string{constants.Checksum: checksum}))
 
 		if err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
 			logger.Error(err, "cannot set controller reference", "resource", r.GetName())
@@ -192,12 +192,14 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 		shouldCreate = shouldCreate || !kubeadm.IsKubeconfigValid(r.resource.Data[r.KubeConfigFileName]) // invalid kubeconfig, or expired client certificate
 		shouldCreate = shouldCreate || status.Checksum != checksum || len(r.resource.UID) == 0           // Wrong checksum
 
+		shouldRotate := utilities.IsRotationRequested(r.resource)
+
 		if !shouldCreate {
 			v, ok := r.resource.Data[r.KubeConfigFileName]
 			shouldCreate = len(v) == 0 || !ok
 		}
-		//nolint:nestif
-		if shouldCreate {
+
+		if shouldCreate || shouldRotate {
 			crtKeyPair := kubeadm.CertificatePrivateKeyPair{
 				Certificate: caCertificatesSecret.Data[kubeadmconstants.CACertName],
 				PrivateKey:  caCertificatesSecret.Data[kubeadmconstants.CAKeyName],
@@ -212,6 +214,10 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 				logger.Error(kcErr, "cannot create a valid kubeconfig")
 
 				return kcErr
+			}
+
+			if shouldRotate {
+				utilities.SetLastRotationTimestamp(r.resource)
 			}
 
 			r.resource.Data[r.KubeConfigFileName] = kubeconfig

--- a/internal/resources/sa_certificate.go
+++ b/internal/resources/sa_certificate.go
@@ -91,7 +91,9 @@ func (r *SACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 	return func() error {
 		logger := log.FromContext(ctx, "resource", r.GetName())
 
-		if checksum := tenantControlPlane.Status.Certificates.SA.Checksum; len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) || len(r.resource.UID) > 0 {
+		isRotationRequested := utilities.IsRotationRequested(r.resource)
+
+		if checksum := tenantControlPlane.Status.Certificates.SA.Checksum; !isRotationRequested && (len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) || len(r.resource.UID) > 0) {
 			isValid, err := crypto.CheckPublicAndPrivateKeyValidity(r.resource.Data[kubeadmconstants.ServiceAccountPublicKeyName], r.resource.Data[kubeadmconstants.ServiceAccountPrivateKeyName])
 			if err != nil {
 				logger.Info(fmt.Sprintf("%s public_key-private_key pair is not valid: %s", kubeadmconstants.ServiceAccountKeyBaseName, err.Error()))
@@ -121,6 +123,10 @@ func (r *SACertificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1
 		}
 
 		r.resource.SetLabels(utilities.KamajiLabels(tenantControlPlane.GetName(), r.GetName()))
+
+		if isRotationRequested {
+			utilities.SetLastRotationTimestamp(r.resource)
+		}
 
 		utilities.SetObjectChecksum(r.resource, r.resource.Data)
 

--- a/internal/utilities/certs_rotation.go
+++ b/internal/utilities/certs_rotation.go
@@ -1,0 +1,40 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package utilities
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	RotateCertificateRequestAnnotation = "certs.kamaji.clastix.io/rotate"
+
+	CertificateX509Label       = "x509"
+	CertificateKubeconfigLabel = "kubeconfig"
+)
+
+func IsRotationRequested(obj client.Object) bool {
+	if obj.GetAnnotations() == nil {
+		return false
+	}
+
+	v, ok := obj.GetAnnotations()[RotateCertificateRequestAnnotation]
+	if ok && v == "" {
+		return true
+	}
+
+	return false
+}
+
+func SetLastRotationTimestamp(obj client.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	annotations[RotateCertificateRequestAnnotation] = metav1.Now().String()
+
+	obj.SetAnnotations(annotations)
+}


### PR DESCRIPTION
Addresses #876.

Annotation `certs.kamaji.clastix.io/rotate` is introduced to perform certificate rotation of certificates stored as Kubernetes secrets in the management cluster.