### PR TITLE
chore: update Go to 1.26.5 (security fixes to crypto/tls, os packages)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clastix/kamaji
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/JamesStewy/go-mysqldump v0.2.2


### PR DESCRIPTION
Updates Go from 1.26.0 to 1.26.5, which includes security fixes to the crypto/tls and os packages.