### PR TITLE
feat(deps): bump gateway-api 1.4.1 to 1.5.1 in Makefile and use TLSRoute v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,21 +277,16 @@ cert-manager:
 	$(HELM) upgrade --install cert-manager jetstack/cert-manager --namespace certmanager-system --create-namespace --set "installCRDs=true"
 
 gateway-api:
+	# Required for the Envoy Dependent Experimentals. Experimentals contains Standard channel CRDs
 	kubectl apply \
 		--server-side \
 		--force-conflicts \
 		--field-manager=helm \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
-	# Required for the TLSRoutes. Experimentals.
-	kubectl apply \
-		--server-side \
-		--force-conflicts \
-		--field-manager=helm \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 	kubectl wait --for=condition=Established crd/gateways.gateway.networking.k8s.io --timeout=60s
 
 envoy-gateway: gateway-api helm ## Install Envoy Gateway for Gateway API tests.
-	$(HELM) upgrade --install eg oci://docker.io/envoyproxy/gateway-helm --version v1.6.1 -n envoy-gateway-system --create-namespace
+	$(HELM) upgrade --install eg oci://docker.io/envoyproxy/gateway-helm --version v1.7.1 -n envoy-gateway-system --create-namespace --skip-crds
 	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 
 load: kind

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	appsv1 "k8s.io/kubernetes/pkg/apis/apps/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -27,7 +26,6 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			// NOTE: This will succeed even if Gateway API is not installed in the cluster.
 			// Only registers the go types.
 			utilruntime.Must(gatewayv1.Install(scheme))
