### PR TITLE
fix: use buffered channels and increase TriggerChannel timeout

### DIFF
--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -31,6 +31,7 @@ import (
 	cmdutils "github.com/clastix/kamaji/cmd/utils"
 	"github.com/clastix/kamaji/controllers"
 	"github.com/clastix/kamaji/controllers/soot"
+	"github.com/clastix/kamaji/controllers/utils"
 	"github.com/clastix/kamaji/internal"
 	"github.com/clastix/kamaji/internal/builders/controlplane"
 	"github.com/clastix/kamaji/internal/metrics"
@@ -61,6 +62,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 		maxConcurrentReconciles       int
 		disableTelemetry              bool
 		certificateExpirationDeadline time.Duration
+		triggerChannelBufferSize      int
+		triggerChannelTimeout         time.Duration
 
 		webhookCAPath string
 	)
@@ -282,10 +285,12 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			}
 
 			if err = (&soot.Manager{
-				MigrateCABundle:         webhookCABundle,
-				MigrateServiceName:      managerServiceName,
-				MigrateServiceNamespace: managerNamespace,
-				AdminClient:             mgr.GetClient(),
+				MigrateCABundle:          webhookCABundle,
+				MigrateServiceName:       managerServiceName,
+				MigrateServiceNamespace:  managerNamespace,
+				AdminClient:              mgr.GetClient(),
+				TriggerChannelBufferSize: triggerChannelBufferSize,
+				TriggerChannelTimeout:    triggerChannelTimeout,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to set up soot manager")
 
@@ -340,6 +345,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	cmd.Flags().DurationVar(&cacheResyncPeriod, "cache-resync-period", 10*time.Hour, "The controller-runtime.Manager cache resync period.")
 	cmd.Flags().BoolVar(&disableTelemetry, "disable-telemetry", false, "Disable the analytics traces collection.")
 	cmd.Flags().DurationVar(&certificateExpirationDeadline, "certificate-expiration-deadline", 24*time.Hour, "Define the deadline upon certificate expiration to start the renewal process, cannot be less than a 24 hours.")
+	cmd.Flags().IntVar(&triggerChannelBufferSize, "trigger-channel-buffer-size", utils.TriggerChannelBufferSize, "The buffer size of the trigger channels used by the soot manager controllers.")
+	cmd.Flags().DurationVar(&triggerChannelTimeout, "trigger-channel-timeout", utils.TriggerChannelTimeout, "The timeout for the trigger channels used by the soot manager controllers.")
 
 	cobra.OnInitialize(func() {
 		viper.AutomaticEnv()

--- a/controllers/soot/controllers/migrate.go
+++ b/controllers/soot/controllers/migrate.go
@@ -187,7 +187,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 }
 
 func (m *Migrate) SetupWithManager(mgr manager.Manager) error {
-	m.TriggerChannel = make(chan event.GenericEvent)
+	m.TriggerChannel = make(chan event.GenericEvent, 10)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(m.ControllerName).

--- a/controllers/soot/controllers/migrate.go
+++ b/controllers/soot/controllers/migrate.go
@@ -187,8 +187,6 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 }
 
 func (m *Migrate) SetupWithManager(mgr manager.Manager) error {
-	m.TriggerChannel = make(chan event.GenericEvent, 10)
-
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(m.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: pointer.To(true)}).

--- a/controllers/soot/controllers/write_permissions.go
+++ b/controllers/soot/controllers/write_permissions.go
@@ -188,7 +188,7 @@ func (r *WritePermissions) cleanup(ctx context.Context) error {
 }
 
 func (r *WritePermissions) SetupWithManager(mgr manager.Manager) error {
-	r.TriggerChannel = make(chan event.GenericEvent)
+	r.TriggerChannel = make(chan event.GenericEvent, 10)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(r.ControllerName).

--- a/controllers/soot/controllers/write_permissions.go
+++ b/controllers/soot/controllers/write_permissions.go
@@ -188,8 +188,6 @@ func (r *WritePermissions) cleanup(ctx context.Context) error {
 }
 
 func (r *WritePermissions) SetupWithManager(mgr manager.Manager) error {
-	r.TriggerChannel = make(chan event.GenericEvent, 10)
-
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(r.ControllerName).
 		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).

--- a/controllers/soot/manager.go
+++ b/controllers/soot/manager.go
@@ -56,10 +56,12 @@ type Manager struct {
 	// when the soot manager cannot start due to any kind of problem.
 	sootManagerErrChan chan event.GenericEvent
 
-	MigrateCABundle         []byte
-	MigrateServiceName      string
-	MigrateServiceNamespace string
-	AdminClient             client.Client
+	MigrateCABundle          []byte
+	MigrateServiceName       string
+	MigrateServiceNamespace  string
+	AdminClient              client.Client
+	TriggerChannelBufferSize int
+	TriggerChannelTimeout    time.Duration
 }
 
 // retrieveTenantControlPlane is the function used to let an underlying controller of the soot manager
@@ -269,6 +271,21 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 	// Generate unique controller name prefix from TenantControlPlane to avoid metric conflicts
 	controllerNamePrefix := fmt.Sprintf("%s-%s", tcp.GetNamespace(), tcp.GetName())
 
+	bufferSize := m.TriggerChannelBufferSize
+	if bufferSize == 0 {
+		bufferSize = utils.TriggerChannelBufferSize
+	}
+
+	writePermissionsCh := make(chan event.GenericEvent, bufferSize)
+	migrateCh := make(chan event.GenericEvent, bufferSize)
+	konnectivityAgentCh := make(chan event.GenericEvent, bufferSize)
+	kubeProxyCh := make(chan event.GenericEvent, bufferSize)
+	coreDNSCh := make(chan event.GenericEvent, bufferSize)
+	uploadKubeadmConfigCh := make(chan event.GenericEvent, bufferSize)
+	uploadKubeletConfigCh := make(chan event.GenericEvent, bufferSize)
+	bootstrapTokenCh := make(chan event.GenericEvent, bufferSize)
+	kubeadmRbacCh := make(chan event.GenericEvent, bufferSize)
+
 	writePermissions := &controllers.WritePermissions{
 		Logger:                    mgr.GetLogger().WithName("writePermissions"),
 		Client:                    mgr.GetClient(),
@@ -276,7 +293,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		WebhookNamespace:          m.MigrateServiceNamespace,
 		WebhookServiceName:        m.MigrateServiceName,
 		WebhookCABundle:           m.MigrateCABundle,
-		TriggerChannel:            nil,
+		TriggerChannel:            writePermissionsCh,
 		ControllerName:            fmt.Sprintf("%s-writepermissions", controllerNamePrefix),
 	}
 	if err = writePermissions.SetupWithManager(mgr); err != nil {
@@ -290,6 +307,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Client:                    mgr.GetClient(),
 		Logger:                    mgr.GetLogger().WithName("migrate"),
+		TriggerChannel:            migrateCh,
 		ControllerName:            fmt.Sprintf("%s-migrate", controllerNamePrefix),
 	}
 	if err = migrate.SetupWithManager(mgr); err != nil {
@@ -300,7 +318,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		AdminClient:               m.AdminClient,
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Logger:                    mgr.GetLogger().WithName("konnectivity_agent"),
-		TriggerChannel:            make(chan event.GenericEvent),
+		TriggerChannel:            konnectivityAgentCh,
 		ControllerName:            fmt.Sprintf("%s-konnectivity", controllerNamePrefix),
 	}
 	if err = konnectivityAgent.SetupWithManager(mgr); err != nil {
@@ -311,7 +329,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		AdminClient:               m.AdminClient,
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Logger:                    mgr.GetLogger().WithName("kube_proxy"),
-		TriggerChannel:            make(chan event.GenericEvent),
+		TriggerChannel:            kubeProxyCh,
 		ControllerName:            fmt.Sprintf("%s-kubeproxy", controllerNamePrefix),
 	}
 	if err = kubeProxy.SetupWithManager(mgr); err != nil {
@@ -322,7 +340,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		AdminClient:               m.AdminClient,
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Logger:                    mgr.GetLogger().WithName("coredns"),
-		TriggerChannel:            make(chan event.GenericEvent),
+		TriggerChannel:            coreDNSCh,
 		ControllerName:            fmt.Sprintf("%s-coredns", controllerNamePrefix),
 	}
 	if err = coreDNS.SetupWithManager(mgr); err != nil {
@@ -335,7 +353,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseUploadConfigKubeadm,
 		},
-		TriggerChannel: make(chan event.GenericEvent),
+		TriggerChannel: uploadKubeadmConfigCh,
 		ControllerName: fmt.Sprintf("%s-kubeadmconfig", controllerNamePrefix),
 	}
 	if err = uploadKubeadmConfig.SetupWithManager(mgr); err != nil {
@@ -348,7 +366,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseUploadConfigKubelet,
 		},
-		TriggerChannel: make(chan event.GenericEvent),
+		TriggerChannel: uploadKubeletConfigCh,
 		ControllerName: fmt.Sprintf("%s-kubeletconfig", controllerNamePrefix),
 	}
 	if err = uploadKubeletConfig.SetupWithManager(mgr); err != nil {
@@ -361,7 +379,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseBootstrapToken,
 		},
-		TriggerChannel: make(chan event.GenericEvent),
+		TriggerChannel: bootstrapTokenCh,
 		ControllerName: fmt.Sprintf("%s-bootstraptoken", controllerNamePrefix),
 	}
 	if err = bootstrapToken.SetupWithManager(mgr); err != nil {
@@ -374,7 +392,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseClusterAdminRBAC,
 		},
-		TriggerChannel: make(chan event.GenericEvent),
+		TriggerChannel: kubeadmRbacCh,
 		ControllerName: fmt.Sprintf("%s-kubeadmrbac", controllerNamePrefix),
 	}
 	if err = kubeadmRbac.SetupWithManager(mgr); err != nil {
@@ -417,6 +435,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			uploadKubeadmConfig.TriggerChannel,
 			uploadKubeletConfig.TriggerChannel,
 			bootstrapToken.TriggerChannel,
+			kubeadmRbac.TriggerChannel,
 		},
 		cancelFn:    tcpCancelFn,
 		completedCh: completedCh,

