### PR TITLE
fix(docs): update delete cluster command with CLUSTER_NAME env variable

### DIFF
--- a/docs/content/cluster-api/vsphere-infra-provider.md
+++ b/docs/content/cluster-api/vsphere-infra-provider.md
@@ -258,7 +258,7 @@ kubectl apply -f capi-kamaji-vsphere-cluster.yaml
 For cluster deletion, use the following command:
 
 ```bash
-kubectl delete cluster sample
+kubectl delete cluster $CLUSTER_NAME
 ```
 
 Always use `kubectl delete cluster $CLUSTER_NAME` to delete the tenant cluster. Using `kubectl delete -f capi-kamaji-vsphere-cluster.yaml` may lead to orphaned resources in some scenarios, as this method doesn't always respect ownership references between resources that were created after the initial deployment.


### PR DESCRIPTION
Updated the `kubectl  delete cluster` command under `vsphere-infra-provider.md` in order to use CLUSTER_NAME env variable instead of plain cluster name. 