### PR TITLE
feat!: inflecting version for konnectivity components from tcp

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -226,7 +226,9 @@ type KonnectivityServerSpec struct {
 	// The port which Konnectivity server is listening to.
 	Port int32 `json:"port"`
 	// Container image version of the Konnectivity server.
-	//+kubebuilder:default=v0.28.6
+	// If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+	//
+	// WARNING: for last cut-off releases, the container image could be not available.
 	Version string `json:"version,omitempty"`
 	// Container image used by the Konnectivity server.
 	//+kubebuilder:default=registry.k8s.io/kas-network-proxy/proxy-server
@@ -250,7 +252,9 @@ type KonnectivityAgentSpec struct {
 	//+kubebuilder:default=registry.k8s.io/kas-network-proxy/proxy-agent
 	Image string `json:"image,omitempty"`
 	// Version for Konnectivity agent.
-	//+kubebuilder:default=v0.28.6
+	// If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+	//
+	// WARNING: for last cut-off releases, the container image could be not available.
 	Version string `json:"version,omitempty"`
 	// Tolerations for the deployed agent.
 	// Can be customized to start the konnectivity-agent even if the nodes are not ready or tainted.
@@ -275,9 +279,9 @@ type KonnectivityAgentSpec struct {
 
 // KonnectivitySpec defines the spec for Konnectivity.
 type KonnectivitySpec struct {
-	//+kubebuilder:default={version:"v0.28.6",image:"registry.k8s.io/kas-network-proxy/proxy-server",port:8132}
+	//+kubebuilder:default={image:"registry.k8s.io/kas-network-proxy/proxy-server",port:8132}
 	KonnectivityServerSpec KonnectivityServerSpec `json:"server,omitempty"`
-	//+kubebuilder:default={version:"v0.28.6",image:"registry.k8s.io/kas-network-proxy/proxy-agent",mode:"DaemonSet"}
+	//+kubebuilder:default={image:"registry.k8s.io/kas-network-proxy/proxy-agent",mode:"DaemonSet"}
 	KonnectivityAgentSpec KonnectivityAgentSpec `json:"agent,omitempty"`
 }
 

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -89,7 +89,6 @@ versions:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-agent
                           mode: DaemonSet
-                          version: v0.28.6
                         properties:
                           extraArgs:
                             description: |-
@@ -170,8 +169,11 @@ versions:
                               type: object
                             type: array
                           version:
-                            default: v0.28.6
-                            description: Version for Konnectivity agent.
+                            description: |-
+                              Version for Konnectivity agent.
+                              If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+
+                              WARNING: for last cut-off releases, the container image could be not available.
                             type: string
                         type: object
                         x-kubernetes-validations:
@@ -181,7 +183,6 @@ versions:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-server
                           port: 8132
-                          version: v0.28.6
                         properties:
                           extraArgs:
                             description: |-
@@ -260,8 +261,11 @@ versions:
                                 type: object
                             type: object
                           version:
-                            default: v0.28.6
-                            description: Container image version of the Konnectivity server.
+                            description: |-
+                              Container image version of the Konnectivity server.
+                              If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+
+                              WARNING: for last cut-off releases, the container image could be not available.
                             type: string
                         required:
                           - port

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -97,7 +97,6 @@ spec:
                           default:
                             image: registry.k8s.io/kas-network-proxy/proxy-agent
                             mode: DaemonSet
-                            version: v0.28.6
                           properties:
                             extraArgs:
                               description: |-
@@ -178,8 +177,11 @@ spec:
                                 type: object
                               type: array
                             version:
-                              default: v0.28.6
-                              description: Version for Konnectivity agent.
+                              description: |-
+                                Version for Konnectivity agent.
+                                If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+
+                                WARNING: for last cut-off releases, the container image could be not available.
                               type: string
                           type: object
                           x-kubernetes-validations:
@@ -189,7 +191,6 @@ spec:
                           default:
                             image: registry.k8s.io/kas-network-proxy/proxy-server
                             port: 8132
-                            version: v0.28.6
                           properties:
                             extraArgs:
                               description: |-
@@ -268,8 +269,11 @@ spec:
                                   type: object
                               type: object
                             version:
-                              default: v0.28.6
-                              description: Container image version of the Konnectivity server.
+                              description: |-
+                                Container image version of the Konnectivity server.
+                                If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+
+                                WARNING: for last cut-off releases, the container image could be not available.
                               type: string
                           required:
                             - port

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -40151,7 +40151,7 @@ Enables the Konnectivity addon in the Tenant Cluster, required if the worker nod
         <td>
           <br/>
           <br/>
-            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-agent mode:DaemonSet version:v0.28.6]<br/>
+            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-agent mode:DaemonSet]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -40160,7 +40160,7 @@ Enables the Konnectivity addon in the Tenant Cluster, required if the worker nod
         <td>
           <br/>
           <br/>
-            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-server port:8132 version:v0.28.6]<br/>
+            <i>Default</i>: map[image:registry.k8s.io/kas-network-proxy/proxy-server port:8132]<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -40246,9 +40246,10 @@ Can be customized to start the konnectivity-agent even if the nodes are not read
         <td><b>version</b></td>
         <td>string</td>
         <td>
