### PR TITLE
feat!: add hostNetwork support for the Konnectivity Agent

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -257,6 +257,12 @@ type KonnectivityAgentSpec struct {
 	//+kubebuilder:default={{key: "CriticalAddonsOnly", operator: "Exists"}}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	ExtraArgs   ExtraArgs           `json:"extraArgs,omitempty"`
+	// HostNetwork enables the konnectivity agent to use the Host network namespace.
+	// By enabling this mode, the Agent doesn't need to wait for the CNI initialisation,
+	// enabling a sort of out-of-band access to nodes for troubleshooting scenarios,
+	// or when the agent needs direct access to the host network.
+	//+kubebuilder:default=false
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 	// Mode allows specifying the Agent deployment mode: Deployment, or DaemonSet (default).
 	//+kubebuilder:default="DaemonSet"
 	//+kubebuilder:validation:Enum=DaemonSet;Deployment

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -108,6 +108,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            hostNetwork:
+                              default: false
+                              description: |-
+                                HostNetwork enables the konnectivity agent to use the Host network namespace.
+                                By enabling this mode, the Agent doesn't need to wait for the CNI initialisation,
+                                enabling a sort of out-of-band access to nodes for troubleshooting scenarios,
+                                or when the agent needs direct access to the host network.
+                              type: boolean
                             image:
                               default: registry.k8s.io/kas-network-proxy/proxy-agent
                               description: AgentImage defines the container image for Konnectivity's agent.

--- a/config/samples/kamaji_v1alpha1_tenantcontrolplane_konnectivity_hostnetwork.yaml
+++ b/config/samples/kamaji_v1alpha1_tenantcontrolplane_konnectivity_hostnetwork.yaml
@@ -1,0 +1,36 @@
+apiVersion: kamaji.clastix.io/v1alpha1
+kind: TenantControlPlane
+metadata:
+  name: example-hostnetwork-tcp
+  namespace: tenant-system
+spec:
+  controlPlane:
+    deployment:
+      replicas: 2
+    service:
+      serviceType: LoadBalancer
+  kubernetes:
+    version: v1.29.0
+    kubelet:
+      cgroupfs: systemd
+      preferredAddressTypes: ["InternalIP", "ExternalIP"]
+  networkProfile:
+    address: "10.0.0.100"
+    port: 6443
+    serviceCidr: "10.96.0.0/16"
+    podCidr: "10.244.0.0/16"
+  addons:
+    coreDNS: {}
+    konnectivity:
+      server:
+        port: 8132
+      agent:
+        hostNetwork: true
+        tolerations:
+          - key: "CriticalAddonsOnly"
+            operator: "Exists"
+          - key: "node.kubernetes.io/not-ready"
+            operator: "Exists"
+            effect: "NoExecute"
+            tolerationSeconds: 300
+    kubeProxy: {}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -39627,6 +39627,18 @@ unxpected ways. Only modify if you know what you are doing.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>hostNetwork</b></td>
+        <td>boolean</td>
+        <td>
+          HostNetwork enables the konnectivity agent to use the Host network namespace.
+By enabling this mode, the Agent doesn't need to wait for the CNI initialisation,
+enabling a sort of out-of-band access to nodes for troubleshooting scenarios,
+or when the agent needs direct access to the host network.<br/>
+          <br/>
+            <i>Default</i>: false<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -190,6 +190,7 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 		podTemplateSpec.SetLabels(utilities.MergeMaps(podTemplateSpec.GetLabels(), specSelector.MatchLabels))
 		podTemplateSpec.Spec.PriorityClassName = "system-cluster-critical"
 		podTemplateSpec.Spec.Tolerations = tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.Tolerations
+		podTemplateSpec.Spec.HostNetwork = tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.HostNetwork
 		podTemplateSpec.Spec.NodeSelector = map[string]string{
 			"kubernetes.io/os": "linux",
 		}


### PR DESCRIPTION
This commit extends CRD API: Added hostNetwork field to KonnectivityAgentSpec struct. It's false by default so it's backwards compatible.

Users can now configure hostNetwork in their TenantControlPlane spec:

```yaml
spec:
  addons:
    konnectivity:
      agent:
        hostNetwork: true
        # 
```

Fixes https://github.com/clastix/kamaji/issues/882