### PR TITLE
chore: resolve noctx linter issues (PR4)

### DIFF
--- a/e2e/utils_test.go
+++ b/e2e/utils_test.go
@@ -43,8 +43,8 @@ func PrintTenantControlPlaneInfo() {
 
 	tcp := tcpList.Items[0]
 
-	kubectlExec := func(args ...string) {
-		cmd := exec.Command("kubectl")
+	kubectlExec := func(ctx context.Context, args ...string) {
+		cmd := exec.CommandContext(ctx, "kubectl")
 
 		var out bytes.Buffer
 		cmd.Stdout = &out
@@ -65,20 +65,23 @@ func PrintTenantControlPlaneInfo() {
 	if CurrentSpecReport().Failed() {
 		_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: Tenant Control Plane definition")
 		kubectlExec(
-			fmt.Sprintf("--namespace=%s", tcp.GetNamespace()),
+			context.Background(),
+			"--namespace="+tcp.GetNamespace(),
 			"get",
 			"tcp",
 			tcp.GetName(),
 		)
 		_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: Tenant Control Plane resources")
 		kubectlExec(
-			fmt.Sprintf("--namespace=%s", tcp.GetNamespace()),
+			context.Background(),
+			"--namespace="+tcp.GetNamespace(),
 			"get",
 			"svc,deployment,pods,ep,configmap,secrets",
 		)
 		_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: Tenant Control Plane pods")
 		kubectlExec(
-			fmt.Sprintf("--namespace=%s", tcp.GetNamespace()),
+			context.Background(),
+			"--namespace="+tcp.GetNamespace(),
 			"describe",
 			"pods",
 		)

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -316,7 +316,7 @@ func (c *MySQLConnection) RevokePrivileges(ctx context.Context, user, dbName str
 }
 
 func (c *MySQLConnection) check(ctx context.Context, nonFilledStatement string, checker func(*sql.Row) (bool, error), args ...any) (bool, error) {
-	statement, err := c.db.Prepare(nonFilledStatement)
+	statement, err := c.db.PrepareContext(ctx, nonFilledStatement)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Use exec.CommandContext and db.PrepareContext instead of non-context versions.