-			utilruntime.Must(gatewayv1alpha2.Install(scheme))
 		},
 	}
 }

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/controllers/finalizers"
@@ -361,7 +360,7 @@ func (r *TenantControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr
 		controllerBuilder = controllerBuilder.
 			Owns(&gatewayv1.HTTPRoute{}).
 			Owns(&gatewayv1.GRPCRoute{}).
-			Owns(&gatewayv1alpha2.TLSRoute{}).
+			Owns(&gatewayv1.TLSRoute{}).
 			Watches(&gatewayv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, object client.Object) []reconcile.Request {
 				return nil
 			}))

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -18,7 +18,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -61,9 +60,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = gatewayv1.Install(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = gatewayv1alpha2.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/e2e/tcp_gateway_konnectivity_ready_test.go
+++ b/e2e/tcp_gateway_konnectivity_ready_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	pointer "k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -100,7 +99,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 
 	It("Should create control plane TLSRoute preserving user-provided parentRef fields", func() {
 		Eventually(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
@@ -129,7 +128,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 
 	It("Should create Konnectivity TLSRoute with correct sectionName", func() {
 		Eventually(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",
 				Namespace: tcp.Namespace,
@@ -152,7 +151,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 
 	It("Should use same hostname for both TLSRoutes", func() {
 		Eventually(func() error {
-			controlPlaneRoute := &gatewayv1alpha2.TLSRoute{}
+			controlPlaneRoute := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
@@ -160,7 +159,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 				return err
 			}
 
-			konnectivityRoute := &gatewayv1alpha2.TLSRoute{}
+			konnectivityRoute := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",
 				Namespace: tcp.Namespace,

--- a/e2e/tcp_gateway_ready_test.go
+++ b/e2e/tcp_gateway_ready_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	pointer "k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -94,7 +93,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 
 	It("Should create control plane TLSRoute preserving user-provided parentRef fields", func() {
 		Eventually(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			// TODO: Check ownership.
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
@@ -125,7 +124,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 	It("Should not create Konnectivity TLSRoute", func() {
 		// Verify Konnectivity route is not created
 		Consistently(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 
 			return k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",

--- a/internal/resources/k8s_gateway_resource.go
+++ b/internal/resources/k8s_gateway_resource.go
@@ -14,14 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
 type KubernetesGatewayResource struct {
-	resource *gatewayv1alpha2.TLSRoute
+	resource *gatewayv1.TLSRoute
 	Client   client.Client
 }
 
@@ -126,7 +125,7 @@ func (r *KubernetesGatewayResource) UpdateTenantControlPlaneStatus(ctx context.C
 }
 
 func (r *KubernetesGatewayResource) Define(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) error {
-	r.resource = &gatewayv1alpha2.TLSRoute{
+	r.resource = &gatewayv1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tcp.GetName(),
 			Namespace: tcp.GetNamespace(),
@@ -154,17 +153,17 @@ func (r *KubernetesGatewayResource) mutate(tcp *kamajiv1alpha1.TenantControlPlan
 			r.resource.Spec.ParentRefs = tcp.Spec.ControlPlane.Gateway.GatewayParentRefs
 		}
 
-		serviceName := gatewayv1alpha2.ObjectName(tcp.Status.Kubernetes.Service.Name)
+		serviceName := gatewayv1.ObjectName(tcp.Status.Kubernetes.Service.Name)
 		servicePort := tcp.Status.Kubernetes.Service.Port
 
 		if serviceName == "" || servicePort == 0 {
 			return fmt.Errorf("service not ready, cannot create TLSRoute")
 		}
 
-		rule := gatewayv1alpha2.TLSRouteRule{
-			BackendRefs: []gatewayv1alpha2.BackendRef{
+		rule := gatewayv1.TLSRouteRule{
+			BackendRefs: []gatewayv1.BackendRef{
 				{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
 						Name: serviceName,
 						Port: &servicePort,
 					},
@@ -173,7 +172,7 @@ func (r *KubernetesGatewayResource) mutate(tcp *kamajiv1alpha1.TenantControlPlan
 		}
 
 		r.resource.Spec.Hostnames = []gatewayv1.Hostname{tcp.Spec.ControlPlane.Gateway.Hostname}
-		r.resource.Spec.Rules = []gatewayv1alpha2.TLSRouteRule{rule}
+		r.resource.Spec.Rules = []gatewayv1.TLSRouteRule{rule}
 
 		return controllerutil.SetControllerReference(tcp, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/k8s_gateway_resource_test.go
+++ b/internal/resources/k8s_gateway_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/resources"
@@ -32,7 +31,7 @@ var _ = BeforeSuite(func() {
 	runtimeScheme = runtime.NewScheme()
 	Expect(scheme.AddToScheme(runtimeScheme)).To(Succeed())
 	Expect(kamajiv1alpha1.AddToScheme(runtimeScheme)).To(Succeed())
-	Expect(gatewayv1alpha2.Install(runtimeScheme)).To(Succeed())
+	Expect(gatewayv1.Install(runtimeScheme)).To(Succeed())
 })
 
 var _ = Describe("KubernetesGatewayResource", func() {
@@ -61,13 +60,13 @@ var _ = Describe("KubernetesGatewayResource", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Gateway: &kamajiv1alpha1.GatewaySpec{
-						Hostname: gatewayv1alpha2.Hostname("test.example.com"),
+						Hostname: gatewayv1.Hostname("test.example.com"),
 						AdditionalMetadata: kamajiv1alpha1.AdditionalMetadata{
 							Labels: map[string]string{
 								"test-label": "test-value",
 							},
 						},
-						GatewayParentRefs: []gatewayv1alpha2.ParentReference{
+						GatewayParentRefs: []gatewayv1.ParentReference{
 							{
 								Name: "test-gateway",
 							},
@@ -104,7 +103,7 @@ var _ = Describe("KubernetesGatewayResource", func() {
 
 		It("should handle multiple parentRefs correctly", func() {
 			namespace := gatewayv1.Namespace("default")
-			tcp.Spec.ControlPlane.Gateway.GatewayParentRefs = []gatewayv1alpha2.ParentReference{
+			tcp.Spec.ControlPlane.Gateway.GatewayParentRefs = []gatewayv1.ParentReference{
 				{
 					Name:      "test-gateway-1",
 					Namespace: &namespace,
@@ -121,14 +120,14 @@ var _ = Describe("KubernetesGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: tcp.Name, Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Spec.ParentRefs).To(HaveLen(2))
-			Expect(route.Spec.ParentRefs[0].Name).To(Equal(gatewayv1alpha2.ObjectName("test-gateway-1")))
+			Expect(route.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName("test-gateway-1")))
 			Expect(route.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
 			Expect(*route.Spec.ParentRefs[0].Namespace).To(Equal(namespace))
-			Expect(route.Spec.ParentRefs[1].Name).To(Equal(gatewayv1alpha2.ObjectName("test-gateway-2")))
+			Expect(route.Spec.ParentRefs[1].Name).To(Equal(gatewayv1.ObjectName("test-gateway-2")))
 			Expect(route.Spec.ParentRefs[1].Namespace).NotTo(BeNil())
 			Expect(*route.Spec.ParentRefs[1].Namespace).To(Equal(namespace))
 		})

--- a/internal/resources/k8s_gateway_utils.go
+++ b/internal/resources/k8s_gateway_utils.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -74,7 +73,7 @@ func FindMatchingListener(listeners []gatewayv1.Listener, ref gatewayv1.ParentRe
 
 // IsGatewayRouteStatusChanged checks if the gateway route status has changed compared to the stored status.
 // Returns true if the status has changed (update needed), false if it's the same.
-func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGatewayStatus, resourceStatus gatewayv1alpha2.RouteStatus) bool {
+func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGatewayStatus, resourceStatus gatewayv1.RouteStatus) bool {
 	if currentStatus == nil {
 		return true
 	}
@@ -139,7 +138,7 @@ func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGateway
 
 // CleanupTLSRoute cleans up a TLSRoute resource if it's managed by the given TenantControlPlane.
 func CleanupTLSRoute(ctx context.Context, c client.Client, routeName, routeNamespace string, tcp metav1.Object) (bool, error) {
-	route := gatewayv1alpha2.TLSRoute{}
+	route := gatewayv1.TLSRoute{}
 	if err := c.Get(ctx, client.ObjectKey{
 		Namespace: routeNamespace,
 		Name:      routeName,
@@ -167,7 +166,7 @@ func CleanupTLSRoute(ctx context.Context, c client.Client, routeName, routeNames
 }
 
 // BuildGatewayAccessPointsStatus builds access points from route statuses.
-func BuildGatewayAccessPointsStatus(ctx context.Context, c client.Client, route *gatewayv1alpha2.TLSRoute, routeStatuses gatewayv1alpha2.RouteStatus) ([]kamajiv1alpha1.GatewayAccessPoint, error) {
+func BuildGatewayAccessPointsStatus(ctx context.Context, c client.Client, route *gatewayv1.TLSRoute, routeStatuses gatewayv1.RouteStatus) ([]kamajiv1alpha1.GatewayAccessPoint, error) {
 	accessPoints := []kamajiv1alpha1.GatewayAccessPoint{}
 	routeNamespace := gatewayv1.Namespace(route.Namespace)
 

--- a/internal/resources/konnectivity/gateway_resource.go
+++ b/internal/resources/konnectivity/gateway_resource.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/resources"
@@ -22,7 +21,7 @@ import (
 )
 
 type KubernetesKonnectivityGatewayResource struct {
-	resource *gatewayv1alpha2.TLSRoute
+	resource *gatewayv1.TLSRoute
 	Client   client.Client
 }
 
@@ -136,7 +135,7 @@ func (r *KubernetesKonnectivityGatewayResource) UpdateTenantControlPlaneStatus(c
 }
 
 func (r *KubernetesKonnectivityGatewayResource) Define(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) error {
-	r.resource = &gatewayv1alpha2.TLSRoute{
+	r.resource = &gatewayv1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-konnectivity", tcp.GetName()),
 			Namespace: tcp.GetNamespace(),
@@ -171,7 +170,7 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 			return fmt.Errorf("control plane gateway hostname is not set")
 		}
 
-		serviceName := gatewayv1alpha2.ObjectName(tcp.Status.Addons.Konnectivity.Service.Name)
+		serviceName := gatewayv1.ObjectName(tcp.Status.Addons.Konnectivity.Service.Name)
 		servicePort := tcp.Status.Addons.Konnectivity.Service.Port
 
 		if serviceName == "" || servicePort == 0 {
@@ -184,10 +183,10 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 		}
 		r.resource.Spec.ParentRefs = newParentRefsSpecWithPortAndSection(tcp.Spec.ControlPlane.Gateway.GatewayParentRefs, servicePort, "konnectivity-server")
 
-		rule := gatewayv1alpha2.TLSRouteRule{
-			BackendRefs: []gatewayv1alpha2.BackendRef{
+		rule := gatewayv1.TLSRouteRule{
+			BackendRefs: []gatewayv1.BackendRef{
 				{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
 						Name: serviceName,
 						Port: &servicePort,
 					},
@@ -196,7 +195,7 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 		}
 
 		r.resource.Spec.Hostnames = []gatewayv1.Hostname{tcp.Spec.ControlPlane.Gateway.Hostname}
-		r.resource.Spec.Rules = []gatewayv1alpha2.TLSRouteRule{rule}
+		r.resource.Spec.Rules = []gatewayv1.TLSRouteRule{rule}
 
 		return controllerutil.SetControllerReference(tcp, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/konnectivity/gateway_resource_test.go
+++ b/internal/resources/konnectivity/gateway_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/resources/konnectivity"
@@ -33,7 +32,6 @@ var _ = BeforeSuite(func() {
 	runtimeScheme = runtime.NewScheme()
 	Expect(scheme.AddToScheme(runtimeScheme)).To(Succeed())
 	Expect(kamajiv1alpha1.AddToScheme(runtimeScheme)).To(Succeed())
-	Expect(gatewayv1alpha2.Install(runtimeScheme)).To(Succeed())
 })
 
 var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
@@ -63,8 +61,8 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Gateway: &kamajiv1alpha1.GatewaySpec{
-						Hostname: gatewayv1alpha2.Hostname("test.example.com"),
-						GatewayParentRefs: []gatewayv1alpha2.ParentReference{
+						Hostname: gatewayv1.Hostname("test.example.com"),
+						GatewayParentRefs: []gatewayv1.ParentReference{
 							{
 								Name:      "test-gateway",
 								Namespace: &namespace,
@@ -123,7 +121,7 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: "test-tcp-konnectivity", Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Name).To(Equal("test-tcp-konnectivity"))
@@ -136,7 +134,7 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: "test-tcp-konnectivity", Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Spec.ParentRefs).To(HaveLen(1))
@@ -153,7 +151,7 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: "test-tcp-konnectivity", Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Spec.Hostnames).To(HaveLen(1))

--- a/internal/utilities/gateway_discovery.go
+++ b/internal/utilities/gateway_discovery.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 // AreGatewayResourcesAvailable checks if Gateway API is available in the cluster through a discovery Client
@@ -51,7 +50,7 @@ func GatewayAPIResourcesAvailable(ctx context.Context, discoveryClient discovery
 
 // TLSRouteAPIAvailable checks specifically for TLSRoute resource availability.
 func TLSRouteAPIAvailable(ctx context.Context, discoveryClient discovery.DiscoveryInterface) (bool, error) {
-	gv := gatewayv1alpha2.SchemeGroupVersion
+	gv := gatewayv1.SchemeGroupVersion
 
 	resourceList, err := discoveryClient.ServerResourcesForGroupVersion(gv.String())
 	if err != nil {
@@ -85,8 +84,8 @@ func IsTLSRouteAvailable(ctx context.Context, c client.Client, discoveryClient d
 func IsTLSRouteAvailableViaClient(ctx context.Context, c client.Client) bool {
 	// Try to check if TLSRoute GVK can be resolved
 	gvk := schema.GroupVersionKind{
-		Group:   gatewayv1alpha2.GroupName,
-		Version: "v1alpha2",
+		Group:   gatewayv1.GroupName,
+		Version: "v1",
 		Kind:    "TLSRoute",
 	}
 

--- a/internal/webhook/handlers/tcp_gateway_validate_test.go
+++ b/internal/webhook/handlers/tcp_gateway_validate_test.go
@@ -109,7 +109,7 @@ var _ = Describe("TCP Gateway Validation Webhook", func() {
 						{Name: "gateway.networking.k8s.io"},
 					},
 				}
-				mockDiscovery.serverResources["gateway.networking.k8s.io/v1alpha2"] = &metav1.APIResourceList{
+				mockDiscovery.serverResources["gateway.networking.k8s.io/v1"] = &metav1.APIResourceList{
 					APIResources: []metav1.APIResource{
 						{Kind: "TLSRoute"},
 					},
@@ -156,7 +156,7 @@ var _ = Describe("TCP Gateway Validation Webhook", func() {
 						{Name: "gateway.networking.k8s.io"},
 					},
 				}
-				mockDiscovery.serverResources["gateway.networking.k8s.io/v1alpha2"] = &metav1.APIResourceList{
+				mockDiscovery.serverResources["gateway.networking.k8s.io/v1"] = &metav1.APIResourceList{
 					APIResources: []metav1.APIResource{
 						{Kind: "Gateway"},
 						{Kind: "HTTPRoute"},
@@ -218,36 +218,6 @@ var _ = Describe("TCP Gateway Validation Webhook", func() {
 			admissionResponse := handler.OnDelete(tcp)
 			_, err := admissionResponse(ctx, admission.Request{})
 			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("with different Gateway API versions", func() {
-		BeforeEach(func() {
-			tcp.Spec.ControlPlane.Gateway = &kamajiv1alpha1.GatewaySpec{
-				Hostname: gatewayv1.Hostname("api.example.com"),
-			}
-			mockDiscovery.serverGroups = &metav1.APIGroupList{
-				Groups: []metav1.APIGroup{
-					{Name: "gateway.networking.k8s.io"},
-				},
-			}
-		})
-
-		It("should work with v1alpha2 TLSRoute", func() {
-			mockDiscovery.serverResources["gateway.networking.k8s.io/v1alpha2"] = &metav1.APIResourceList{
-				APIResources: []metav1.APIResource{
-					{Kind: "TLSRoute"},
-				},
-			}
-
-			_, err := handler.OnCreate(tcp)(ctx, admission.Request{})
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should handle missing version gracefully", func() {
-			_, err := handler.OnCreate(tcp)(ctx, admission.Request{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("TLSRoute resource is not available"))
 		})
 	})
 })


### PR DESCRIPTION
## Description

- fixes: https://github.com/clastix/kamaji/issues/1117

- However this likely should wait until Envoy releases v1.8

