### PR TITLE
fix(docs): update all cert-manager helm charts with a pinned version

### DIFF
--- a/docs/content/cluster-api/external-cluster.md
+++ b/docs/content/cluster-api/external-cluster.md
@@ -149,6 +149,7 @@ Install cert-manager:
 helm upgrade --install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
+  --version v1.18.3 \
   --set crds.enabled=true
 ```
 

--- a/docs/content/cluster-api/openstack-infra-provider.md
+++ b/docs/content/cluster-api/openstack-infra-provider.md
@@ -593,6 +593,7 @@ metadata:
   name: cert-manager
   namespace: ${CLUSTER_NAMESPACE}
 spec:
+  version: v1.18.3
   clusterSelector:
     matchLabels:
       addons.cluster.x-k8s.io/cert-manager: "true"

--- a/docs/content/getting-started/kamaji-aws.md
+++ b/docs/content/getting-started/kamaji-aws.md
@@ -140,7 +140,7 @@ helm install \
   --namespace cert-manager \
   --create-namespace \
   --version v1.11.0 \
-  --set crds.enabled=true
+  --set installCRDs=true
 ```
 
 ### Install ExternalDNS (optional)

--- a/docs/content/getting-started/kamaji-aws.md
+++ b/docs/content/getting-started/kamaji-aws.md
@@ -139,8 +139,8 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.11.0 \
-  --set installCRDs=true
+  --version v1.18.3 \
+  --set crds.enabled=true
 ```
 
 ### Install ExternalDNS (optional)

--- a/docs/content/getting-started/kamaji-generic.md
+++ b/docs/content/getting-started/kamaji-generic.md
@@ -64,6 +64,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
+  --version v.1.18.3 \
   --set crds.enabled=true
 ```
 

--- a/docs/content/getting-started/kamaji-kind.md
+++ b/docs/content/getting-started/kamaji-kind.md
@@ -44,6 +44,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
+  --version v.1.18.3 \
   --set crds.enabled=true
 ```
 


### PR DESCRIPTION
Update all cert-manager helm charts with a pinned version as declared within the Makefile