### PR TITLE
fix(kubelet): strip version-gated fields from kubelet-config for K8s < 1.35

### DIFF
--- a/internal/kubeadm/uploadconfig_test.go
+++ b/internal/kubeadm/uploadconfig_test.go
@@ -1,0 +1,127 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeadm
+
+import (
+	"testing"
+
+	kubelettypes "k8s.io/kubelet/config/v1beta1"
+
+	"github.com/clastix/kamaji/internal/utilities"
+)
+
+func TestGetKubeletConfigmapContent_VersionGatedFields(t *testing.T) {
+	t.Parallel()
+
+	kubeletCfg := KubeletConfiguration{
+		TenantControlPlaneDomain:        "cluster.local",
+		TenantControlPlaneDNSServiceIPs: []string{"10.96.0.10"},
+		TenantControlPlaneCgroupDriver:  "systemd",
+	}
+
+	tests := []struct {
+		name                                   string
+		version                                string
+		expectCrashLoopBackOffCleared           bool
+		expectImagePullCredentialsPolicyCleared bool
+	}{
+		{
+			name:                                   "v1.30 should clear version-gated fields",
+			version:                                "1.30.0",
+			expectCrashLoopBackOffCleared:           true,
+			expectImagePullCredentialsPolicyCleared: true,
+		},
+		{
+			name:                                   "v1.34.5 should clear version-gated fields",
+			version:                                "1.34.5",
+			expectCrashLoopBackOffCleared:           true,
+			expectImagePullCredentialsPolicyCleared: true,
+		},
+		{
+			name:                                   "v-prefixed v1.34.1 should clear version-gated fields",
+			version:                                "v1.34.1",
+			expectCrashLoopBackOffCleared:           true,
+			expectImagePullCredentialsPolicyCleared: true,
+		},
+		{
+			name:                                   "v1.35.0 should preserve version-gated fields",
+			version:                                "1.35.0",
+			expectCrashLoopBackOffCleared:           false,
+			expectImagePullCredentialsPolicyCleared: false,
+		},
+		{
+			name:                                   "v1.36.0 should preserve version-gated fields",
+			version:                                "1.36.0",
+			expectCrashLoopBackOffCleared:           false,
+			expectImagePullCredentialsPolicyCleared: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := getKubeletConfigmapContent(kubeletCfg, nil, tt.version)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if content == nil {
+				t.Fatal("expected non-nil content")
+			}
+
+			var kc kubelettypes.KubeletConfiguration
+			if err := utilities.DecodeFromYAML(string(content), &kc); err != nil {
+				t.Fatalf("failed to decode kubelet config: %v", err)
+			}
+
+			if tt.expectCrashLoopBackOffCleared {
+				if kc.CrashLoopBackOff.MaxContainerRestartPeriod != nil {
+					t.Errorf("expected CrashLoopBackOff.MaxContainerRestartPeriod to be nil for version %s, got %v",
+						tt.version, kc.CrashLoopBackOff.MaxContainerRestartPeriod)
+				}
+			} else {
+				if kc.CrashLoopBackOff.MaxContainerRestartPeriod == nil {
+					t.Errorf("expected CrashLoopBackOff.MaxContainerRestartPeriod to be set for version %s",
+						tt.version)
+				}
+			}
+
+			if tt.expectImagePullCredentialsPolicyCleared {
+				if kc.ImagePullCredentialsVerificationPolicy != "" {
+					t.Errorf("expected ImagePullCredentialsVerificationPolicy to be empty for version %s, got %q",
+						tt.version, kc.ImagePullCredentialsVerificationPolicy)
+				}
+			} else {
+				if kc.ImagePullCredentialsVerificationPolicy == "" {
+					t.Errorf("expected ImagePullCredentialsVerificationPolicy to be set for version %s",
+						tt.version)
+				}
+			}
+		})
+	}
+}
+
+func TestGetKubeletConfigmapContent_InvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	kubeletCfg := KubeletConfiguration{
+		TenantControlPlaneDomain:        "cluster.local",
+		TenantControlPlaneDNSServiceIPs: []string{"10.96.0.10"},
+		TenantControlPlaneCgroupDriver:  "systemd",
+	}
+
+	invalidVersions := []string{"", "not-a-version", "abc.def.ghi"}
+
+	for _, version := range invalidVersions {
+		t.Run("version="+version, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := getKubeletConfigmapContent(kubeletCfg, nil, version)
+			if err == nil {
+				t.Errorf("expected error for invalid version %q, got nil", version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes kubelet-config generation for tenant clusters running Kubernetes versions prior to 1.35.

Since Kamaji is now compiled against Kubernetes 1.35 libraries, `SetDefaults_KubeletConfiguration()` populates two fields that are gated behind feature gates introduced in 1.35:

- `crashLoopBackOff.maxContainerRestartPeriod` (`KubeletCrashLoopBackOffMax`)
- `imagePullCredentialsVerificationPolicy` (`KubeletEnsureSecretPulledImages`)

Kubelets < 1.35 reject these fields during configuration validation because the corresponding feature gates do not exist (or are not enabled), causing worker nodes to fail to join the tenant cluster with:

```text
failed to validate kubelet configuration, error: [
  invalid configuration: FeatureGate KubeletCrashLoopBackOffMax not enabled,
    CrashLoopBackOff.MaxContainerRestartPeriod must not be set,
  invalid configuration: imagePullCredentialsVerificationPolicy must not be set
    if KubeletEnsureSecretPulledImages feature gate is not enabled
]
```

This fix passes the target Kubernetes version into `getKubeletConfigmapContent` and clears the incompatible fields when the version is below 1.35. The clearing happens before `configurationJSONPatches` are applied, so users can still override these fields explicitly if needed.

## Context

We hit this issue in [Cozystack](https://github.com/cozystack/cozystack) after upgrading to Kamaji edge-26.2.4. All tenant clusters running K8s v1.30–v1.34 were affected — worker nodes could not join because kubelet rejected the version-gated fields in the kubelet-config ConfigMap.

While `configurationJSONPatches` (#1052) provides a per-TenantControlPlane workaround, it requires every user to manually patch each cluster, and is not exposed through the KamajiControlPlane CRD (CAPI provider). This fix resolves the issue at the operator level, requiring no user intervention.

Fixes #1062
