### PR TITLE
feat(deps): bump gateway api to 1.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,17 +281,11 @@ gateway-api:
 		--server-side \
 		--force-conflicts \
 		--field-manager=helm \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
-	# Required for the TLSRoutes. Experimentals.
-	kubectl apply \
-		--server-side \
-		--force-conflicts \
-		--field-manager=helm \
-		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
+		-f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 	kubectl wait --for=condition=Established crd/gateways.gateway.networking.k8s.io --timeout=60s
 
-envoy-gateway: gateway-api helm ## Install Envoy Gateway for Gateway API tests.
-	$(HELM) upgrade --install eg oci://docker.io/envoyproxy/gateway-helm --version v1.6.1 -n envoy-gateway-system --create-namespace
+envoy-gateway: gateway-api helm  ## Install Envoy Gateway for Gateway API tests, with skip-crds to avoid conflicts with the CRDs installed by Gateway API.
+	$(HELM) upgrade --install eg oci://docker.io/envoyproxy/gateway-helm --version v1.8.0 -n envoy-gateway-system --create-namespace --skip-crds
 	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 
 load: kind

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -7864,7 +7864,7 @@ versions:
 
                                     * The Route refers to a nonexistent parent.
                                     * The Route is of a type that the controller does not support.
-                                    * The Route is in a namespace the controller does not have access to.
+                                    * The Route is in a namespace to which the controller does not have access.
 
                                     <gateway:util:excludeFromCRD>
 
@@ -8690,7 +8690,7 @@ versions:
 
                                 * The Route refers to a nonexistent parent.
                                 * The Route is of a type that the controller does not support.
-                                * The Route is in a namespace the controller does not have access to.
+                                * The Route is in a namespace to which the controller does not have access.
 
                                 <gateway:util:excludeFromCRD>
 

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -7872,7 +7872,7 @@ spec:
 
                                       * The Route refers to a nonexistent parent.
                                       * The Route is of a type that the controller does not support.
-                                      * The Route is in a namespace the controller does not have access to.
+                                      * The Route is in a namespace to which the controller does not have access.
 
                                       <gateway:util:excludeFromCRD>
 
@@ -8698,7 +8698,7 @@ spec:
 
                                   * The Route refers to a nonexistent parent.
                                   * The Route is of a type that the controller does not support.
-                                  * The Route is in a namespace the controller does not have access to.
+                                  * The Route is in a namespace to which the controller does not have access.
 
                                   <gateway:util:excludeFromCRD>
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	appsv1 "k8s.io/kubernetes/pkg/apis/apps/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -27,7 +26,6 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			// NOTE: This will succeed even if Gateway API is not installed in the cluster.
 			// Only registers the go types.
 			utilruntime.Must(gatewayv1.Install(scheme))
-			utilruntime.Must(gatewayv1alpha2.Install(scheme))
 		},
 	}
 }

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/controllers/finalizers"
@@ -388,7 +387,7 @@ func (r *TenantControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr
 		controllerBuilder = controllerBuilder.
 			Owns(&gatewayv1.HTTPRoute{}).
 			Owns(&gatewayv1.GRPCRoute{}).
-			Owns(&gatewayv1alpha2.TLSRoute{}).
+			Owns(&gatewayv1.TLSRoute{}).
 			Watches(&gatewayv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, object client.Object) []reconcile.Request {
 				return nil
 			}))

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -46559,7 +46559,7 @@ due to lack of controller visibility, that includes when:
 
 * The Route refers to a nonexistent parent.
 * The Route is of a type that the controller does not support.
-* The Route is in a namespace the controller does not have access to.
+* The Route is in a namespace to which the controller does not have access.
 
 <gateway:util:excludeFromCRD>
 
@@ -48375,7 +48375,7 @@ due to lack of controller visibility, that includes when:
 
 * The Route refers to a nonexistent parent.
 * The Route is of a type that the controller does not support.
