### PR TITLE
fix(e2e): widen the migration webhook wait above the observed CI stall

### DIFF
--- a/e2e/tcp_migration_test.go
+++ b/e2e/tcp_migration_test.go
@@ -101,9 +101,17 @@ func featureTestMigration(driver string) {
 		StatusMustEqualTo(tcp, kamajiv1alpha1.VersionMigrating)
 
 		By("waiting for the webhook installation")
+		// Measured directly in CI (GitHub Actions run 30307341733): the whole manager
+		// process - the host-side tenantcontrolplane controller across every TCP in the
+		// suite, plus this tenant's own soot sub-manager - went completely silent for
+		// 2m16s (21:45:45 to 21:48:01 UTC) with no errors logged, consistent with the
+		// process being starved of CPU on the 2-vCPU runner rather than any Kamaji-side
+		// bug: many tenant control planes, datastores, and their apiservers all compete
+		// for the same two cores. One minute sits well inside that observed stall, so
+		// the wait is widened to five for headroom above it.
 		Eventually(func() error {
 			return tcpClient.Get(context.Background(), types.NamespacedName{Name: "kamaji-freeze"}, &admissionregistrationv1.ValidatingWebhookConfiguration{})
-		}, time.Minute, time.Second).Should(Succeed())
+		}, 5*time.Minute, time.Second).Should(Succeed())
 
 		By("ensuring changes are not allowed")
 		Consistently(func() error {


### PR DESCRIPTION
## Summary

`e2e/tcp_migration_test.go` waits one minute for the `kamaji-freeze` `ValidatingWebhookConfiguration` to appear in the tenant cluster after a datastore migration starts. That budget sits *inside* the stall the manager routinely experiences on the CI runner, so the spec fails intermittently without anything being wrong in Kamaji.

This widens the wait to five minutes. One line, plus the rationale.

## Evidence

From GitHub Actions run 30307341733: the entire manager process — the host-side `tenantcontrolplane` controller across every TCP in the suite, plus this tenant's own soot sub-manager — went completely silent for **2m16s** (21:45:45 → 21:48:01 UTC), with no errors logged.

Nothing was failing; nothing was retrying. That signature is CPU starvation on the 2-vCPU runner, where many tenant control planes, datastores and their API servers all compete for two cores. A one-minute wait cannot survive a stall of that length.

## Why not treat it as a product bug

The webhook does get installed — just later than the spec allows. Nothing in the logs points at a reconcile failure, and the same spec passes consistently once the wait clears the stall. Tightening anything on the Kamaji side would be fixing the wrong thing.

The spec still fails if the webhook genuinely never arrives. It just stops failing when the runner is merely slow.

## Why this is a separate PR

This is currently the sole reason the `Kubernetes` job is red on #1252 and #1251, and it also lives inside #986. Splitting it out means those can go green without waiting on any of the feature reviews.

If you would rather it ride along with #986, say so and I will close this.
