### PR TITLE
chore: add OpenContainers labels to container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,15 @@ run: manifests generate ## Run a controller from your host.
 build: $(KO)
 	LD_FLAGS=$(LD_FLAGS) \
 	KOCACHE=/tmp/ko-cache KO_DOCKER_REPO=${CONTAINER_REPOSITORY} \
-	$(KO) build ./ --bare --tags=$(VERSION) --local=$(KO_LOCAL) --push=$(KO_PUSH)
+	$(KO) build ./ --bare --tags=$(VERSION) --local=$(KO_LOCAL) --push=$(KO_PUSH) \
+		--image-label "org.opencontainers.image.authors=Clastix https://clastix.io/" \
+		--image-label "org.opencontainers.image.title=Kamaji" \
+		--image-label "org.opencontainers.image.vendor=Clastix" \
+		--image-label "org.opencontainers.image.source=https://github.com/clastix/kamaji" \
+		--image-label "org.opencontainers.image.url=https://kamaji.clastix.io" \
+		--image-label "org.opencontainers.image.created=$$(date --utc '+%FT%H:%M:%SZ')" \
+		--image-label "org.opencontainers.image.revision=$(GIT_HEAD_COMMIT)" \
+		--image-label "org.opencontainers.image.version=$(VERSION)"
 
 ##@ Development
 


### PR DESCRIPTION
Resolves https://github.com/clastix/kamaji/issues/1173

```bash
make build
docker inspect docker.io/clastix/kamaji:7c305273f130e6843ba6ee489af44d5d7846ee8815b1258eeba56f7d28396c6f
...
"Labels": {
                "dev.chainguard.image.title": "static",
                "dev.chainguard.package.main": "",
                "org.opencontainers.image.authors": "Clastix https://clastix.io/",
                "org.opencontainers.image.created": "2026-06-10T09:26:14Z",
                "org.opencontainers.image.revision": "cf2e2a4",
                "org.opencontainers.image.source": "https://github.com/clastix/kamaji",
                "org.opencontainers.image.title": "Kamaji",
                "org.opencontainers.image.url": "https://kamaji.clastix.io",
                "org.opencontainers.image.vendor": "Clastix",
                "org.opencontainers.image.version": "26.6.2-edge"
            }
```