-          Version for Konnectivity agent.<br/>
-          <br/>
-            <i>Default</i>: v0.28.6<br/>
+          Version for Konnectivity agent.
+If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+
+WARNING: for last cut-off releases, the container image could be not available.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -40373,9 +40374,10 @@ unxpected ways. Only modify if you know what you are doing.<br/>
         <td><b>version</b></td>
         <td>string</td>
         <td>
-          Container image version of the Konnectivity server.<br/>
-          <br/>
-            <i>Default</i>: v0.28.6<br/>
+          Container image version of the Konnectivity server.
+If left empty, Kamaji will automatically inflect the version from the deployed Tenant Control Plane.
+
+WARNING: for last cut-off releases, the container image could be not available.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/builders/controlplane/konnectivity_server.go
+++ b/internal/builders/controlplane/konnectivity_server.go
@@ -6,6 +6,7 @@ package controlplane
 import (
 	"fmt"
 
+	"github.com/blang/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,7 +34,20 @@ type Konnectivity struct {
 	Scheme runtime.Scheme
 }
 
-func (k Konnectivity) buildKonnectivityContainer(addon *kamajiv1alpha1.KonnectivitySpec, replicas int32, podSpec *corev1.PodSpec) {
+func (k Konnectivity) serverVersion(tcpVersion, addonVersion string) string {
+	if addonVersion != "" {
+		return addonVersion
+	}
+
+	version, parsedErr := semver.ParseTolerant(tcpVersion)
+	if parsedErr != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("v0.%d.0", version.Minor)
+}
+
+func (k Konnectivity) buildKonnectivityContainer(tcpVersion string, addon *kamajiv1alpha1.KonnectivitySpec, replicas int32, podSpec *corev1.PodSpec) {
 	found, index := utilities.HasNamedContainer(podSpec.Containers, konnectivityServerName)
 	if !found {
 		index = len(podSpec.Containers)
@@ -41,7 +55,7 @@ func (k Konnectivity) buildKonnectivityContainer(addon *kamajiv1alpha1.Konnectiv
 	}
 
 	podSpec.Containers[index].Name = konnectivityServerName
-	podSpec.Containers[index].Image = fmt.Sprintf("%s:%s", addon.KonnectivityServerSpec.Image, addon.KonnectivityServerSpec.Version)
+	podSpec.Containers[index].Image = fmt.Sprintf("%s:%s", addon.KonnectivityServerSpec.Image, k.serverVersion(tcpVersion, addon.KonnectivityServerSpec.Version))
 	podSpec.Containers[index].Command = []string{"/proxy-server"}
 
 	args := utilities.ArgsFromSliceToMap(addon.KonnectivityServerSpec.ExtraArgs)
@@ -254,7 +268,7 @@ func (k Konnectivity) buildVolumes(status kamajiv1alpha1.KonnectivityStatus, pod
 }
 
 func (k Konnectivity) Build(deployment *appsv1.Deployment, tenantControlPlane kamajiv1alpha1.TenantControlPlane) {
-	k.buildKonnectivityContainer(tenantControlPlane.Spec.Addons.Konnectivity, *tenantControlPlane.Spec.ControlPlane.Deployment.Replicas, &deployment.Spec.Template.Spec)
+	k.buildKonnectivityContainer(tenantControlPlane.Spec.Kubernetes.Version, tenantControlPlane.Spec.Addons.Konnectivity, *tenantControlPlane.Spec.ControlPlane.Deployment.Replicas, &deployment.Spec.Template.Spec)
 	k.buildVolumeMounts(&deployment.Spec.Template.Spec)
 	k.buildVolumes(tenantControlPlane.Status.Addons.Konnectivity, &deployment.Spec.Template.Spec)
 


### PR DESCRIPTION
Addresses #494.

Marking this change as breaking due to the release cycle of Konnectivity being delayed compared to the Kubernetes control plane components: although v1.34.0 has been released as OCI artefacts, `konnectivity-server` and `konnectivity-agent` are still not built and available.