### PR TITLE
fix(docs): aws network-interfaces is an array

### DIFF
--- a/docs/content/getting-started/kamaji-aws.md
+++ b/docs/content/getting-started/kamaji-aws.md
@@ -359,7 +359,7 @@ cat <<EOF >> worker-user-data.sh
 $JOIN_CMD
 EOF
 
-aws ec2 run-instances --image-id $WORKER_AMI --instance-type "t2.medium" --user-data $(cat worker-user-data.sh | base64 -w0) --network-interfaces '{"SubnetId":'"'${KAMAJI_PRIVATE_SUBNET_ID}'"',"AssociatePublicIpAddress":false,"DeviceIndex":0,"Groups":["<REPLACE_WITH_SG>"]}' --count "1" 
+aws ec2 run-instances --image-id $WORKER_AMI --instance-type "t2.medium" --user-data $(cat worker-user-data.sh | base64 -w0) --network-interfaces '[{"SubnetId":'"'${KAMAJI_PRIVATE_SUBNET_ID}'"',"AssociatePublicIpAddress":false,"DeviceIndex":0,"Groups":["<REPLACE_WITH_SG>"]}]' --count "1"
 ```
 
 We have used user data to run the `kubeadm join` command on the instance boot. This will make sure that the worker node will join the cluster automatically.


### PR DESCRIPTION
Firstly, thanks for this amazingly detailed writeup for running kamaji on aws, which is very helpful! This pr is per offline discussed with @prometherion to submit a fix for the typo in the doc.

My aws local cli version:
`aws-cli/2.11.20 Python/3.11.3 Linux/5.15.0-107-generic exe/x86_64.ubuntu.20 prompt/off`

My following command will fail in the "Create tenant worker nodes" section:
```
$ aws ec2 run-instances --image-id $WORKER_AMI --instance-type "t2.medium" --user-data $(cat worker-user-data.sh | base64 -w0) --network-interfaces '{"SubnetId":'"'${KAMAJI_PRIVATE_SUBNET_ID}'"',"AssociatePublicIpAddress":false,"DeviceIndex":0,"Groups":["sg-0a5b3e488ca101057"]}' --count "1"

Error parsing parameter '--network-interfaces': Invalid JSON: Expecting value: line 1 column 13 (char 12)
JSON received: {"SubnetId":'subnet-07b00a0b5208be7f2',"AssociatePublicIpAddress":false,"DeviceIndex":0,"Groups":["sg-0a5b3e488ca101057"]}
```

However, when I changed it to use a list (a [] wrapping the {} for --network-interfaces), it works fine:
```
$ aws ec2 run-instances \
>   --image-id "$WORKER_AMI" \
>   --instance-type t2.medium \
>   --user-data file://worker-user-data.sh \
>   --network-interfaces '[{"SubnetId":"'"$KAMAJI_PRIVATE_SUBNET_ID"'","AssociatePublicIpAddress":false,"DeviceIndex":0,"Groups":["sg-0a5b3e488ca101057"]}]' \
>   --count 1
```