### PR TITLE
fix: default values for schema and username

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_funcs.go
+++ b/api/v1alpha1/tenantcontrolplane_funcs.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -94,4 +95,18 @@ func getLoadBalancerAddress(ingress []corev1.LoadBalancerIngress) (string, error
 	}
 
 	return "", kamajierrors.MissingValidIPError{}
+}
+
+func (in *TenantControlPlane) normalizeNamespaceName() string {
+	// The dash character (-) must be replaced with an underscore, PostgreSQL is complaining about it:
+	// https://github.com/clastix/kamaji/issues/328
+	return strings.ReplaceAll(fmt.Sprintf("%s_%s", in.GetNamespace(), in.GetName()), "-", "_")
+}
+
+func (in *TenantControlPlane) GetDefaultDatastoreUsername() string {
+	return in.normalizeNamespaceName()
+}
+
+func (in *TenantControlPlane) GetDefaultDatastoreSchema() string {
+	return in.normalizeNamespaceName()
 }

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -5,7 +5,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -163,8 +162,7 @@ func (r *Config) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.
 				// or defaulted by the defaulting webhook
 				username = []byte(tenantControlPlane.Spec.DataStoreUsername)
 			default:
-				// this can only happen on TCP creations when the webhook is not installed
-				return fmt.Errorf("cannot build datastore storage config, username must either exist in Spec or Status")
+				username = []byte(tenantControlPlane.GetDefaultDatastoreUsername())
 			}
 		}
 
@@ -180,8 +178,7 @@ func (r *Config) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.
 			// or defaulted by the defaulting webhook
 			dataStoreSchema = tenantControlPlane.Spec.DataStoreSchema
 		default:
-			// this can only happen on TCP creations when the webhook is not installed
-			return fmt.Errorf("cannot build datastore storage config, schema name must either exist in Spec or Status")
+			dataStoreSchema = tenantControlPlane.GetDefaultDatastoreSchema()
 		}
 
 		r.resource.Data = map[string][]byte{

--- a/internal/webhook/handlers/tcp_defaults.go
+++ b/internal/webhook/handlers/tcp_defaults.go
@@ -5,9 +5,7 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net"
-	"strings"
 
 	"github.com/pkg/errors"
 	"gomodules.xyz/jsonpatch/v2"
@@ -73,14 +71,10 @@ func (t TenantControlPlaneDefaults) defaultUnsetFields(tcp *kamajiv1alpha1.Tenan
 	}
 
 	if len(tcp.Spec.DataStoreSchema) == 0 {
-		dss := strings.ReplaceAll(fmt.Sprintf("%s_%s", tcp.GetNamespace(), tcp.GetName()), "-", "_")
-		tcp.Spec.DataStoreSchema = dss
+		tcp.Spec.DataStoreSchema = tcp.GetDefaultDatastoreSchema()
 	}
 
 	if len(tcp.Spec.DataStoreUsername) == 0 {
-		// The dash character (-) must be replaced with an underscore, PostgreSQL is complaining about it:
-		// https://github.com/clastix/kamaji/issues/328
-		username := strings.ReplaceAll(fmt.Sprintf("%s_%s", tcp.GetNamespace(), tcp.GetName()), "-", "_")
-		tcp.Spec.DataStoreUsername = username
+		tcp.Spec.DataStoreUsername = tcp.GetDefaultDatastoreUsername()
 	}
 }


### PR DESCRIPTION
With #891 we introduced customisation of Datastore username and schema: this works well for newer TenantControlPlane instances, validation fails when processing already created resources due to non migrated resources.

The fix implements the previous fallback with a default value according to the previous one and implemented in the webhook.

Supersedes #904 due to inactivity and the lack of addressing of requested changes.