### PR TITLE
chore: bump golangci-lint v2.0.2 -> v2.12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) CGO_ENABLED=0 go install -ldflags="-s -w" github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
+	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) CGO_ENABLED=0 go install -ldflags="-s -w" github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 .PHONY: apidocs-gen
 apidocs-gen: $(APIDOCS_GEN)  ## Download crdoc locally if necessary.


### PR DESCRIPTION
**PR: 1/12**

Bumps golangci-lint from v2.0.2 to v2.12.2 to enable newer linters and establish a baseline of ~174 linting issues to be fixed incrementally in subsequent PRs.