### PR TITLE
fix: when --authorization-config is present, do not apply the --authorization-mode default

### DIFF
--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -685,12 +685,17 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 	// Opinionated defaults: applied only when the user didn't provide the same flag in ExtraArgs.
 	safeDefaults := map[string]string{
 		"--allow-privileged":                   "true",
-		"--authorization-mode":                 "Node,RBAC",
 		"--enable-bootstrap-token-auth":        "true",
 		"--requestheader-extra-headers-prefix": "X-Remote-Extra-",
 		"--requestheader-group-headers":        "X-Remote-Group",
 		"--requestheader-username-headers":     "X-Remote-User",
 		"--service-account-issuer":             "https://kubernetes.default.svc.cluster.local",
+	}
+
+	// https://github.com/kubernetes/kubernetes/blob/6720f0f96000abb82ad51d1177489b04188819d8/cmd/kubeadm/app/phases/controlplane/manifests.go#L253-L255
+	// Mirror kubeadm's mutually exclusive configuration
+	if _, ok := utilities.ArgsFromSliceToMap(userExtras)["--authorization-config"]; !ok {
+		safeDefaults["--authorization-mode"] = "Node,RBAC"
 	}
 
 	// backward compatibility for deprecated CIDR fields


### PR DESCRIPTION
Fixes #1120 

I think we can re-open the issue as @ayan-khan-rtds  described it. We also need to set --authorization-config flags and this is not possible when the default --authorization-mode is set. Overriding it is not enough, as the apiserver will still fail as long as it is set, no matter the value.

I think a good way to fix would be to imitate kubeadm behavior of mutual exclusion here:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/controlplane/manifests.go#L253C1-L255C3

And this is what this PR is trying to imitate/achieve.

To provide more details on quick reproduction:

Apply the following on a kamaji enabled cluster:
```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: repro-authz-config
  namespace: mgmt
stringData:
  authorization-config.yaml: |
    apiVersion: apiserver.config.k8s.io/v1
    kind: AuthorizationConfiguration
    authorizers:
      - type: Node
        name: node
      - type: RBAC
        name: rbac
---
apiVersion: kamaji.clastix.io/v1alpha1
kind: TenantControlPlane
metadata:
  name: repro-authz-config
  namespace: mgmt
spec:
  dataStore: default
  controlPlane:
    deployment:
      replicas: 1
      extraArgs:
        apiServer:
          - --authorization-config=/etc/kubernetes/authz/authorization-config.yaml
      additionalVolumes:
        - name: authz-config
          secret:
            secretName: repro-authz-config
      additionalVolumeMounts:
        apiServer:
          - name: authz-config
            mountPath: /etc/kubernetes/authz
            readOnly: true
    service:
      serviceType: ClusterIP
  kubernetes:
    version: v1.36.1
    kubelet:
      cgroupfs: systemd
  networkProfile:
    port: 6443
 ```
 
 The following logs will be returned on the created apiserver container:
 ```
kube-apiserver E0715 09:55:54.177808       1 run.go:72] "command failed" err="--authorization-config can not be specified when --authorization-mode or --authorization-webhook-* flags are defined"                         │
 ```
 
 `--authorization-webhook-*` legacy flags are not set by default so those are not a case we need to handle. 
 This PR should keep current behavior with setting sane default (exactly same as how kubeadm works) while still allowing `--authorization-config`
 
Are you ok with this @prometherion ? We are considering Kamaji as our solution for hosted control plane and this is a feature-fix we might need for our transition.