### PR TITLE
test(api): cover advertiseAddress IP validation

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types_test.go
+++ b/api/v1alpha1/tenantcontrolplane_types_test.go
@@ -75,4 +75,47 @@ var _ = Describe("Cluster controller", func() {
 			Expect(err.Error()).To(ContainSubstring("LoadBalancer source ranges are supported only with LoadBalancer service type"))
 		})
 	})
+
+	Context("AdvertiseAddress", func() {
+		It("allows a valid IPv4 address", func() {
+			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
+			tcp.Spec.NetworkProfile.AdvertiseAddress = "10.0.0.10"
+
+			err := k8sClient.Create(ctx, tcp)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows a valid IPv6 address", func() {
+			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
+			tcp.Spec.NetworkProfile.AdvertiseAddress = "2001:db8::1"
+
+			err := k8sClient.Create(ctx, tcp)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows creation when advertiseAddress is unset", func() {
+			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
+
+			err := k8sClient.Create(ctx, tcp)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("denies a DNS hostname", func() {
+			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
+			tcp.Spec.NetworkProfile.AdvertiseAddress = "control-plane.example.com"
+
+			err := k8sClient.Create(ctx, tcp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("advertiseAddress must be a valid IP address"))
+		})
+
+		It("denies a malformed IP address", func() {
+			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
+			tcp.Spec.NetworkProfile.AdvertiseAddress = "10.0.0.999"
+
+			err := k8sClient.Create(ctx, tcp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("advertiseAddress must be a valid IP address"))
+		})
+	})
 })


### PR DESCRIPTION
## What

Adds envtest coverage for the `advertiseAddress` IP validation introduced in #1202.

#1202 added a field-level CEL rule on `NetworkProfileSpec.advertiseAddress`:

```
+kubebuilder:validation:XValidation:rule="self == '' || isIP(self)",message="advertiseAddress must be a valid IP address"
```

but merged without a test. This backfills that coverage so the rule and its message are guarded against regressions.

## Cases

Mirrors the existing `LoadBalancer Source Ranges` suite in `api/v1alpha1/tenantcontrolplane_types_test.go`:

- accepts a valid IPv4 address
- accepts a valid IPv6 address
- accepts an unset `advertiseAddress`
- rejects a DNS hostname
- rejects a malformed IP (e.g. `10.0.0.999`)

## Notes

Test-only; no API or behaviour change. Verified locally against envtest (Kubernetes 1.31.0): all 5 specs pass, confirming `isIP` is enforced and the rejection message matches.
