### PR TITLE
fix(docs): cert-manager values and cluster api kind hyperlink

### DIFF
--- a/docs/content/cluster-api/control-plane-provider.md
+++ b/docs/content/cluster-api/control-plane-provider.md
@@ -60,7 +60,7 @@ spec:
 ```
 
 !!! info "Full Reference"
-    For a full reference of the `KamajiControlPlane` custom resource, please see the [Reference APIs](https://doc.crds.dev/github.com/clastix/cluster-api-control-plane-provider-kamaji/controlplane.cluster.x-k8s.io/KamajiControlPlane/v1alpha1).
+    For a full reference of the `KamajiControlPlane` custom resource, please see the [Reference APIs](https://doc.crds.dev/github.com/clastix/cluster-api-control-plane-provider-kamaji/controlplane.cluster.x-k8s.io/KamajiControlPlane/v1alpha2).
 
 ## Getting started with the Kamaji Control Plane Provider
 
@@ -95,4 +95,3 @@ As result, the following Cluster API components will be installed:
 In the next step, we will create a fully functional Kubernetes cluster using the Kamaji Control Plane Provider and the Infrastructure provider of choice.
 
 For a complete list of supported infrastructure providers, please refer to the [other providers](other-providers.md) page.
-

--- a/docs/content/cluster-api/external-cluster.md
+++ b/docs/content/cluster-api/external-cluster.md
@@ -149,7 +149,7 @@ Install cert-manager:
 helm upgrade --install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 Install Kamaji:

--- a/docs/content/cluster-api/openstack-infra-provider.md
+++ b/docs/content/cluster-api/openstack-infra-provider.md
@@ -608,7 +608,8 @@ spec:
     upgrade:
       maxHistory: 10
   valuesTemplate: |
-    installCRDs: true
+    crds: 
+      enabled: true
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy

--- a/docs/content/getting-started/kamaji-aws.md
+++ b/docs/content/getting-started/kamaji-aws.md
@@ -140,7 +140,7 @@ helm install \
   --namespace cert-manager \
   --create-namespace \
   --version v1.11.0 \
-  --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 ### Install ExternalDNS (optional)

--- a/docs/content/getting-started/kamaji-generic.md
+++ b/docs/content/getting-started/kamaji-generic.md
@@ -64,7 +64,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 ## Install Kamaji Controller

--- a/docs/content/getting-started/kamaji-kind.md
+++ b/docs/content/getting-started/kamaji-kind.md
@@ -44,7 +44,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --set installCRDs=true
+  --set crds.enabled=true
 ```
 
 This will install cert-manager to the cluster. You can watch the progress of the installation on the cluster using the command
@@ -189,4 +189,3 @@ To check if your `kind` docker network has IPv6 enabled you can use the followin
 docker network inspect kind | jq '.[0].EnableIPv6'
 true
 ```
-


### PR DESCRIPTION
Updated KamajiControlPlane API hyperlink in ClusterAPI documentation section from v1alpha1 to v1alpha2  newer version for correct  rendering of the schema into docs.crds.dev website.