-* The Route is in a namespace the controller does not have access to.
+* The Route is in a namespace to which the controller does not have access.
 
 <gateway:util:excludeFromCRD>
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -18,7 +18,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -61,9 +60,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = gatewayv1.Install(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = gatewayv1alpha2.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/e2e/tcp_gateway_konnectivity_ready_test.go
+++ b/e2e/tcp_gateway_konnectivity_ready_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	pointer "k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -100,7 +99,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 
 	It("Should create control plane TLSRoute preserving user-provided parentRef fields", func() {
 		Eventually(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
@@ -129,7 +128,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 
 	It("Should create Konnectivity TLSRoute with correct sectionName", func() {
 		Eventually(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",
 				Namespace: tcp.Namespace,
@@ -152,7 +151,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 
 	It("Should use same hostname for both TLSRoutes", func() {
 		Eventually(func() error {
-			controlPlaneRoute := &gatewayv1alpha2.TLSRoute{}
+			controlPlaneRoute := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
@@ -160,7 +159,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 				return err
 			}
 
-			konnectivityRoute := &gatewayv1alpha2.TLSRoute{}
+			konnectivityRoute := &gatewayv1.TLSRoute{}
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",
 				Namespace: tcp.Namespace,

--- a/e2e/tcp_gateway_ready_test.go
+++ b/e2e/tcp_gateway_ready_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	pointer "k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -94,7 +93,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 
 	It("Should create control plane TLSRoute preserving user-provided parentRef fields", func() {
 		Eventually(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			// TODO: Check ownership.
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
@@ -125,7 +124,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 	It("Should not create Konnectivity TLSRoute", func() {
 		// Verify Konnectivity route is not created
 		Consistently(func() error {
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 
 			return k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	k8s.io/kubernetes v1.36.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/gateway-api v1.4.1
+	sigs.k8s.io/gateway-api v1.5.1
 )
 
 require (
@@ -106,7 +106,7 @@ require (
 	github.com/lithammer/dedent v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
-	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
+github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
@@ -557,6 +559,8 @@ sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/gateway-api v1.4.1 h1:NPxFutNkKNa8UfLd2CMlEuhIPMQgDQ6DXNKG9sHbJU8=
 sigs.k8s.io/gateway-api v1.4.1/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
+sigs.k8s.io/gateway-api v1.5.1 h1:RqVRIlkhLhUO8wOHKTLnTJA6o/1un4po4/6M1nRzdd0=
+sigs.k8s.io/gateway-api v1.5.1/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=

--- a/internal/resources/k8s_gateway_resource.go
+++ b/internal/resources/k8s_gateway_resource.go
@@ -14,14 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
 type KubernetesGatewayResource struct {
-	resource *gatewayv1alpha2.TLSRoute
+	resource *gatewayv1.TLSRoute
 	Client   client.Client
 }
 
@@ -126,7 +125,7 @@ func (r *KubernetesGatewayResource) UpdateTenantControlPlaneStatus(ctx context.C
 }
 
 func (r *KubernetesGatewayResource) Define(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) error {
-	r.resource = &gatewayv1alpha2.TLSRoute{
+	r.resource = &gatewayv1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tcp.GetName(),
 			Namespace: tcp.GetNamespace(),
@@ -154,17 +153,17 @@ func (r *KubernetesGatewayResource) mutate(tcp *kamajiv1alpha1.TenantControlPlan
 			r.resource.Spec.ParentRefs = tcp.Spec.ControlPlane.Gateway.GatewayParentRefs
 		}
 
-		serviceName := gatewayv1alpha2.ObjectName(tcp.Status.Kubernetes.Service.Name)
+		serviceName := gatewayv1.ObjectName(tcp.Status.Kubernetes.Service.Name)
 		servicePort := tcp.Status.Kubernetes.Service.Port
 
 		if serviceName == "" || servicePort == 0 {
 			return fmt.Errorf("service not ready, cannot create TLSRoute")
 		}
 
-		rule := gatewayv1alpha2.TLSRouteRule{
-			BackendRefs: []gatewayv1alpha2.BackendRef{
+		rule := gatewayv1.TLSRouteRule{
+			BackendRefs: []gatewayv1.BackendRef{
 				{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
 						Name: serviceName,
 						Port: &servicePort,
 					},
@@ -173,7 +172,7 @@ func (r *KubernetesGatewayResource) mutate(tcp *kamajiv1alpha1.TenantControlPlan
 		}
 
 		r.resource.Spec.Hostnames = []gatewayv1.Hostname{tcp.Spec.ControlPlane.Gateway.Hostname}
-		r.resource.Spec.Rules = []gatewayv1alpha2.TLSRouteRule{rule}
+		r.resource.Spec.Rules = []gatewayv1.TLSRouteRule{rule}
 
 		return controllerutil.SetControllerReference(tcp, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/k8s_gateway_resource_test.go
+++ b/internal/resources/k8s_gateway_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/resources"
@@ -33,7 +32,6 @@ var _ = BeforeSuite(func() {
 	Expect(scheme.AddToScheme(runtimeScheme)).To(Succeed())
 	Expect(kamajiv1alpha1.AddToScheme(runtimeScheme)).To(Succeed())
 	Expect(gatewayv1.Install(runtimeScheme)).To(Succeed())
-	Expect(gatewayv1alpha2.Install(runtimeScheme)).To(Succeed())
 })
 
 var _ = Describe("KubernetesGatewayResource", func() {
@@ -62,13 +60,13 @@ var _ = Describe("KubernetesGatewayResource", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Gateway: &kamajiv1alpha1.GatewaySpec{
-						Hostname: gatewayv1alpha2.Hostname("test.example.com"),
+						Hostname: gatewayv1.Hostname("test.example.com"),
 						AdditionalMetadata: kamajiv1alpha1.AdditionalMetadata{
 							Labels: map[string]string{
 								"test-label": "test-value",
 							},
 						},
-						GatewayParentRefs: []gatewayv1alpha2.ParentReference{
+						GatewayParentRefs: []gatewayv1.ParentReference{
 							{
 								Name: "test-gateway",
 							},
@@ -105,7 +103,7 @@ var _ = Describe("KubernetesGatewayResource", func() {
 
 		It("should handle multiple parentRefs correctly", func() {
 			namespace := gatewayv1.Namespace("default")
-			tcp.Spec.ControlPlane.Gateway.GatewayParentRefs = []gatewayv1alpha2.ParentReference{
+			tcp.Spec.ControlPlane.Gateway.GatewayParentRefs = []gatewayv1.ParentReference{
 				{
 					Name:      "test-gateway-1",
 					Namespace: &namespace,
@@ -122,14 +120,14 @@ var _ = Describe("KubernetesGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: tcp.Name, Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Spec.ParentRefs).To(HaveLen(2))
-			Expect(route.Spec.ParentRefs[0].Name).To(Equal(gatewayv1alpha2.ObjectName("test-gateway-1")))
+			Expect(route.Spec.ParentRefs[0].Name).To(Equal(gatewayv1.ObjectName("test-gateway-1")))
 			Expect(route.Spec.ParentRefs[0].Namespace).NotTo(BeNil())
 			Expect(*route.Spec.ParentRefs[0].Namespace).To(Equal(namespace))
-			Expect(route.Spec.ParentRefs[1].Name).To(Equal(gatewayv1alpha2.ObjectName("test-gateway-2")))
+			Expect(route.Spec.ParentRefs[1].Name).To(Equal(gatewayv1.ObjectName("test-gateway-2")))
 			Expect(route.Spec.ParentRefs[1].Namespace).NotTo(BeNil())
 			Expect(*route.Spec.ParentRefs[1].Namespace).To(Equal(namespace))
 		})
@@ -274,14 +272,14 @@ var _ = Describe("KubernetesGatewayResource", func() {
 			gwNamespace = "gateway-system"
 			gwName      = "test-gateway"
 			gateway     *gatewayv1.Gateway
-			route       *gatewayv1alpha2.TLSRoute
+			route       *gatewayv1.TLSRoute
 			fakeClient  client.Client
 		)
 
 		// Builds a RouteStatus with a single Accepted parent using the
 		// supplied ParentReference.
-		buildRouteStatus := func(ref gatewayv1.ParentReference) gatewayv1alpha2.RouteStatus {
-			return gatewayv1alpha2.RouteStatus{
+		buildRouteStatus := func(ref gatewayv1.ParentReference) gatewayv1.RouteStatus {
+			return gatewayv1.RouteStatus{
 				Parents: []gatewayv1.RouteParentStatus{{
 					ParentRef: ref,
 					Conditions: []metav1.Condition{{
@@ -316,9 +314,9 @@ var _ = Describe("KubernetesGatewayResource", func() {
 				},
 			}
 
-			route = &gatewayv1alpha2.TLSRoute{
+			route = &gatewayv1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{Name: "tcp", Namespace: "tenant-ns"},
-				Spec: gatewayv1alpha2.TLSRouteSpec{
+				Spec: gatewayv1.TLSRouteSpec{
 					Hostnames: []gatewayv1.Hostname{"tcp.example.com"},
 				},
 			}

--- a/internal/resources/k8s_gateway_utils.go
+++ b/internal/resources/k8s_gateway_utils.go
@@ -16,7 +16,6 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
@@ -80,7 +79,7 @@ func FindMatchingListener(listeners []gatewayv1.Listener, ref gatewayv1.ParentRe
 
 // IsGatewayRouteStatusChanged checks if the gateway route status has changed compared to the stored status.
 // Returns true if the status has changed (update needed), false if it's the same.
-func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGatewayStatus, resourceStatus gatewayv1alpha2.RouteStatus) bool {
+func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGatewayStatus, resourceStatus gatewayv1.RouteStatus) bool {
 	if currentStatus == nil {
 		return true
 	}
@@ -145,7 +144,7 @@ func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGateway
 
 // CleanupTLSRoute cleans up a TLSRoute resource if it's managed by the given TenantControlPlane.
 func CleanupTLSRoute(ctx context.Context, c client.Client, routeName, routeNamespace string, tcp metav1.Object) (bool, error) {
-	route := gatewayv1alpha2.TLSRoute{}
+	route := gatewayv1.TLSRoute{}
 	if err := c.Get(ctx, client.ObjectKey{
 		Namespace: routeNamespace,
 		Name:      routeName,
@@ -187,7 +186,7 @@ func CleanupTLSRoute(ctx context.Context, c client.Client, routeName, routeNames
 // Unresolvable or unprogrammed Gateways are skipped rather than returned as
 // errors, so that a single mis-attached parentRef does not block the whole
 // status update for the Route.
-func BuildGatewayAccessPointsStatus(ctx context.Context, c client.Client, route *gatewayv1alpha2.TLSRoute, routeStatuses gatewayv1alpha2.RouteStatus) ([]kamajiv1alpha1.GatewayAccessPoint, error) {
+func BuildGatewayAccessPointsStatus(ctx context.Context, c client.Client, route *gatewayv1.TLSRoute, routeStatuses gatewayv1.RouteStatus) ([]kamajiv1alpha1.GatewayAccessPoint, error) {
 	accessPoints := []kamajiv1alpha1.GatewayAccessPoint{}
 	routeNamespace := gatewayv1.Namespace(route.Namespace)
 

--- a/internal/resources/konnectivity/gateway_resource.go
+++ b/internal/resources/konnectivity/gateway_resource.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/resources"
@@ -22,7 +21,7 @@ import (
 )
 
 type KubernetesKonnectivityGatewayResource struct {
-	resource *gatewayv1alpha2.TLSRoute
+	resource *gatewayv1.TLSRoute
 	Client   client.Client
 }
 
@@ -136,7 +135,7 @@ func (r *KubernetesKonnectivityGatewayResource) UpdateTenantControlPlaneStatus(c
 }
 
 func (r *KubernetesKonnectivityGatewayResource) Define(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) error {
-	r.resource = &gatewayv1alpha2.TLSRoute{
+	r.resource = &gatewayv1.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-konnectivity", tcp.GetName()),
 			Namespace: tcp.GetNamespace(),
@@ -171,7 +170,7 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 			return fmt.Errorf("control plane gateway hostname is not set")
 		}
 
-		serviceName := gatewayv1alpha2.ObjectName(tcp.Status.Addons.Konnectivity.Service.Name)
+		serviceName := gatewayv1.ObjectName(tcp.Status.Addons.Konnectivity.Service.Name)
 		servicePort := tcp.Status.Addons.Konnectivity.Service.Port
 
 		if serviceName == "" || servicePort == 0 {
@@ -184,10 +183,10 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 		}
 		r.resource.Spec.ParentRefs = newParentRefsSpecWithPortAndSection(tcp.Spec.ControlPlane.Gateway.GatewayParentRefs, servicePort, "konnectivity-server")
 
-		rule := gatewayv1alpha2.TLSRouteRule{
-			BackendRefs: []gatewayv1alpha2.BackendRef{
+		rule := gatewayv1.TLSRouteRule{
+			BackendRefs: []gatewayv1.BackendRef{
 				{
-					BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
 						Name: serviceName,
 						Port: &servicePort,
 					},
@@ -196,7 +195,7 @@ func (r *KubernetesKonnectivityGatewayResource) mutate(tcp *kamajiv1alpha1.Tenan
 		}
 
 		r.resource.Spec.Hostnames = []gatewayv1.Hostname{tcp.Spec.ControlPlane.Gateway.Hostname}
-		r.resource.Spec.Rules = []gatewayv1alpha2.TLSRouteRule{rule}
+		r.resource.Spec.Rules = []gatewayv1.TLSRouteRule{rule}
 
 		return controllerutil.SetControllerReference(tcp, r.resource, r.Client.Scheme())
 	}

--- a/internal/resources/konnectivity/gateway_resource_test.go
+++ b/internal/resources/konnectivity/gateway_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/resources/konnectivity"
@@ -33,7 +32,7 @@ var _ = BeforeSuite(func() {
 	runtimeScheme = runtime.NewScheme()
 	Expect(scheme.AddToScheme(runtimeScheme)).To(Succeed())
 	Expect(kamajiv1alpha1.AddToScheme(runtimeScheme)).To(Succeed())
-	Expect(gatewayv1alpha2.Install(runtimeScheme)).To(Succeed())
+	Expect(gatewayv1.Install(runtimeScheme)).To(Succeed())
 })
 
 var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
@@ -63,8 +62,8 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Gateway: &kamajiv1alpha1.GatewaySpec{
-						Hostname: gatewayv1alpha2.Hostname("test.example.com"),
-						GatewayParentRefs: []gatewayv1alpha2.ParentReference{
+						Hostname: gatewayv1.Hostname("test.example.com"),
+						GatewayParentRefs: []gatewayv1.ParentReference{
 							{
 								Name:      "test-gateway",
 								Namespace: &namespace,
@@ -123,7 +122,7 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: "test-tcp-konnectivity", Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Name).To(Equal("test-tcp-konnectivity"))
@@ -136,7 +135,7 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: "test-tcp-konnectivity", Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Spec.ParentRefs).To(HaveLen(1))
@@ -153,7 +152,7 @@ var _ = Describe("KubernetesKonnectivityGatewayResource", func() {
 			_, err = resource.CreateOrUpdate(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
 
-			route := &gatewayv1alpha2.TLSRoute{}
+			route := &gatewayv1.TLSRoute{}
 			err = resource.Client.Get(ctx, client.ObjectKey{Name: "test-tcp-konnectivity", Namespace: tcp.Namespace}, route)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(route.Spec.Hostnames).To(HaveLen(1))

--- a/internal/utilities/gateway_discovery.go
+++ b/internal/utilities/gateway_discovery.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 // AreGatewayResourcesAvailable checks if Gateway API is available in the cluster through a discovery Client
@@ -51,7 +50,7 @@ func GatewayAPIResourcesAvailable(ctx context.Context, discoveryClient discovery
 
 // TLSRouteAPIAvailable checks specifically for TLSRoute resource availability.
 func TLSRouteAPIAvailable(ctx context.Context, discoveryClient discovery.DiscoveryInterface) (bool, error) {
-	gv := gatewayv1alpha2.SchemeGroupVersion
+	gv := gatewayv1.GroupVersion
 
 	resourceList, err := discoveryClient.ServerResourcesForGroupVersion(gv.String())
 	if err != nil {
@@ -85,8 +84,8 @@ func IsTLSRouteAvailable(ctx context.Context, c client.Client, discoveryClient d
 func IsTLSRouteAvailableViaClient(ctx context.Context, c client.Client) bool {
 	// Try to check if TLSRoute GVK can be resolved
 	gvk := schema.GroupVersionKind{
-		Group:   gatewayv1alpha2.GroupName,
-		Version: "v1alpha2",
+		Group:   gatewayv1.GroupName,
+		Version: gatewayv1.GroupVersion.Version,
 		Kind:    "TLSRoute",
 	}
 

--- a/internal/webhook/handlers/tcp_gateway_validate_test.go
+++ b/internal/webhook/handlers/tcp_gateway_validate_test.go
@@ -109,7 +109,7 @@ var _ = Describe("TCP Gateway Validation Webhook", func() {
 						{Name: "gateway.networking.k8s.io"},
 					},
 				}
-				mockDiscovery.serverResources["gateway.networking.k8s.io/v1alpha2"] = &metav1.APIResourceList{
+				mockDiscovery.serverResources["gateway.networking.k8s.io/v1"] = &metav1.APIResourceList{
 					APIResources: []metav1.APIResource{
 						{Kind: "TLSRoute"},
 					},
@@ -156,7 +156,7 @@ var _ = Describe("TCP Gateway Validation Webhook", func() {
 						{Name: "gateway.networking.k8s.io"},
 					},
 				}
-				mockDiscovery.serverResources["gateway.networking.k8s.io/v1alpha2"] = &metav1.APIResourceList{
+				mockDiscovery.serverResources["gateway.networking.k8s.io/v1"] = &metav1.APIResourceList{
 					APIResources: []metav1.APIResource{
 						{Kind: "Gateway"},
 						{Kind: "HTTPRoute"},
@@ -218,36 +218,6 @@ var _ = Describe("TCP Gateway Validation Webhook", func() {
 			admissionResponse := handler.OnDelete(tcp)
 			_, err := admissionResponse(ctx, admission.Request{})
 			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("with different Gateway API versions", func() {
-		BeforeEach(func() {
-			tcp.Spec.ControlPlane.Gateway = &kamajiv1alpha1.GatewaySpec{
-				Hostname: gatewayv1.Hostname("api.example.com"),
-			}
-			mockDiscovery.serverGroups = &metav1.APIGroupList{
-				Groups: []metav1.APIGroup{
-					{Name: "gateway.networking.k8s.io"},
-				},
-			}
-		})
-
-		It("should work with v1alpha2 TLSRoute", func() {
-			mockDiscovery.serverResources["gateway.networking.k8s.io/v1alpha2"] = &metav1.APIResourceList{
-				APIResources: []metav1.APIResource{
-					{Kind: "TLSRoute"},
-				},
-			}
-
-			_, err := handler.OnCreate(tcp)(ctx, admission.Request{})
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should handle missing version gracefully", func() {
-			_, err := handler.OnCreate(tcp)(ctx, admission.Request{})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("TLSRoute resource is not available"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Updates Gateway API dependency to `sigs.k8s.io/gateway-api v1.5.1`.
- Switches Kamaji TLSRoute usage from `v1alpha2` to `gateway.networking.k8s.io/v1`.
- Updates controller watches, resource handling, discovery checks, tests, and apidocs.
- Updates e2e Gateway API setup to use Gateway API `v1.5.1`.
- Updates Envoy Gateway e2e install to `v1.8.0`.

## Context

- Gateway API `v1.5.1` promotes `TLSRoute` to `v1`.
- While testing against Kubernetes `1.36`, Envoy Gateway `1.7` hit a compatibility issue fixed in Envoy Gateway `1.8` related to using multiple passthrough TLS listener rules (necessary for our organizations konnectivity/k8s api TLSRoutes) 
   - ref: https://github.com/envoyproxy/gateway/pull/8521
- Envoy Gateway `1.8` expects newer Gateway API CRDs, so the e2e stack is updated together.

## Testing

- `make test`
- `make golint`
- `bin/ginkgo -v --focus='Gateway API' ./e2e`

Focused Gateway API e2e result:

```text
Ran 7 of 29 Specs in 189.649 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 22 Skipped