### PR TITLE
fix(kamaji): use system:masters for admin.conf to avoid CRB race

### DIFF
--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -212,7 +212,18 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 				r.resource.Data = map[string][]byte{}
 			}
 
-			kubeconfig, kcErr := kubeadm.CreateKubeconfig(r.KubeConfigFileName, crtKeyPair, config)
+			// admin.conf uses the super-admin cert config (O=system:masters) so it has
+			// unconditional cluster access without depending on the kubeadm:cluster-admins
+			// ClusterRoleBinding that PhaseClusterAdminRBAC creates asynchronously.
+			// Since kubeadm v1.29 (KEP-2305), CreateKubeconfig("admin.conf",...) emits
+			// O=kubeadm:cluster-admins, which requires that CRB to exist; between the TCP
+			// reconciler writing admin.conf and the soot manager finishing
+			// PhaseClusterAdminRBAC, any caller using admin.conf gets 403.
+			kubeconfigFileName := r.KubeConfigFileName
+			if kubeconfigFileName == kubeadmconstants.AdminKubeConfigFileName {
+				kubeconfigFileName = kubeadmconstants.SuperAdminKubeConfigFileName
+			}
+			kubeconfig, kcErr := kubeadm.CreateKubeconfig(kubeconfigFileName, crtKeyPair, config)
 			if kcErr != nil {
 				logger.Error(kcErr, "cannot create a valid kubeconfig")
 


### PR DESCRIPTION
Fixes #1167.

Since kubeadm v1.29 (KEP-2305), `CreateKubeconfig("admin.conf",...)` emits `O=kubeadm:cluster-admins` instead of `O=system:masters`. The matching `kubeadm:cluster-admins → cluster-admin` ClusterRoleBinding is created by `PhaseClusterAdminRBAC` in the soot manager, which runs asynchronously after the TCP reconciler writes `admin.conf`. Any operator using the `admin-kubeconfig` secret in this window receives HTTP 403.

This PR generates `admin.conf` with the `super-admin.conf` cert configuration (`O=system:masters`), which bypasses RBAC entirely and removes the dependency on ClusterRoleBinding ordering. The secret key remains `admin.conf`; only the embedded cert's Organization field changes. `super-admin.conf` already uses `O=system:masters` for the same reason.