### PR TITLE
fix(soot): add unique controller names to prevent metric conflicts

### DIFF
--- a/controllers/soot/controllers/coredns.go
+++ b/controllers/soot/controllers/coredns.go
@@ -36,6 +36,7 @@ type CoreDNS struct {
 	AdminClient               client.Client
 	GetTenantControlPlaneFunc utils.TenantControlPlaneRetrievalFn
 	TriggerChannel            chan event.GenericEvent
+	ControllerName            string
 }
 
 func (c *CoreDNS) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
@@ -80,6 +81,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile
 
 func (c *CoreDNS) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(c.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == kubeadm.CoreDNSClusterRoleBindingName

--- a/controllers/soot/controllers/konnectivity.go
+++ b/controllers/soot/controllers/konnectivity.go
@@ -37,6 +37,7 @@ type KonnectivityAgent struct {
 	AdminClient               client.Client
 	GetTenantControlPlaneFunc utils.TenantControlPlaneRetrievalFn
 	TriggerChannel            chan event.GenericEvent
+	ControllerName            string
 }
 
 func (k *KonnectivityAgent) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
@@ -87,6 +88,7 @@ func (k *KonnectivityAgent) Reconcile(ctx context.Context, _ reconcile.Request) 
 
 func (k *KonnectivityAgent) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(k.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&appsv1.DaemonSet{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == konnectivity.AgentName && object.GetNamespace() == konnectivity.AgentNamespace

--- a/controllers/soot/controllers/kubeadm_phase.go
+++ b/controllers/soot/controllers/kubeadm_phase.go
@@ -29,6 +29,7 @@ type KubeadmPhase struct {
 	GetTenantControlPlaneFunc utils.TenantControlPlaneRetrievalFn
 	TriggerChannel            chan event.GenericEvent
 	Phase                     resources.KubeadmPhaseResource
+	ControllerName            string
 
 	logger logr.Logger
 }
@@ -75,6 +76,7 @@ func (k *KubeadmPhase) SetupWithManager(mgr manager.Manager) error {
 	k.logger = mgr.GetLogger().WithName(k.Phase.GetName())
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(k.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(k.Phase.GetWatchedObject(), builder.WithPredicates(predicate.NewPredicateFuncs(k.Phase.GetPredicateFunc()))).
 		WatchesRawSource(source.Channel(k.TriggerChannel, &handler.EnqueueRequestForObject{})).

--- a/controllers/soot/controllers/kubeproxy.go
+++ b/controllers/soot/controllers/kubeproxy.go
@@ -36,6 +36,7 @@ type KubeProxy struct {
 	AdminClient               client.Client
 	GetTenantControlPlaneFunc utils.TenantControlPlaneRetrievalFn
 	TriggerChannel            chan event.GenericEvent
+	ControllerName            string
 }
 
 func (k *KubeProxy) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
@@ -82,6 +83,7 @@ func (k *KubeProxy) Reconcile(ctx context.Context, _ reconcile.Request) (reconci
 
 func (k *KubeProxy) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(k.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == kubeadm.KubeProxyClusterRoleBindingName

--- a/controllers/soot/controllers/migrate.go
+++ b/controllers/soot/controllers/migrate.go
@@ -39,6 +39,7 @@ type Migrate struct {
 	WebhookServiceName        string
 	WebhookCABundle           []byte
 	TriggerChannel            chan event.GenericEvent
+	ControllerName            string
 }
 
 func (m *Migrate) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
@@ -189,6 +190,7 @@ func (m *Migrate) SetupWithManager(mgr manager.Manager) error {
 	m.TriggerChannel = make(chan event.GenericEvent)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(m.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: pointer.To(true)}).
 		For(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			vwc := m.object()

--- a/controllers/soot/controllers/write_permissions.go
+++ b/controllers/soot/controllers/write_permissions.go
@@ -39,6 +39,7 @@ type WritePermissions struct {
 	WebhookServiceName        string
 	WebhookCABundle           []byte
 	TriggerChannel            chan event.GenericEvent
+	ControllerName            string
 }
 
 func (r *WritePermissions) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
@@ -190,6 +191,7 @@ func (r *WritePermissions) SetupWithManager(mgr manager.Manager) error {
 	r.TriggerChannel = make(chan event.GenericEvent)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
+		Named(r.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == r.object().GetName()

--- a/e2e/tcp_datastore_overrides_test.go
+++ b/e2e/tcp_datastore_overrides_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with DataStoreOverrides",
 	// Fill TenantControlPlane object
 	tcp := &kamajiv1alpha1.TenantControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tcp-clusterip",
+			Name:      "tcp-datastore-overrides",
 			Namespace: "default",
 		},
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{


### PR DESCRIPTION
Fixes #1025

Previously, all soot managers (one per TenantControlPlane) created controllers with identical names (e.g., 'clusterrolebinding', 'configmap'). These controllers registered metrics with the same labels in the global Prometheus registry, causing worker count conflicts and negative values when TenantControlPlanes were dynamically created/destroyed.

This fix adds unique controller names by:
- Adding a ControllerName field to all soot controller structs
- Using .Named() in SetupWithManager with a unique name per TCP
- Generating names as {namespace}-{name}-{controller-type}

Now each TenantControlPlane's controllers have unique metric labels, preventing conflicts and eliminating negative worker counts.