### PR TITLE
fix(gateway): allow explicit parentRefs for kube-apiserver TLSRoute

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -155,7 +155,6 @@ type IngressSpec struct {
 }
 
 // GatewaySpec defines the options for the Gateway which will expose API Server of the Tenant Control Plane.
-// +kubebuilder:validation:XValidation:rule="!has(self.parentRefs) || size(self.parentRefs) == 0 || self.parentRefs.all(ref, !has(ref.port) && !has(ref.sectionName))",message="parentRefs must not specify port or sectionName, these are set automatically by Kamaji"
 type GatewaySpec struct {
 	// AdditionalMetadata to add Labels and Annotations support.
 	AdditionalMetadata AdditionalMetadata `json:"additionalMetadata,omitempty"`

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -6896,9 +6896,6 @@ versions:
                           type: object
                         type: array
                     type: object
-                    x-kubernetes-validations:
-                      - message: parentRefs must not specify port or sectionName, these are set automatically by Kamaji
-                        rule: '!has(self.parentRefs) || size(self.parentRefs) == 0 || self.parentRefs.all(ref, !has(ref.port) && !has(ref.sectionName))'
                   ingress:
                     description: Defining the options for an Optional Ingress which will expose API Server of the Tenant Control Plane
                     properties:

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6904,9 +6904,6 @@ spec:
                             type: object
                           type: array
                       type: object
-                      x-kubernetes-validations:
-                        - message: parentRefs must not specify port or sectionName, these are set automatically by Kamaji
-                          rule: '!has(self.parentRefs) || size(self.parentRefs) == 0 || self.parentRefs.all(ref, !has(ref.port) && !has(ref.sectionName))'
                     ingress:
                       description: Defining the options for an Optional Ingress which will expose API Server of the Tenant Control Plane
                       properties:

--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -212,7 +212,7 @@ func ScaleTenantControlPlane(tcp *kamajiv1alpha1.TenantControlPlane, replicas in
 	Expect(err).To(Succeed())
 }
 
-// CreateGatewayWithListeners creates a Gateway with both kube-apiserver and konnectivity-server listeners.
+// CreateGatewayWithListeners creates a Gateway with control plane and konnectivity-server listeners.
 func CreateGatewayWithListeners(gatewayName, namespace, gatewayClassName, hostname string) {
 	GinkgoHelper()
 	gateway := &gatewayv1.Gateway{
@@ -224,7 +224,7 @@ func CreateGatewayWithListeners(gatewayName, namespace, gatewayClassName, hostna
 			GatewayClassName: gatewayv1.ObjectName(gatewayClassName),
 			Listeners: []gatewayv1.Listener{
 				{
-					Name:     "kube-apiserver",
+					Name:     "cp-listener",
 					Port:     6443,
 					Protocol: gatewayv1.TLSProtocolType,
 					Hostname: pointer.To(gatewayv1.Hostname(hostname)),

--- a/internal/resources/k8s_gateway_resource.go
+++ b/internal/resources/k8s_gateway_resource.go
@@ -150,16 +150,15 @@ func (r *KubernetesGatewayResource) mutate(tcp *kamajiv1alpha1.TenantControlPlan
 			tcp.Spec.ControlPlane.Gateway.AdditionalMetadata.Annotations)
 		r.resource.SetAnnotations(annotations)
 
+		if tcp.Spec.ControlPlane.Gateway.GatewayParentRefs != nil {
+			r.resource.Spec.ParentRefs = tcp.Spec.ControlPlane.Gateway.GatewayParentRefs
+		}
+
 		serviceName := gatewayv1alpha2.ObjectName(tcp.Status.Kubernetes.Service.Name)
 		servicePort := tcp.Status.Kubernetes.Service.Port
 
 		if serviceName == "" || servicePort == 0 {
 			return fmt.Errorf("service not ready, cannot create TLSRoute")
-		}
-
-		if tcp.Spec.ControlPlane.Gateway.GatewayParentRefs != nil {
-			// Copy parentRefs and explicitly set port and sectionName fields
-			r.resource.Spec.ParentRefs = NewParentRefsSpecWithPortAndSection(tcp.Spec.ControlPlane.Gateway.GatewayParentRefs, servicePort, "kube-apiserver")
 		}
 
 		rule := gatewayv1alpha2.TLSRouteRule{

--- a/internal/resources/k8s_gateway_utils.go
+++ b/internal/resources/k8s_gateway_utils.go
@@ -226,16 +226,3 @@ func BuildGatewayAccessPointsStatus(ctx context.Context, c client.Client, route 
 
 	return accessPoints, nil
 }
-
-// NewParentRefsSpecWithPortAndSection creates a copy of parentRefs with port and sectionName set for each reference.
-func NewParentRefsSpecWithPortAndSection(parentRefs []gatewayv1.ParentReference, port int32, sectionName string) []gatewayv1.ParentReference {
-	result := make([]gatewayv1.ParentReference, len(parentRefs))
-	sectionNamePtr := gatewayv1.SectionName(sectionName)
-	for i, parentRef := range parentRefs {
-		result[i] = *parentRef.DeepCopy()
-		result[i].Port = &port
-		result[i].SectionName = &sectionNamePtr
-	}
-
-	return result
-}

--- a/internal/resources/konnectivity/gateway_resource.go
+++ b/internal/resources/konnectivity/gateway_resource.go
@@ -182,7 +182,7 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 		if tcp.Spec.ControlPlane.Gateway.GatewayParentRefs == nil {
 			return fmt.Errorf("control plane gateway parentRefs are not specified")
 		}
-		r.resource.Spec.ParentRefs = resources.NewParentRefsSpecWithPortAndSection(tcp.Spec.ControlPlane.Gateway.GatewayParentRefs, servicePort, "konnectivity-server")
+		r.resource.Spec.ParentRefs = newParentRefsSpecWithPortAndSection(tcp.Spec.ControlPlane.Gateway.GatewayParentRefs, servicePort, "konnectivity-server")
 
 		rule := gatewayv1alpha2.TLSRouteRule{
 			BackendRefs: []gatewayv1alpha2.BackendRef{
@@ -229,4 +229,17 @@ func (r *KubernetesKonnectivityGatewayResource) CreateOrUpdate(ctx context.Conte
 
 func (r *KubernetesKonnectivityGatewayResource) GetName() string {
 	return "konnectivity_gateway_routes"
+}
+
+// newParentRefsSpecWithPortAndSection creates a copy of parentRefs with port and sectionName set for each reference.
+func newParentRefsSpecWithPortAndSection(parentRefs []gatewayv1.ParentReference, port int32, sectionName string) []gatewayv1.ParentReference {
+	result := make([]gatewayv1.ParentReference, len(parentRefs))
+	sectionNamePtr := gatewayv1.SectionName(sectionName)
+	for i, parentRef := range parentRefs {
+		result[i] = *parentRef.DeepCopy()
+		result[i].Port = &port
+		result[i].SectionName = &sectionNamePtr
+	}
+
+	return result
 }


### PR DESCRIPTION
Previously, when Kamaji created TLSRoutes for the kube-apiserver and konnectivity, it automatically set the parentRefs `port` and `sectionName`, overriding any user-provided values via TCP spec. This prevented users from targeting specific Gateway listeners.

This change allows users to explicitly define parentRefs for the kube-apiserver TLSRoute through `TCP.spec.controlPlane.gateway.parentRefs`.

The konnectivity TLSRoute behavior remains unchanged.

Fixes https://github.com/clastix/kamaji/issues/1061