### PR TITLE
fix: strip load balancer ports before updating TenantControlPlane status

### DIFF
--- a/internal/resources/k8s_service_resource.go
+++ b/internal/resources/k8s_service_resource.go
@@ -48,7 +48,7 @@ func (r *KubernetesServiceResource) CleanUp(context.Context, *kamajiv1alpha1.Ten
 }
 
 func (r *KubernetesServiceResource) UpdateTenantControlPlaneStatus(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
-	tenantControlPlane.Status.Kubernetes.Service.ServiceStatus = r.resource.Status
+	tenantControlPlane.Status.Kubernetes.Service.ServiceStatus = StripLoadBalancerPortsFromServiceStatus(r.resource.Status)
 	tenantControlPlane.Status.Kubernetes.Service.Name = r.resource.GetName()
 	tenantControlPlane.Status.Kubernetes.Service.Namespace = r.resource.GetNamespace()
 	tenantControlPlane.Status.Kubernetes.Service.Port = r.resource.Spec.Ports[0].Port

--- a/internal/resources/konnectivity/service_resource.go
+++ b/internal/resources/konnectivity/service_resource.go
@@ -113,7 +113,7 @@ func (r *ServiceResource) UpdateTenantControlPlaneStatus(_ context.Context, tena
 		tenantControlPlane.Status.Addons.Konnectivity.Service.Name = r.resource.GetName()
 		tenantControlPlane.Status.Addons.Konnectivity.Service.Namespace = r.resource.GetNamespace()
 		tenantControlPlane.Status.Addons.Konnectivity.Service.Port = r.resource.Spec.Ports[1].Port
-		tenantControlPlane.Status.Addons.Konnectivity.Service.ServiceStatus = r.resource.Status
+		tenantControlPlane.Status.Addons.Konnectivity.Service.ServiceStatus = resources.StripLoadBalancerPortsFromServiceStatus(r.resource.Status)
 	}
 
 	return nil

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -132,3 +132,18 @@ func getStoredKubeadmConfiguration(ctx context.Context, client client.Client, tm
 
 	return config, nil
 }
+
+func StripLoadBalancerPortsFromServiceStatus(s corev1.ServiceStatus) corev1.ServiceStatus {
+	sanitized := s
+
+	if len(s.LoadBalancer.Ingress) > 0 {
+		sanitized.LoadBalancer.Ingress = make([]corev1.LoadBalancerIngress, len(s.LoadBalancer.Ingress))
+		copy(sanitized.LoadBalancer.Ingress, s.LoadBalancer.Ingress)
+	}
+
+	for i := range sanitized.LoadBalancer.Ingress {
+		sanitized.LoadBalancer.Ingress[i].Ports = nil
+	}
+
+	return sanitized
+}

--- a/internal/resources/resource_test.go
+++ b/internal/resources/resource_test.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestStripLoadBalancerPortsFromServiceStatus(t *testing.T) {
+	ipModeProxy := corev1.LoadBalancerIPModeProxy
+
+	tests := []struct {
+		name   string
+		input  corev1.ServiceStatus
+		assert func(t *testing.T, orig, got corev1.ServiceStatus)
+	}{
+		{
+			name: "ip ingress with ports and ipMode",
+			input: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							IP:     "172.18.0.3",
+							IPMode: &ipModeProxy,
+							Ports: []corev1.PortStatus{
+								{Port: 6443, Protocol: corev1.ProtocolTCP},
+								{Port: 8132, Protocol: corev1.ProtocolTCP},
+							},
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, orig, got corev1.ServiceStatus) {
+				t.Helper()
+				if got.LoadBalancer.Ingress[0].Ports != nil {
+					t.Fatalf("expected ports stripped, got %#v", got.LoadBalancer.Ingress[0].Ports)
+				}
+				if got.LoadBalancer.Ingress[0].IP != "172.18.0.3" {
+					t.Fatalf("IP not preserved")
+				}
+				if got.LoadBalancer.Ingress[0].IPMode == nil || *got.LoadBalancer.Ingress[0].IPMode != ipModeProxy {
+					t.Fatalf("IPMode not preserved")
+				}
+				if orig.LoadBalancer.Ingress[0].Ports == nil {
+					t.Fatalf("original ports mutated")
+				}
+			},
+		},
+		{
+			name: "hostname ingress with ports",
+			input: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{
+							Hostname: "example.local",
+							Ports: []corev1.PortStatus{
+								{Port: 6443, Protocol: corev1.ProtocolTCP},
+							},
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, orig, got corev1.ServiceStatus) {
+				t.Helper()
+				if got.LoadBalancer.Ingress[0].Ports != nil {
+					t.Fatalf("expected ports stripped")
+				}
+				if got.LoadBalancer.Ingress[0].Hostname != "example.local" {
+					t.Fatalf("hostname not preserved")
+				}
+			},
+		},
+		{
+			name:  "no ingress",
+			input: corev1.ServiceStatus{},
+			assert: func(t *testing.T, _, got corev1.ServiceStatus) {
+				t.Helper()
+				if len(got.LoadBalancer.Ingress) != 0 {
+					t.Fatalf("expected no ingress")
+				}
+			},
+		},
+		{
+			name: "ingress with nil ports",
+			input: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.0.0.1"},
+					},
+				},
+			},
+			assert: func(t *testing.T, _, got corev1.ServiceStatus) {
+				t.Helper()
+				if got.LoadBalancer.Ingress[0].Ports != nil {
+					t.Fatalf("expected ports to stay nil")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := tt.input
+			got := StripLoadBalancerPortsFromServiceStatus(tt.input)
+			tt.assert(t, orig, got)
+		})
+	}
+}


### PR DESCRIPTION
Before applying status for TenantControlPlane, strip load balancer ports from status.

Addresses https://github.com/clastix/kamaji/issues/1081