### PR TITLE
feat: use kube-dc external endpoint services for cross-VPC access

### DIFF
--- a/internal/datastore/connection.go
+++ b/internal/datastore/connection.go
@@ -38,6 +38,10 @@ func NewStorageConnection(ctx context.Context, client client.Client, ds kamajiv1
 
 		return NewPostgreSQLConnection(*cc)
 	case kamajiv1alpha1.EtcdDriver:
+		if ds.Spec.TLSConfig != nil {
+			cc.TLSConfig.ServerName = cc.Endpoints[0].Host
+		}
+
 		return NewETCDConnection(*cc)
 	case kamajiv1alpha1.KineNatsDriver:
 		return NewNATSConnection(*cc)

--- a/internal/resources/api_server_certificate.go
+++ b/internal/resources/api_server_certificate.go
@@ -152,6 +152,12 @@ func (r *APIServerCertificate) mutate(ctx context.Context, tenantControlPlane *k
 			addr, _, aErr := tenantControlPlane.AssignedControlPlaneAddress()
 			if aErr == nil {
 				commonNames = append(commonNames, addr)
+				// Add external endpoint DNS name for kube-dc cross-VPC access
+				// Format: <service>-ext.<namespace>.svc.cluster.local
+				extDNS := fmt.Sprintf("%s-ext.%s.svc.cluster.local", 
+					tenantControlPlane.GetName(), 
+					tenantControlPlane.GetNamespace())
+				commonNames = append(commonNames, extDNS)
 			}
 
 			dnsNamesMatches, dnsErr := crypto.CheckCertificateNamesAndIPs(r.resource.Data[kubeadmconstants.APIServerCertName], commonNames)


### PR DESCRIPTION
- Replace hardcoded LoadBalancer IPs with stable DNS names
- Use <service>-ext.namespace.svc.cluster.local pattern
- Leverage kube-dc's automatic external endpoint management
- Enable cross-VPC deployments without IP hardcoding

This change makes Kamaji compatible with kube-dc's external endpoint feature, which automatically creates -ext services for LoadBalancers. When a TenantControlPlane gets a LoadBalancer IP, Kamaji will now connect via the external endpoint service instead of the internal ClusterIP, enabling cross-VPC communication.