### PR TITLE
docs: mention metal-stack as supported provider

### DIFF
--- a/docs/content/cluster-api/other-providers.md
+++ b/docs/content/cluster-api/other-providers.md
@@ -9,6 +9,7 @@ Kamaji offers seamless integration with the most popular [Cluster API Infrastruc
 - Hetzner
 - KubeVirt
 - Metal³
+- metal-stack
 - Nutanix
 - OpenStack
 - Tinkerbell


### PR DESCRIPTION
Just to finish up https://github.com/clastix/cluster-api-control-plane-provider-kamaji/pull/323