### PR TITLE
feat: loose control over k8s patch version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,5 +46,9 @@ jobs:
           sudo apt-get install -y golang-cfssl
           sudo swapoff -a
           sudo modprobe br_netfilter
+      - name: install required Go tools
+        run: make kind ko helm ginkgo
+      - name: cleaning up go mod
+        run: go clean -modcache
       - name: e2e testing
         run: make e2e

--- a/e2e/tcp_validation_version_unsupport_test.go
+++ b/e2e/tcp_validation_version_unsupport_test.go
@@ -23,14 +23,14 @@ var _ = Describe("using an unsupported TenantControlPlane Kubernetes version", f
 	v, err := semver.Make(upgrade.KubeadmVersion[1:])
 	Expect(err).ToNot(HaveOccurred())
 
-	unsupported, err := semver.Make(fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch+1))
+	unsupported, err := semver.Make(fmt.Sprintf("%d.%d.%d", v.Major, v.Minor+1, 0))
 	Expect(err).ToNot(HaveOccurred())
 
 	It("should be blocked on creation", func() {
 		Consistently(func() error {
 			tcp := kamajiv1alpha1.TenantControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "non-linear-update",
+					Name:      "unsupported-version",
 					Namespace: "default",
 				},
 				Spec: kamajiv1alpha1.TenantControlPlaneSpec{


### PR DESCRIPTION
Addressing #990 and #1013: Kamaji sticks now to minor versions, not checking if the patch version of Kubernetes is available or not.