### PR TITLE
fix: rework the trigger channels around how source.Channel consumes them

### DIFF
--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -31,7 +31,6 @@ import (
 	cmdutils "github.com/clastix/kamaji/cmd/utils"
 	"github.com/clastix/kamaji/controllers"
 	"github.com/clastix/kamaji/controllers/soot"
-	"github.com/clastix/kamaji/controllers/utils"
 	"github.com/clastix/kamaji/internal"
 	"github.com/clastix/kamaji/internal/builders/controlplane"
 	"github.com/clastix/kamaji/internal/metrics"
@@ -62,8 +61,6 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 		maxConcurrentReconciles       int
 		disableTelemetry              bool
 		certificateExpirationDeadline time.Duration
-		triggerChannelBufferSize      int
-		triggerChannelTimeout         time.Duration
 
 		webhookCAPath string
 	)
@@ -140,6 +137,10 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				return err
 			}
 
+			// Both channels are unbuffered: their consumer is a controller-runtime goroutine parked on
+			// them, so every send is a direct hand-off, and a buffer would only ever hold events in the
+			// window where that goroutine hasn't started yet. Both senders wait for the consumer instead
+			// of dropping, which covers that window without a buffer size to pick.
 			tcpChannel, certChannel := make(chan event.GenericEvent), make(chan event.GenericEvent)
 			metricsRecorder := metrics.DefaultRecorder()
 