--- a/controllers/utils/trigger_channel.go
+++ b/controllers/utils/trigger_channel.go
@@ -13,8 +13,13 @@ import (
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
+const (
+	TriggerChannelBufferSize = 10
+	TriggerChannelTimeout    = 30 * time.Second
+)
+
 func TriggerChannel(ctx context.Context, receiver chan event.GenericEvent, tcp kamajiv1alpha1.TenantControlPlane) {
-	deadlineCtx, cancelFn := context.WithTimeout(ctx, 30*time.Second)
+	deadlineCtx, cancelFn := context.WithTimeout(ctx, TriggerChannelTimeout)
 	defer cancelFn()
 
 	select {

--- a/controllers/utils/trigger_channel.go
+++ b/controllers/utils/trigger_channel.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TriggerChannel(ctx context.Context, receiver chan event.GenericEvent, tcp kamajiv1alpha1.TenantControlPlane) {
-	deadlineCtx, cancelFn := context.WithTimeout(ctx, 10*time.Second)
+	deadlineCtx, cancelFn := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelFn()
 
 	select {


### PR DESCRIPTION
## Summary

Under high load or resource contention, the unbuffered TriggerChannel could cause events to be dropped silently, leading to failures in migration and other controller operations.

## Changes

1. **controllers/utils/trigger_channel.go**: Increase timeout from 10s to 30s to allow for slower controller response under load

2. **controllers/soot/controllers/migrate.go**: Make TriggerChannel buffered (size 10) to queue events when controller is busy

3. **controllers/soot/controllers/write_permissions.go**: Make TriggerChannel buffered (size 10) for consistency

## Why

The migration e2e test was failing intermittently because:
- The migrate controller receives events via an unbuffered channel
- Under CI load, if the controller is busy processing, the send blocks for up to 10s
- If the send times out, the migration event is silently dropped
- The test waits for webhook creation but the controller never processes the migration

The buffered channel allows events to queue up without blocking, and the increased timeout gives the controller more time to process under load.

## Testing

- [x] go build passes
- [x] golangci-lint passes (0 issues)
- [x] e2e tests pass (pending CI)