### PR TITLE
feat(manager): add --pprof-bind-address flag

### DIFF
--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -46,6 +46,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	var (
 		metricsBindAddress            string
 		healthProbeBindAddress        string
+		pprofBindAddress              string
 		leaderElect                   bool
 		tmpDirectory                  string
 		kineImage                     string
@@ -114,6 +115,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				Metrics: metricsserver.Options{
 					BindAddress: metricsBindAddress,
 				},
+				PprofBindAddress: pprofBindAddress,
 				WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
 					Port: 9443,
 				}),
@@ -323,6 +325,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	// Setting CLI flags
 	cmd.Flags().StringVar(&metricsBindAddress, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	cmd.Flags().StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	cmd.Flags().StringVar(&pprofBindAddress, "pprof-bind-address", "", "The address the pprof profiler binds to.")
 	cmd.Flags().BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().StringVar(&tmpDirectory, "tmp-directory", "/tmp/kamaji", "Directory which will be used to work with temporary files.")
 	cmd.Flags().StringVar(&kineImage, "kine-image", "rancher/kine:v0.11.10-amd64", "Container image along with tag to use for the Kine sidecar container (used only if etcd-storage-type is set to one of kine strategies).")


### PR DESCRIPTION
# Context

Following the [Kubebuilder pprof tutorial](https://book.kubebuilder.io/reference/pprof-tutorial), this PR integrates controller-runtime's built-in `PprofBindAddress` support into Kamaji.

Currently, the Kamaji controller manager does not expose a way to enable Go's pprof profiler at runtime. Adding a dedicated pprof endpoint simplifies debugging of performance issues and memory leaks.

# Proposed change

This PR adds a new CLI flag `--pprof-bind-address` to the manager command, following the same pattern as the existing `--metrics-bind-address` and `--health-probe-bind-address` flags.

When set to a bind address (e.g. ":6767"), a pprof HTTP endpoint is exposed for CPU and memory profiling.
When left empty (default), no pprof server is started, preserving existing behavior.
