### PR TITLE
fix: preserving deployment labels

### DIFF
--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -116,7 +116,11 @@ type Deployment struct {
 func (d Deployment) Build(ctx context.Context, deployment *appsv1.Deployment, tenantControlPlane kamajiv1alpha1.TenantControlPlane) {
 	address, _, _ := tenantControlPlane.AssignedControlPlaneAddress()
 
-	d.setLabels(deployment, utilities.MergeMaps(utilities.KamajiLabels(tenantControlPlane.GetName(), "deployment"), tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Labels))
+	d.setLabels(deployment, utilities.MergeMaps(
+		deployment.GetLabels(),
+		utilities.KamajiLabels(tenantControlPlane.GetName(), "deployment"),
+		tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Labels,
+	))
 	d.setAnnotations(deployment, utilities.MergeMaps(deployment.Annotations, tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalMetadata.Annotations))
 	d.setTemplateLabels(&deployment.Spec.Template, utilities.MergeMaps(d.templateLabels(ctx, &tenantControlPlane), tenantControlPlane.Spec.ControlPlane.Deployment.PodAdditionalMetadata.Labels))
 	d.setTemplateAnnotations(&deployment.Spec.Template, utilities.MergeMaps(tenantControlPlane.Spec.ControlPlane.Deployment.PodAdditionalMetadata.Annotations, map[string]string{


### PR DESCRIPTION
Especially useful for Capsule environments, there's a conflict when updating Deployment labels managed by the `TenantControlPlane` reconciler, which is not aware of the Project Capsule labels.