### PR TITLE
feat: Make error field optional to support other load balancers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,10 @@ crds: controller-gen yq
 	$(CONTROLLER_GEN) crd webhook paths="./..." output:stdout | $(YQ) 'select(documentIndex == 0)' > ./charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
 	$(CONTROLLER_GEN) crd webhook paths="./..." output:stdout | $(YQ) 'select(documentIndex == 1)' > ./charts/kamaji/crds/kamaji.clastix.io_kubeconfiggenerators.yaml
 	$(CONTROLLER_GEN) crd webhook paths="./..." output:stdout | $(YQ) 'select(documentIndex == 2)' > ./charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+	# Fix upstream k8s.io/api bug: PortStatus.Error is marked +kubebuilder:validation:Required
+	# but is actually optional (pointer with omitempty). Remove "error" from required arrays
+	# in PortStatus definitions to match actual Kubernetes API behavior.
+	$(YQ) -i '(.. | select(tag == "!!seq") | select(contains(["error","port","protocol"]))) -= ["error"]' ./charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
 	$(YQ) -i '. *n load("./charts/kamaji/controller-gen/crd-conversion.yaml")' ./charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
 	# kamaji-crds chart
 	cp ./charts/kamaji/controller-gen/crd-conversion.yaml ./charts/kamaji-crds/hack/crd-conversion.yaml

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -7874,7 +7874,6 @@ versions:
                                               The supported values are: "TCP", "UDP", "SCTP"
                                             type: string
                                         required:
-                                          - error
                                           - port
                                           - protocol
                                         type: object
@@ -8598,7 +8597,6 @@ versions:
                                           The supported values are: "TCP", "UDP", "SCTP"
                                         type: string
                                     required:
-                                      - error
                                       - port
                                       - protocol
                                     type: object
@@ -8741,7 +8739,6 @@ versions:
                                           The supported values are: "TCP", "UDP", "SCTP"
                                         type: string
                                     required:
-                                      - error
                                       - port
                                       - protocol
                                     type: object

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -7882,7 +7882,6 @@ spec:
                                                 The supported values are: "TCP", "UDP", "SCTP"
                                               type: string
                                           required:
-                                            - error
                                             - port
                                             - protocol
                                           type: object
@@ -8606,7 +8605,6 @@ spec:
                                             The supported values are: "TCP", "UDP", "SCTP"
                                           type: string
                                       required:
-                                        - error
                                         - port
                                         - protocol
                                       type: object
@@ -8749,7 +8747,6 @@ spec:
                                             The supported values are: "TCP", "UDP", "SCTP"
                                           type: string
                                       required:
-                                        - error
                                         - port
                                         - protocol
                                       type: object


### PR DESCRIPTION
Towards slack thread https://kubernetes.slack.com/archives/C03GLTTMWNN/p1769519363387849

When using kube-vip load balancers, we noticed the kamaji controller logs errors because the CRD enforces a specific `error` field on services, which does not exist on those LBs.

This PRs removes `error` from the required fields in the CRD.