@@ -285,12 +286,10 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			}
 
 			if err = (&soot.Manager{
-				MigrateCABundle:          webhookCABundle,
-				MigrateServiceName:       managerServiceName,
-				MigrateServiceNamespace:  managerNamespace,
-				AdminClient:              mgr.GetClient(),
-				TriggerChannelBufferSize: triggerChannelBufferSize,
-				TriggerChannelTimeout:    triggerChannelTimeout,
+				MigrateCABundle:         webhookCABundle,
+				MigrateServiceName:      managerServiceName,
+				MigrateServiceNamespace: managerNamespace,
+				AdminClient:             mgr.GetClient(),
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to set up soot manager")
 
@@ -345,8 +344,6 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	cmd.Flags().DurationVar(&cacheResyncPeriod, "cache-resync-period", 10*time.Hour, "The controller-runtime.Manager cache resync period.")
 	cmd.Flags().BoolVar(&disableTelemetry, "disable-telemetry", false, "Disable the analytics traces collection.")
 	cmd.Flags().DurationVar(&certificateExpirationDeadline, "certificate-expiration-deadline", 24*time.Hour, "Define the deadline upon certificate expiration to start the renewal process, cannot be less than a 24 hours.")
-	cmd.Flags().IntVar(&triggerChannelBufferSize, "trigger-channel-buffer-size", utils.TriggerChannelBufferSize, "The buffer size of the trigger channels used by the soot manager controllers.")
-	cmd.Flags().DurationVar(&triggerChannelTimeout, "trigger-channel-timeout", utils.TriggerChannelTimeout, "The timeout for the trigger channels used by the soot manager controllers.")
 
 	cobra.OnInitialize(func() {
 		viper.AutomaticEnv()

--- a/controllers/datastore_controller.go
+++ b/controllers/datastore_controller.go
@@ -138,14 +138,7 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 		logger.Info("triggering cascading reconciliation for TenantControlPlanes")
 
-		for _, tcp := range tcpList.Items {
-			var shrunkTCP kamajiv1alpha1.TenantControlPlane
-
-			shrunkTCP.Name = tcp.Name
-			shrunkTCP.Namespace = tcp.Namespace
-
-			go utils.TriggerChannel(ctx, r.TenantControlPlaneTrigger, shrunkTCP)
-		}
+		r.triggerTenantControlPlanes(ctx, tcpList)
 	}()
 
 	if ds.GetDeletionTimestamp() != nil {
@@ -247,6 +240,36 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 	})
 
 	return reconcile.Result{}, err
+}
+
+// triggerTenantControlPlanes enqueues a reconciliation for every TenantControlPlane referencing the
+// DataStore, propagating changes that don't surface on the DataStore object itself, such as the
+// content of the Secret objects backing its TLS configuration.
+//
+// TenantControlPlaneTrigger is shared by all of them, so each event carries a distinct workqueue key
+// and dropping one would lose a reconciliation: unlike the coalescing sends of the soot manager,
+// these wait for the consumer to catch up, and only bail out once the manager is shutting down.
+//
+// The whole fan-out runs on a single goroutine rather than one per TenantControlPlane. The receiving
+// end is a controller-runtime goroutine parked on the channel, so each send is a direct hand-off to
+// it and sending sequentially costs the same as sending concurrently, minus the scheduling of one
+// goroutine per item. It also bounds what a fleet-wide trigger allocates while the consumer isn't
+// running yet: one parked sender instead of one per TenantControlPlane.
+func (r *DataStore) triggerTenantControlPlanes(ctx context.Context, tcpList kamajiv1alpha1.TenantControlPlaneList) {
+	go func() {
+		for _, tcp := range tcpList.Items {
+			var shrunkTCP kamajiv1alpha1.TenantControlPlane
+
+			shrunkTCP.Name = tcp.Name
+			shrunkTCP.Namespace = tcp.Namespace
+
+			select {
+			case r.TenantControlPlaneTrigger <- event.GenericEvent{Object: &shrunkTCP}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func (r *DataStore) SetupWithManager(mgr controllerruntime.Manager) error {

--- a/controllers/soot/manager.go
+++ b/controllers/soot/manager.go
@@ -56,12 +56,10 @@ type Manager struct {
 	// when the soot manager cannot start due to any kind of problem.
 	sootManagerErrChan chan event.GenericEvent
 
-	MigrateCABundle          []byte
-	MigrateServiceName       string
-	MigrateServiceNamespace  string
-	AdminClient              client.Client
-	TriggerChannelBufferSize int
-	TriggerChannelTimeout    time.Duration
+	MigrateCABundle         []byte
+	MigrateServiceName      string
+	MigrateServiceNamespace string
+	AdminClient             client.Client
 }
 
 // retrieveTenantControlPlane is the function used to let an underlying controller of the soot manager
@@ -205,7 +203,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 				shrunkTCP.Name = tcp.Name
 				shrunkTCP.Namespace = tcp.Namespace
 
-				go utils.TriggerChannel(ctx, trigger, shrunkTCP)
+				utils.CoalesceTriggerChannel(trigger, shrunkTCP)
 			}
 		}
 
@@ -271,21 +269,6 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 	// Generate unique controller name prefix from TenantControlPlane to avoid metric conflicts
 	controllerNamePrefix := fmt.Sprintf("%s-%s", tcp.GetNamespace(), tcp.GetName())
 
-	bufferSize := m.TriggerChannelBufferSize
-	if bufferSize == 0 {
-		bufferSize = utils.TriggerChannelBufferSize
-	}
-
-	writePermissionsCh := make(chan event.GenericEvent, bufferSize)
-	migrateCh := make(chan event.GenericEvent, bufferSize)
-	konnectivityAgentCh := make(chan event.GenericEvent, bufferSize)
-	kubeProxyCh := make(chan event.GenericEvent, bufferSize)
-	coreDNSCh := make(chan event.GenericEvent, bufferSize)
-	uploadKubeadmConfigCh := make(chan event.GenericEvent, bufferSize)
-	uploadKubeletConfigCh := make(chan event.GenericEvent, bufferSize)
-	bootstrapTokenCh := make(chan event.GenericEvent, bufferSize)
-	kubeadmRbacCh := make(chan event.GenericEvent, bufferSize)
-
 	writePermissions := &controllers.WritePermissions{
 		Logger:                    mgr.GetLogger().WithName("writePermissions"),
 		Client:                    mgr.GetClient(),
@@ -293,7 +276,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		WebhookNamespace:          m.MigrateServiceNamespace,
 		WebhookServiceName:        m.MigrateServiceName,
 		WebhookCABundle:           m.MigrateCABundle,
-		TriggerChannel:            writePermissionsCh,
+		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-writepermissions", controllerNamePrefix),
 	}
 	if err = writePermissions.SetupWithManager(mgr); err != nil {
@@ -307,7 +290,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Client:                    mgr.GetClient(),
 		Logger:                    mgr.GetLogger().WithName("migrate"),
-		TriggerChannel:            migrateCh,
+		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-migrate", controllerNamePrefix),
 	}
 	if err = migrate.SetupWithManager(mgr); err != nil {
@@ -318,7 +301,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		AdminClient:               m.AdminClient,
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Logger:                    mgr.GetLogger().WithName("konnectivity_agent"),
-		TriggerChannel:            konnectivityAgentCh,
+		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-konnectivity", controllerNamePrefix),
 	}
 	if err = konnectivityAgent.SetupWithManager(mgr); err != nil {
@@ -329,7 +312,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		AdminClient:               m.AdminClient,
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Logger:                    mgr.GetLogger().WithName("kube_proxy"),
-		TriggerChannel:            kubeProxyCh,
+		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-kubeproxy", controllerNamePrefix),
 	}
 	if err = kubeProxy.SetupWithManager(mgr); err != nil {
@@ -340,7 +323,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		AdminClient:               m.AdminClient,
 		GetTenantControlPlaneFunc: m.retrieveTenantControlPlane(tcpCtx, request),
 		Logger:                    mgr.GetLogger().WithName("coredns"),
-		TriggerChannel:            coreDNSCh,
+		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-coredns", controllerNamePrefix),
 	}
 	if err = coreDNS.SetupWithManager(mgr); err != nil {
@@ -353,7 +336,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseUploadConfigKubeadm,
 		},
-		TriggerChannel: uploadKubeadmConfigCh,
+		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeadmconfig", controllerNamePrefix),
 	}
 	if err = uploadKubeadmConfig.SetupWithManager(mgr); err != nil {
@@ -366,7 +349,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseUploadConfigKubelet,
 		},
-		TriggerChannel: uploadKubeletConfigCh,
+		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeletconfig", controllerNamePrefix),
 	}
 	if err = uploadKubeletConfig.SetupWithManager(mgr); err != nil {
@@ -379,7 +362,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseBootstrapToken,
 		},
-		TriggerChannel: bootstrapTokenCh,
+		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-bootstraptoken", controllerNamePrefix),
 	}
 	if err = bootstrapToken.SetupWithManager(mgr); err != nil {
@@ -392,7 +375,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 			Client: m.AdminClient,
 			Phase:  resources.PhaseClusterAdminRBAC,
 		},
-		TriggerChannel: kubeadmRbacCh,
+		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeadmrbac", controllerNamePrefix),
 	}
 	if err = kubeadmRbac.SetupWithManager(mgr); err != nil {

--- a/controllers/utils/trigger_channel.go
+++ b/controllers/utils/trigger_channel.go
@@ -4,28 +4,34 @@
 package utils
 
 import (
-	"context"
-	"time"
-
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
-const (
-	TriggerChannelBufferSize = 10
-	TriggerChannelTimeout    = 30 * time.Second
-)
+// CoalesceTriggerChannelBufferSize is the buffer size of the channels fed by CoalesceTriggerChannel,
+// and one slot is both the minimum and the maximum that makes sense.
+//
+// It cannot be zero: a send on an unbuffered channel only succeeds when the receiver is already
+// parked on it, so every nudge would be skipped in the window where the source.Channel consumer
+// hasn't started yet, which is precisely the window the send has to survive.
+//
+// It doesn't need to be more than one: all the events are interchangeable nudges for the same
+// workqueue key, so a pending one already tells the consumer to reconcile, and the workqueue
+// collapses anything queued on top of it. Extra slots would only buy redundant sends.
+const CoalesceTriggerChannelBufferSize = 1
 
-func TriggerChannel(ctx context.Context, receiver chan event.GenericEvent, tcp kamajiv1alpha1.TenantControlPlane) {
-	deadlineCtx, cancelFn := context.WithTimeout(ctx, TriggerChannelTimeout)
-	defer cancelFn()
-
+// CoalesceTriggerChannel enqueues a reconciliation for the given TenantControlPlane without ever
+// blocking: it's meant for channels dedicated to a single TenantControlPlane, where all the events
+// are interchangeable nudges for the same workqueue key. When the buffer is full a reconciliation
+// is already pending and covers this request, so skipping the send coalesces it rather than losing
+// it: no goroutine, and no deadline to tune.
+//
+// Channels shared by several TenantControlPlane objects carry a distinct workqueue key per event
+// and cannot use this: they have to wait for the consumer instead of skipping the send.
+func CoalesceTriggerChannel(receiver chan event.GenericEvent, tcp kamajiv1alpha1.TenantControlPlane) {
 	select {
 	case receiver <- event.GenericEvent{Object: &tcp}:
-		return
-	case <-deadlineCtx.Done():
-		log.FromContext(ctx).Error(deadlineCtx.Err(), "cannot send due to timeout")
+	default:
 	}
 }


### PR DESCRIPTION
Follow-up after #1258 has been merged.

The _buffer sizes_ and the _send deadline_ introduced for the trigger channels were tuning a bottleneck that isn't there, and one of the two flags exposing them was wired to a field nothing ever read.
    
The consumer of a `source.Channel` is a dedicated `controller-runtime` goroutine parked on the channel, draining into an internal buffer of 1024 events and forwarding each one to the workqueue with a single non-blocking `Add`. It is ready practically always, and a send only ever waits in the window between the manager start and the moment that goroutine begins consuming. What the channels needed was a send policy matching what their events mean, not a size to tune.

The nine channels of a soot manager serve a single TenantControlPlane and carry interchangeable nudges for the same workqueue key, so their sends now coalesce: when an event is already pending it asks for the very reconciliation this one wanted, and skipping the send drops nothing. That removes both the goroutine per send and the deadline bounding it. Their buffer is one slot, which is at once the minimum and the maximum that means anything: zero would skip every nudge before the consumer starts, since an unbuffered send only succeeds against a parked receiver, while further slots would only queue events the workqueue collapses anyway.

The channel shared by the _DataStore_ controller is the opposite case, as every event carries a distinct workqueue key and a skipped send loses a reconciliation outright. It keeps waiting for the consumer, bounded by the context rather than by a deadline that could only ever turn a delay of milliseconds into a silent drop once the fleet outgrew the buffer. Its fan-out now runs sequentially on a single goroutine: against a parked receiver, each send is a direct hand-off, so sending sequentially costs the same minus the per-item scheduling, and a fleet-wide trigger parks one sender instead of one per TenantControlPlane. The channels of the root manager are unbuffered again, left with nothing to absorb.

`controllers/utils` is therefore down to the coalescing helper alone, the multi-key send living next to the _DataStore_ reconciler that is its only caller.
Both `--trigger-channel-buffer-size` and `--trigger-channel-timeout` are gone: the former tuned something inert, the latter never reached the code it named.