### PR TITLE
fix(kubeadm): call AllowAPIServerToAccessKubeletAPI in BootstrapToken added in k8s v1.36.1

### DIFF
--- a/internal/kubeadm/bootstraptoken.go
+++ b/internal/kubeadm/bootstraptoken.go
@@ -40,6 +40,10 @@ func BootstrapToken(client kubernetes.Interface, config *Configuration) error {
 		return err
 	}
 
+	if err := node.AllowAPIServerToAccessKubeletAPI(client); err != nil {
+		return fmt.Errorf("error allowing API server kubelet client to access the kubelet API: %w", err)
+	}
+
 	bootstrapConfig := &clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"": {


### PR DESCRIPTION
Fixes https://github.com/clastix/kamaji/issues/1171 except the monitoring permissions.