### PR TITLE
feat: make replicas optional for Konnectivity Agent mode Deployment

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -289,7 +289,7 @@ var (
 	KonnectivityAgentModeDeployment KonnectivityAgentMode = "Deployment"
 )
 
-//+kubebuilder:validation:XValidation:rule="!(self.mode == 'DaemonSet' && has(self.replicas) && self.replicas != 0) && !(self.mode == 'Deployment' && self.replicas == 0)",message="replicas must be 0 when mode is DaemonSet, and greater than 0 when mode is Deployment"
+//+kubebuilder:validation:XValidation:rule="!(self.mode == 'DaemonSet' && has(self.replicas) && self.replicas != 0) && !(self.mode == 'Deployment' && has(self.replicas) && self.replicas == 0)",message="replicas must be 0 (or unset) when mode is DaemonSet, and greater than 0 (or unset) when mode is Deployment"
 
 type KonnectivityAgentSpec struct {
 	// AgentImage defines the container image for Konnectivity's agent.
@@ -318,7 +318,7 @@ type KonnectivityAgentSpec struct {
 	// Replicas defines the number of replicas when Mode is Deployment.
 	// Must be 0 if Mode is DaemonSet.
 	//+kubebuilder:validation:Optional
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 }
 
 // KonnectivitySpec defines the spec for Konnectivity.

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -178,8 +178,8 @@ versions:
                             type: string
                         type: object
                         x-kubernetes-validations:
-                          - message: replicas must be 0 when mode is DaemonSet, and greater than 0 when mode is Deployment
-                            rule: '!(self.mode == ''DaemonSet'' && has(self.replicas) && self.replicas != 0) && !(self.mode == ''Deployment'' && self.replicas == 0)'
+                          - message: replicas must be 0 (or unset) when mode is DaemonSet, and greater than 0 (or unset) when mode is Deployment
+                            rule: '!(self.mode == ''DaemonSet'' && has(self.replicas) && self.replicas != 0) && !(self.mode == ''Deployment'' && has(self.replicas) && self.replicas == 0)'
                       server:
                         default:
                           image: registry.k8s.io/kas-network-proxy/proxy-server

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -186,8 +186,8 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-validations:
-                            - message: replicas must be 0 when mode is DaemonSet, and greater than 0 when mode is Deployment
-                              rule: '!(self.mode == ''DaemonSet'' && has(self.replicas) && self.replicas != 0) && !(self.mode == ''Deployment'' && self.replicas == 0)'
+                            - message: replicas must be 0 (or unset) when mode is DaemonSet, and greater than 0 (or unset) when mode is Deployment
+                              rule: '!(self.mode == ''DaemonSet'' && has(self.replicas) && self.replicas != 0) && !(self.mode == ''Deployment'' && has(self.replicas) && self.replicas == 0)'
                         server:
                           default:
                             image: registry.k8s.io/kas-network-proxy/proxy-server

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -281,8 +281,10 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 		case kamajiv1alpha1.KonnectivityAgentModeDeployment:
 			//nolint:forcetypeassert
 			r.resource.(*appsv1.Deployment).Spec.Template = *podTemplateSpec
-			//nolint:forcetypeassert
-			r.resource.(*appsv1.Deployment).Spec.Replicas = pointer.To(tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.Replicas)
+			if tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.Replicas != nil {
+				//nolint:forcetypeassert
+				r.resource.(*appsv1.Deployment).Spec.Replicas = tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.Replicas
+			}
 		}
 
 		return nil


### PR DESCRIPTION
Currently, the replicas field is optional in the Konnectivity Agent mode Deployment, but the CRDs validation rules enforce replicas to be set and greater than 0. This creates a conflict with Deployment autoscalers (e.g., cluster-proportional-autoscaler), as the operator continuously reconciles and overwrites the replica count set by the autoscaler, effectively preventing autoscaling from working correctly.