### PR TITLE
feat(api): add automountServiceAccountToken field for control-plane deployment

### DIFF
--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -327,6 +327,8 @@ type DeploymentSpec struct {
 	//+kubebuilder:default="default"
 	// ServiceAccountName allows to specify the service account to be mounted to the pods of the Control plane deployment
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	// AutomountServiceAccountToken allows to enable the automatic mounting of the service account token to the pods of the Control plane deployment
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
 	// ContainerSecurityContexts allows to specify the security context for the individual control plane components.
 	ContainerSecurityContexts *ControlPlaneContainerSecurityContexts `json:"containerSecurityContexts,omitempty"`
 	// PodSecurityContext allows to specify the security context for the control plane pod.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -797,6 +797,11 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 		*out = new(ControlPlaneProbes)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AutomountServiceAccountToken != nil {
+		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ContainerSecurityContexts != nil {
 		in, out := &in.ContainerSecurityContexts, &out.ContainerSecurityContexts
 		*out = new(ControlPlaneContainerSecurityContexts)

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -6301,6 +6301,9 @@ versions:
                                 x-kubernetes-list-type: atomic
                             type: object
                         type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken allows to enable the automatic mounting of the service account token to the pods of the Control plane deployment
+                        type: boolean
                       containerSecurityContexts:
                         description: ContainerSecurityContexts allows to specify the security context for the individual control plane components.
                         properties:

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -6309,6 +6309,9 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                           type: object
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken allows to enable the automatic mounting of the service account token to the pods of the Control plane deployment
+                          type: boolean
                         containerSecurityContexts:
                           description: ContainerSecurityContexts allows to specify the security context for the individual control plane components.
                           properties:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -31346,6 +31346,13 @@ More info: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>automountServiceAccountToken</b></td>
+        <td>boolean</td>
+        <td>
+          AutomountServiceAccountToken allows to enable the automatic mounting of the service account token to the pods of the Control plane deployment<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#tenantcontrolplanespeccontrolplanedeploymentcontainersecuritycontexts">containerSecurityContexts</a></b></td>
         <td>object</td>
         <td>

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -1208,6 +1208,8 @@ func (d Deployment) setAffinity(spec *corev1.PodSpec, tcp kamajiv1alpha1.TenantC
 }
 
 func (d Deployment) setServiceAccount(spec *corev1.PodSpec, tcp kamajiv1alpha1.TenantControlPlane) {
+	spec.AutomountServiceAccountToken = tcp.Spec.ControlPlane.Deployment.AutomountServiceAccountToken
+
 	if len(tcp.Spec.ControlPlane.Deployment.ServiceAccountName) > 0 {
 		spec.ServiceAccountName = tcp.Spec.ControlPlane.Deployment.ServiceAccountName
 

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -284,4 +284,44 @@ var _ = Describe("Controlplane Deployment", func() {
 			Expect(c.ReadinessProbe.HTTPGet.Port.IntValue()).To(Equal(6443))
 		})
 	})
+
+	Describe("ServiceAccount", func() {
+		It("should default to 'default' SA with nil automount", func() {
+			podSpec := &corev1.PodSpec{}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			d.setServiceAccount(podSpec, tcp)
+			Expect(podSpec.ServiceAccountName).To(Equal("default"))
+			Expect(podSpec.AutomountServiceAccountToken).To(BeNil())
+		})
+
+		It("should set a custom SA name with nil automount", func() {
+			podSpec := &corev1.PodSpec{}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.ServiceAccountName = "custom-sa"
+			d.setServiceAccount(podSpec, tcp)
+			Expect(podSpec.ServiceAccountName).To(Equal("custom-sa"))
+			Expect(podSpec.AutomountServiceAccountToken).To(BeNil())
+		})
+
+		It("should enable automount when AutomountServiceAccountToken is true", func() {
+			podSpec := &corev1.PodSpec{}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.AutomountServiceAccountToken = pointer.To(true)
+			d.setServiceAccount(podSpec, tcp)
+			Expect(podSpec.ServiceAccountName).To(Equal("default"))
+			Expect(podSpec.AutomountServiceAccountToken).ToNot(BeNil())
+			Expect(*podSpec.AutomountServiceAccountToken).To(BeTrue())
+		})
+
+		It("should disable automount when AutomountServiceAccountToken is false", func() {
+			podSpec := &corev1.PodSpec{}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.AutomountServiceAccountToken = pointer.To(false)
+			tcp.Spec.ControlPlane.Deployment.ServiceAccountName = "another-sa"
+			d.setServiceAccount(podSpec, tcp)
+			Expect(podSpec.ServiceAccountName).To(Equal("another-sa"))
+			Expect(podSpec.AutomountServiceAccountToken).ToNot(BeNil())
+			Expect(*podSpec.AutomountServiceAccountToken).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
# Context

By default, the control-plane pods created by Kamaji mount the Service Account (SA) token of the namespace's default SA (or a user-specified custom SA).

This token is not functionally required by the tenant control-plane components (kube-apiserver, kube-controller-manager, kube-scheduler).

# Proposed Change

This PR adds a new optional boolean field `automountServiceAccountToken` under `spec.controlPlane.deployment`.
- Default: false
- When false, `automountServiceAccountToken: false` is explicitly set on the Deployment's PodSpec, preventing Kubernetes from mounting the SA token.
- When true, the token is mounted as before (standard Kubernetes behavior).

NB: As-is, the default is set to false, but I leave it to your discretion whether to switch the default to true to avoid a rollout on existing pods and preserve backward compatibility.