### PR TITLE
chore: resolve noinlineerr linter issues (PR5)

### DIFF
--- a/api/v1alpha1/datastore_funcs.go
+++ b/api/v1alpha1/datastore_funcs.go
@@ -26,7 +26,8 @@ func (in *ContentRef) GetContent(ctx context.Context, client client.Client) ([]b
 	}
 
 	secret, namespacedName := &corev1.Secret{}, types.NamespacedName{Name: secretRef.Name, Namespace: secretRef.Namespace}
-	if err := client.Get(ctx, namespacedName, secret); err != nil {
+	err := client.Get(ctx, namespacedName, secret)
+	if err != nil {
 		return nil, err
 	}
 

--- a/api/v1alpha1/networkprofile_types_test.go
+++ b/api/v1alpha1/networkprofile_types_test.go
@@ -45,7 +45,8 @@ var _ = Describe("NetworkProfile validation", func() {
 		if tcp.Name == "" {
 			return
 		}
-		if err := k8sClient.Delete(ctx, tcp); err != nil && !apierrors.IsNotFound(err) {
+		err := k8sClient.Delete(ctx, tcp)
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})

--- a/api/v1alpha1/tenantcontrolplane_types_test.go
+++ b/api/v1alpha1/tenantcontrolplane_types_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Cluster controller", func() {
@@ -31,7 +30,8 @@ var _ = Describe("Cluster controller", func() {
 	})
 
 	AfterEach(func() {
-		if err := k8sClient.Delete(ctx, tcp); err != nil && !apierrors.IsNotFound(err) {
+		err := k8sClient.Delete(ctx, tcp)
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -123,7 +123,7 @@ var _ = Describe("Cluster controller", func() {
 	Context("AllocateLoadBalancerNodePorts", func() {
 		It("allows the field when service type is LoadBalancer", func() {
 			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeLoadBalancer
-			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = ptr.To(false)
+			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = new(false)
 
 			err := k8sClient.Create(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
@@ -138,7 +138,7 @@ var _ = Describe("Cluster controller", func() {
 
 		It("denies the field when service type is not LoadBalancer", func() {
 			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
-			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = ptr.To(false)
+			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = new(false)
 
 			err := k8sClient.Create(ctx, tcp)
 			Expect(err).To(HaveOccurred())

--- a/api/v1alpha1/tenantcontrolplane_types_test.go
+++ b/api/v1alpha1/tenantcontrolplane_types_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Cluster controller", func() {
@@ -123,7 +124,7 @@ var _ = Describe("Cluster controller", func() {
 	Context("AllocateLoadBalancerNodePorts", func() {
 		It("allows the field when service type is LoadBalancer", func() {
 			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeLoadBalancer
-			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = new(false)
+			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = ptr.To(false)
 
 			err := k8sClient.Create(ctx, tcp)
 			Expect(err).NotTo(HaveOccurred())
@@ -138,7 +139,7 @@ var _ = Describe("Cluster controller", func() {
 
 		It("denies the field when service type is not LoadBalancer", func() {
 			tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeNodePort
-			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = new(false)
+			tcp.Spec.ControlPlane.Service.AllocateLoadBalancerNodePorts = ptr.To(false)
 
 			err := k8sClient.Create(ctx, tcp)
 			Expect(err).To(HaveOccurred())

--- a/api/v1alpha1/validations_test.go
+++ b/api/v1alpha1/validations_test.go
@@ -30,7 +30,8 @@ var _ = Describe("Datastores validation test", func() {
 	})
 
 	AfterEach(func() {
-		if err := k8sClient.Delete(ctx, ds); err != nil && !apierrors.IsNotFound(err) {
+		err := k8sClient.Delete(ctx, ds)
+		if err != nil && !apierrors.IsNotFound(err) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})

--- a/cmd/kubeconfig-generator/cmd.go
+++ b/cmd/kubeconfig-generator/cmd.go
@@ -95,12 +95,14 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 
 			setupLog.Info("setting probes")
 			{
-				if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+				err = mgr.AddHealthzCheck("healthz", healthz.Ping)
+				if err != nil {
 					setupLog.Error(err, "unable to set up health check")
 
 					return err
 				}
-				if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+				err = mgr.AddReadyzCheck("readyz", healthz.Ping)
+				if err != nil {
 					setupLog.Error(err, "unable to set up ready check")
 
 					return err
@@ -109,33 +111,37 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 
 			certController := &controllers.CertificateLifecycle{Channel: triggerChan, Deadline: certificateExpirationDeadline, Metrics: metricsRecorder}
 			certController.EnqueueFn = certController.EnqueueForKubeconfigGenerator
-			if err = certController.SetupWithManager(mgr); err != nil {
+			err = certController.SetupWithManager(mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "CertificateLifecycle")
 
 				return err
 			}
 
-			if err = (&controllers.KubeconfigGeneratorWatcher{
+			err = (&controllers.KubeconfigGeneratorWatcher{
 				Client:        mgr.GetClient(),
 				GeneratorChan: triggerChan,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "KubeconfigGeneratorWatcher")
 
 				return err
 			}
 
-			if err = (&controllers.KubeconfigGeneratorReconciler{
+			err = (&controllers.KubeconfigGeneratorReconciler{
 				Client:            mgr.GetClient(),
 				NotValidThreshold: certificateExpirationDeadline,
 				CertificateChan:   triggerChan,
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "KubeconfigGenerator")
 
 				return err
 			}
 
 			setupLog.Info("starting manager")
-			if err = mgr.Start(ctx); err != nil {
+			err = mgr.Start(ctx)
+			if err != nil {
 				setupLog.Error(err, "problem running manager")
 
 				return err

--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -75,7 +75,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			klog.SetOutput(io.Discard)
 			klog.LogToStderr(false)
 
-			if err = cmdutils.CheckFlags(cmd.Flags(), []string{"kine-image", "migrate-image", "tmp-directory", "pod-namespace", "webhook-service-name", "serviceaccount-name", "webhook-ca-path"}...); err != nil {
+			err = cmdutils.CheckFlags(cmd.Flags(), []string{"kine-image", "migrate-image", "tmp-directory", "pod-namespace", "webhook-service-name", "serviceaccount-name", "webhook-ca-path"}...)
+			if err != nil {
 				return err
 			}
 
@@ -83,7 +84,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				return fmt.Errorf("certificate expiration deadline must be at least 24 hours")
 			}
 
-			if webhookCABundle, err = os.ReadFile(webhookCAPath); err != nil {
+			webhookCABundle, err = os.ReadFile(webhookCAPath)
+			if err != nil {
 				return fmt.Errorf("unable to read webhook CA: %w", err)
 			}
 
@@ -144,7 +146,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			tcpChannel, certChannel := make(chan event.GenericEvent), make(chan event.GenericEvent)
 			metricsRecorder := metrics.DefaultRecorder()
 
-			if err = (&controllers.DataStore{Client: mgr.GetClient(), Metrics: metricsRecorder, TenantControlPlaneTrigger: tcpChannel}).SetupWithManager(mgr); err != nil {
+			err = (&controllers.DataStore{Client: mgr.GetClient(), Metrics: metricsRecorder, TenantControlPlaneTrigger: tcpChannel}).SetupWithManager(mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "DataStore")
 
 				return err
@@ -178,7 +181,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				DiscoveryClient:         discoveryClient,
 			}
 
-			if err = reconciler.SetupWithManager(ctx, mgr); err != nil {
+			err = reconciler.SetupWithManager(ctx, mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "Namespace")
 
 				return err
@@ -210,19 +214,22 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			certController := &controllers.CertificateLifecycle{Channel: certChannel, Deadline: certificateExpirationDeadline, Metrics: metricsRecorder}
 			certController.EnqueueFn = certController.EnqueueForTenantControlPlane
 
-			if err = certController.SetupWithManager(mgr); err != nil {
+			err = certController.SetupWithManager(mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "CertificateLifecycle")
 
 				return err
 			}
 
-			if err = (&kamajiv1alpha1.DatastoreUsedSecret{}).SetupWithManager(ctx, mgr); err != nil {
+			err = (&kamajiv1alpha1.DatastoreUsedSecret{}).SetupWithManager(ctx, mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create indexer", "indexer", "DatastoreUsedSecret")
 
 				return err
 			}
 
-			if err = (&kamajiv1alpha1.TenantControlPlaneStatusDataStore{}).SetupWithManager(ctx, mgr); err != nil {
+			err = (&kamajiv1alpha1.TenantControlPlaneStatusDataStore{}).SetupWithManager(ctx, mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to create indexer", "indexer", "TenantControlPlaneStatusDataStore")
 
 				return err
@@ -230,7 +237,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 
 			// Only requires to look for the core api group.
 			if utilities.AreGatewayResourcesAvailable(ctx, mgr.GetClient(), discoveryClient) {
-				if err = (&kamajiv1alpha1.GatewayListener{}).SetupWithManager(ctx, mgr); err != nil {
+				err = (&kamajiv1alpha1.GatewayListener{}).SetupWithManager(ctx, mgr)
+				if err != nil {
 					setupLog.Error(err, "unable to create indexer", "indexer", "GatewayListener")
 
 					return err
@@ -285,30 +293,34 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				return err
 			}
 
-			if err = (&soot.Manager{
+			err = (&soot.Manager{
 				MigrateCABundle:         webhookCABundle,
 				MigrateServiceName:      managerServiceName,
 				MigrateServiceNamespace: managerNamespace,
 				AdminClient:             mgr.GetClient(),
-			}).SetupWithManager(mgr); err != nil {
+			}).SetupWithManager(mgr)
+			if err != nil {
 				setupLog.Error(err, "unable to set up soot manager")
 
 				return err
 			}
 
-			if err = mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+			err = mgr.AddHealthzCheck("healthz", healthz.Ping)
+			if err != nil {
 				setupLog.Error(err, "unable to set up health check")
 
 				return err
 			}
-			if err = mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+			err = mgr.AddReadyzCheck("readyz", healthz.Ping)
+			if err != nil {
 				setupLog.Error(err, "unable to set up ready check")
 
 				return err
 			}
 
 			setupLog.Info("starting manager")
-			if err = mgr.Start(ctx); err != nil {
+			err = mgr.Start(ctx)
+			if err != nil {
 				setupLog.Error(err, "problem running manager")
 
 				return err

--- a/cmd/migrate/cmd.go
+++ b/cmd/migrate/cmd.go
@@ -55,21 +55,24 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			log.Info("retrieving the TenantControlPlane")
 
 			tcp := &kamajiv1alpha1.TenantControlPlane{}
-			if err = client.Get(ctx, types.NamespacedName{Namespace: parts[0], Name: parts[1]}, tcp); err != nil {
+			err = client.Get(ctx, types.NamespacedName{Namespace: parts[0], Name: parts[1]}, tcp)
+			if err != nil {
 				return err
 			}
 
 			log.Info("retrieving the TenantControlPlane used DataStore")
 
 			originDs := &kamajiv1alpha1.DataStore{}
-			if err = client.Get(ctx, types.NamespacedName{Name: tcp.Status.Storage.DataStoreName}, originDs); err != nil {
+			err = client.Get(ctx, types.NamespacedName{Name: tcp.Status.Storage.DataStoreName}, originDs)
+			if err != nil {
 				return err
 			}
 
 			log.Info("retrieving the target DataStore")
 
 			targetDs := &kamajiv1alpha1.DataStore{}
-			if err = client.Get(ctx, types.NamespacedName{Name: targetDataStore}, targetDs); err != nil {
+			err = client.Get(ctx, types.NamespacedName{Name: targetDataStore}, targetDs)
+			if err != nil {
 				return err
 			}
 
@@ -103,7 +106,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				if exists, _ := targetConnection.DBExists(ctx, tcp.Status.Storage.Setup.Schema); exists {
 					log.Info("A colliding schema on target DataStore is present, cleaning up")
 
-					if dErr := targetConnection.DeleteDB(ctx, tcp.Status.Storage.Setup.Schema); dErr != nil {
+					dErr := targetConnection.DeleteDB(ctx, tcp.Status.Storage.Setup.Schema)
+					if dErr != nil {
 						return fmt.Errorf("error cleaning up prior migration: %s", dErr.Error())
 					}
 
@@ -113,7 +117,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			// Start migrating from the old Datastore to the new one
 			log.Info("migration from origin to target started")
 
-			if err = originConnection.Migrate(ctx, *tcp, targetConnection); err != nil {
+			err = originConnection.Migrate(ctx, *tcp, targetConnection)
+			if err != nil {
 				return fmt.Errorf("unable to migrate data from %s to %s: %w", originDs.GetName(), targetDs.GetName(), err)
 			}
 

--- a/controllers/certificate_lifecycle_controller.go
+++ b/controllers/certificate_lifecycle_controller.go
@@ -47,7 +47,8 @@ func (s *CertificateLifecycle) Reconcile(ctx context.Context, request reconcile.
 		metricCtx, cancelMetricCtx := metrics.NewRefreshContextFrom(c)
 		defer cancelMetricCtx()
 
-		if err := s.refreshCertificatesMetrics(metricCtx); err != nil {
+		err := s.refreshCertificatesMetrics(metricCtx)
+		if err != nil {
 			logger.WithName("metrics").Error(err, "cannot refresh certificate status gauges")
 		}
 	}(ctx)
@@ -55,7 +56,8 @@ func (s *CertificateLifecycle) Reconcile(ctx context.Context, request reconcile.
 	logger.Info("starting CertificateLifecycle handling")
 
 	var secret corev1.Secret
-	if err := s.client.Get(ctx, request.NamespacedName, &secret); err != nil {
+	err := s.client.Get(ctx, request.NamespacedName, &secret)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("resource may have been deleted, skipping")
 
@@ -81,7 +83,6 @@ func (s *CertificateLifecycle) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	var crt *x509.Certificate
-	var err error
 
 	switch checkType {
 	case utilities.CertificateX509Label:
@@ -151,7 +152,8 @@ func (s *CertificateLifecycle) extractCertificateFromBareSecret(secret corev1.Se
 	var err error
 
 	for _, v := range secret.Data {
-		if crt, err = crypto.ParseCertificateBytes(v); err == nil {
+		crt, err = crypto.ParseCertificateBytes(v)
+		if err == nil {
 			break
 		}
 	}
@@ -168,7 +170,8 @@ func (s *CertificateLifecycle) extractCertificateFromKubeconfig(secret corev1.Se
 	var err error
 
 	for k := range secret.Data {
-		if kc, err = utilities.DecodeKubeconfig(secret, k); err == nil {
+		kc, err = utilities.DecodeKubeconfig(secret, k)
+		if err == nil {
 			break
 		}
 	}
@@ -188,16 +191,18 @@ func (s *CertificateLifecycle) extractCertificateFromKubeconfig(secret corev1.Se
 func (s *CertificateLifecycle) SetupWithManager(mgr controllerruntime.Manager) error {
 	s.client = mgr.GetClient()
 
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		metricCtx, cancelMetricCtx := metrics.NewRefreshContextFrom(ctx)
 		defer cancelMetricCtx()
 
-		if err := s.refreshCertificatesMetrics(metricCtx); err != nil {
+		err := s.refreshCertificatesMetrics(metricCtx)
+		if err != nil {
 			controllerruntime.Log.WithName("metrics").Error(err, "cannot initialize certificate status gauges")
 		}
 
 		return nil
-	})); err != nil {
+	}))
+	if err != nil {
 		return err
 	}
 
@@ -228,7 +233,8 @@ func (s *CertificateLifecycle) refreshCertificatesMetrics(ctx context.Context) e
 	countsByTenantControlPlane := map[k8stypes.NamespacedName]map[string]map[string]int{}
 
 	var tenantControlPlaneList kamajiv1alpha1.TenantControlPlaneList
-	if err := s.client.List(ctx, &tenantControlPlaneList); err != nil {
+	err := s.client.List(ctx, &tenantControlPlaneList)
+	if err != nil {
 		return err
 	}
 
@@ -239,7 +245,8 @@ func (s *CertificateLifecycle) refreshCertificatesMetrics(ctx context.Context) e
 	}
 
 	var secretList corev1.SecretList
-	if err := s.client.List(ctx, &secretList); err != nil {
+	err = s.client.List(ctx, &secretList)
+	if err != nil {
 		return err
 	}
 

--- a/controllers/certificate_lifecycle_controller_metrics_test.go
+++ b/controllers/certificate_lifecycle_controller_metrics_test.go
@@ -29,10 +29,12 @@ func TestCertificateRefreshMetrics(t *testing.T) {
 	t.Parallel()
 
 	scheme := runtime.NewScheme()
-	if err := kamajiv1alpha1.AddToScheme(scheme); err != nil {
+	err := kamajiv1alpha1.AddToScheme(scheme)
+	if err != nil {
 		t.Fatalf("failed adding kamaji scheme: %v", err)
 	}
-	if err := corev1.AddToScheme(scheme); err != nil {
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
 		t.Fatalf("failed adding corev1 scheme: %v", err)
 	}
 
@@ -91,7 +93,8 @@ func TestCertificateRefreshMetrics(t *testing.T) {
 		Metrics:  recorder,
 	}
 
-	if err := s.refreshCertificatesMetrics(t.Context()); err != nil {
+	err = s.refreshCertificatesMetrics(t.Context())
+	if err != nil {
 		t.Fatalf("refreshCertificatesMetrics returned error: %v", err)
 	}
 

--- a/controllers/datastore_controller.go
+++ b/controllers/datastore_controller.go
@@ -50,13 +50,15 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 		metricCtx, cancelMetricCtx := metrics.NewRefreshContextFrom(c)
 		defer cancelMetricCtx()
 
-		if gaugeErr := r.refreshDatastoreMetrics(metricCtx); gaugeErr != nil {
+		gaugeErr := r.refreshDatastoreMetrics(metricCtx)
+		if gaugeErr != nil {
 			logger.WithName("metrics").Error(gaugeErr, "cannot refresh DataStore metrics")
 		}
 	}(ctx)
 
 	var ds kamajiv1alpha1.DataStore
-	if dsErr := r.Client.Get(ctx, request.NamespacedName, &ds); dsErr != nil {
+	dsErr := r.Client.Get(ctx, request.NamespacedName, &ds)
+	if dsErr != nil {
 		if k8serrors.IsNotFound(dsErr) {
 			logger.Info("resource may have been deleted, skipping")
 
@@ -78,7 +80,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 		logger.Info("missing finalizer, adding it")
 
 		ds.SetFinalizers(append(ds.GetFinalizers(), kamajiv1alpha1.DataStoreTCPFinalizer))
-		if uErr := r.Client.Update(ctx, &ds); uErr != nil {
+		uErr := r.Client.Update(ctx, &ds)
+		if uErr != nil {
 			return reconcile.Result{}, uErr
 		}
 
@@ -89,9 +92,10 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 	// that would be required, such as changing TLS Configuration, or Basic Auth.
 	var tcpList kamajiv1alpha1.TenantControlPlaneList
 
-	if lErr := r.Client.List(ctx, &tcpList, client.MatchingFieldsSelector{
+	lErr := r.Client.List(ctx, &tcpList, client.MatchingFieldsSelector{
 		Selector: fields.OneTermEqualSelector(kamajiv1alpha1.TenantControlPlaneUsedDataStoreKey, ds.GetName()),
-	}); lErr != nil {
+	})
+	if lErr != nil {
 		return reconcile.Result{}, fmt.Errorf("cannot retrieve list of the Tenant Control Plane using the following instance: %w", lErr)
 	}
 
@@ -110,7 +114,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 			logger.Info("removing finalizer upon true condition")
 
 			controllerutil.RemoveFinalizer(&ds, kamajiv1alpha1.DataStoreTCPFinalizer)
-			if uErr := r.Client.Update(ctx, &ds); uErr != nil {
+			uErr := r.Client.Update(ctx, &ds)
+			if uErr != nil {
 				logger.Error(uErr, "cannot update object")
 
 				return
@@ -124,7 +129,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 		ds.Status.ObservedGeneration = ds.Generation
 		ds.Status.Ready = meta.IsStatusConditionTrue(ds.Status.Conditions, kamajiv1alpha1.DataStoreConditionValidType)
 
-		if err = r.Client.Status().Update(ctx, &ds); err != nil {
+		err = r.Client.Status().Update(ctx, &ds)
+		if err != nil {
 			logger.Error(err, "cannot update the status for the given instance")
 
 			return
@@ -175,7 +181,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return reconcile.Result{}, nil
 	}
 
-	if exists := meta.FindStatusCondition(ds.Status.Conditions, kamajiv1alpha1.DataStoreConditionValidType); exists == nil {
+	exists := meta.FindStatusCondition(ds.Status.Conditions, kamajiv1alpha1.DataStoreConditionValidType)
+	if exists == nil {
 		logger.Info("missing starting condition")
 
 		meta.SetStatusCondition(&ds.Status.Conditions, metav1.Condition{
@@ -186,7 +193,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 			Message:            "Controller will process the validation.",
 		})
 
-		if sErr := r.Client.Status().Update(ctx, &ds); sErr != nil {
+		sErr := r.Client.Status().Update(ctx, &ds)
+		if sErr != nil {
 			return reconcile.Result{}, fmt.Errorf("cannot update the status for the given instance: %w", sErr)
 		}
 
@@ -196,7 +204,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if ds.Spec.BasicAuth != nil {
 		logger.Info("validating basic authentication")
 
-		if vErr := r.validateBasicAuth(ctx, ds); vErr != nil {
+		vErr := r.validateBasicAuth(ctx, ds)
+		if vErr != nil {
 			meta.SetStatusCondition(&ds.Status.Conditions, metav1.Condition{
 				Type:               kamajiv1alpha1.DataStoreConditionValidType,
 				Status:             metav1.ConditionFalse,
@@ -215,7 +224,8 @@ func (r *DataStore) Reconcile(ctx context.Context, request reconcile.Request) (r
 
 	logger.Info("validating TLS configuration")
 
-	if vErr := r.validateTLSConfig(ctx, ds); vErr != nil {
+	vErr := r.validateTLSConfig(ctx, ds)
+	if vErr != nil {
 		meta.SetStatusCondition(&ds.Status.Conditions, metav1.Condition{
 			Type:               kamajiv1alpha1.DataStoreConditionValidType,
 			Status:             metav1.ConditionFalse,
@@ -273,16 +283,18 @@ func (r *DataStore) triggerTenantControlPlanes(ctx context.Context, tcpList kama
 }
 
 func (r *DataStore) SetupWithManager(mgr controllerruntime.Manager) error {
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		metricCtx, cancelMetricCtx := metrics.NewRefreshContextFrom(ctx)
 		defer cancelMetricCtx()
 
-		if err := r.refreshDatastoreMetrics(metricCtx); err != nil {
+		err := r.refreshDatastoreMetrics(metricCtx)
+		if err != nil {
 			controllerruntime.Log.WithName("metrics").Error(err, "cannot initialize DataStore metrics")
 		}
 
 		return nil
-	})); err != nil {
+	}))
+	if err != nil {
 		return err
 	}
 
@@ -312,7 +324,8 @@ func (r *DataStore) SetupWithManager(mgr controllerruntime.Manager) error {
 		}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			var dsList kamajiv1alpha1.DataStoreList
-			if err := r.Client.List(ctx, &dsList, client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(kamajiv1alpha1.DatastoreUsedSecretNamespacedNameKey, fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName()))}); err != nil {
+			err := r.Client.List(ctx, &dsList, client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(kamajiv1alpha1.DatastoreUsedSecretNamespacedNameKey, fmt.Sprintf("%s/%s", object.GetNamespace(), object.GetName()))})
+			if err != nil {
 				return nil
 			}
 
@@ -331,7 +344,8 @@ func (r *DataStore) SetupWithManager(mgr controllerruntime.Manager) error {
 func (r *DataStore) refreshDatastoreMetrics(ctx context.Context) error {
 	var dataStoreList kamajiv1alpha1.DataStoreList
 
-	if err := r.Client.List(ctx, &dataStoreList); err != nil {
+	err := r.Client.List(ctx, &dataStoreList)
+	if err != nil {
 		return err
 	}
 
@@ -388,11 +402,13 @@ func classifyDataStoreStatusLabel(ds *kamajiv1alpha1.DataStore) string {
 }
 
 func (r *DataStore) validateBasicAuth(ctx context.Context, ds kamajiv1alpha1.DataStore) error {
-	if err := r.validateContentReference(ctx, ds.Spec.BasicAuth.Password); err != nil {
+	err := r.validateContentReference(ctx, ds.Spec.BasicAuth.Password)
+	if err != nil {
 		return fmt.Errorf("basic-auth password is not valid, %w", err)
 	}
 
-	if err := r.validateContentReference(ctx, ds.Spec.BasicAuth.Username); err != nil {
+	err = r.validateContentReference(ctx, ds.Spec.BasicAuth.Username)
+	if err != nil {
 		return fmt.Errorf("basic-auth username is not valid, %w", err)
 	}
 
@@ -404,7 +420,8 @@ func (r *DataStore) validateTLSConfig(ctx context.Context, ds kamajiv1alpha1.Dat
 		return nil
 	}
 
-	if err := r.validateContentReference(ctx, ds.Spec.TLSConfig.CertificateAuthority.Certificate); err != nil {
+	err := r.validateContentReference(ctx, ds.Spec.TLSConfig.CertificateAuthority.Certificate)
+	if err != nil {
 		return fmt.Errorf("CA certificate is not valid, %w", err)
 	}
 
@@ -419,17 +436,20 @@ func (r *DataStore) validateTLSConfig(ctx context.Context, ds kamajiv1alpha1.Dat
 	}
 
 	if ds.Spec.TLSConfig.CertificateAuthority.PrivateKey != nil {
-		if err := r.validateContentReference(ctx, *ds.Spec.TLSConfig.CertificateAuthority.PrivateKey); err != nil {
+		err := r.validateContentReference(ctx, *ds.Spec.TLSConfig.CertificateAuthority.PrivateKey)
+		if err != nil {
 			return fmt.Errorf("CA private key is not valid, %w", err)
 		}
 	}
 
 	if ds.Spec.TLSConfig.ClientCertificate != nil {
-		if err := r.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.Certificate); err != nil {
+		err := r.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.Certificate)
+		if err != nil {
 			return fmt.Errorf("client certificate is not valid, %w", err)
 		}
 
-		if err := r.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.PrivateKey); err != nil {
+		err = r.validateContentReference(ctx, ds.Spec.TLSConfig.ClientCertificate.PrivateKey)
+		if err != nil {
 			return fmt.Errorf("client private key is not valid, %w", err)
 		}
 	}
@@ -449,7 +469,8 @@ func (r *DataStore) validateContentReference(ctx context.Context, ref kamajiv1al
 		return fmt.Errorf("the Secret reference namespace is mandatory")
 	}
 
-	if err := r.Client.Get(ctx, k8stypes.NamespacedName{Name: ref.SecretRef.SecretReference.Name, Namespace: ref.SecretRef.SecretReference.Namespace}, &corev1.Secret{}); err != nil {
+	err := r.Client.Get(ctx, k8stypes.NamespacedName{Name: ref.SecretRef.SecretReference.Name, Namespace: ref.SecretRef.SecretReference.Namespace}, &corev1.Secret{})
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return fmt.Errorf("secret %s/%s is not found", ref.SecretRef.SecretReference.Namespace, ref.SecretRef.SecretReference.Name)
 		}

--- a/controllers/datastore_controller_metrics_test.go
+++ b/controllers/datastore_controller_metrics_test.go
@@ -20,7 +20,8 @@ func TestDataStoreRefreshMetrics(t *testing.T) {
 	t.Parallel()
 
 	scheme := runtime.NewScheme()
-	if err := kamajiv1alpha1.AddToScheme(scheme); err != nil {
+	err := kamajiv1alpha1.AddToScheme(scheme)
+	if err != nil {
 		t.Fatalf("failed adding kamaji scheme: %v", err)
 	}
 
@@ -51,7 +52,8 @@ func TestDataStoreRefreshMetrics(t *testing.T) {
 		Metrics: recorder,
 	}
 
-	if err := r.refreshDatastoreMetrics(t.Context()); err != nil {
+	err = r.refreshDatastoreMetrics(t.Context())
+	if err != nil {
 		t.Fatalf("refreshDatastoreMetrics returned error: %v", err)
 	}
 

--- a/controllers/kubeconfiggenerator_controller.go
+++ b/controllers/kubeconfiggenerator_controller.go
@@ -61,7 +61,8 @@ func (r *KubeconfigGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.
 	logger.Info("reconciling resource")
 
 	var generator kamajiv1alpha1.KubeconfigGenerator
-	if err := r.Client.Get(ctx, req.NamespacedName, &generator); err != nil {
+	err := r.Client.Get(ctx, req.NamespacedName, &generator)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("resource may have been deleted, skipping")
 
@@ -89,7 +90,8 @@ func (r *KubeconfigGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.
 	generator.Status = status
 	generator.Status.ObservedGeneration = generator.Generation
 
-	if statusErr := r.Client.Status().Update(ctx, &generator); statusErr != nil {
+	statusErr := r.Client.Status().Update(ctx, &generator)
+	if statusErr != nil {
 		logger.Error(statusErr, "cannot update resource status")
 
 		return ctrl.Result{}, statusErr
@@ -107,7 +109,8 @@ func (r *KubeconfigGeneratorReconciler) handle(ctx context.Context, generator *k
 	}
 
 	var namespaceList corev1.NamespaceList
-	if err := r.Client.List(ctx, &namespaceList, &client.ListOptions{LabelSelector: nsSelector}); err != nil {
+	err := r.Client.List(ctx, &namespaceList, &client.ListOptions{LabelSelector: nsSelector})
+	if err != nil {
 		return kamajiv1alpha1.KubeconfigGeneratorStatus{}, fmt.Errorf("cannot filter Namespace objects using provided selector: %w", err)
 	}
 
@@ -120,7 +123,8 @@ func (r *KubeconfigGeneratorReconciler) handle(ctx context.Context, generator *k
 		}
 
 		var tcpList kamajiv1alpha1.TenantControlPlaneList
-		if err := r.Client.List(ctx, &tcpList, &client.ListOptions{Namespace: ns.GetName(), LabelSelector: tcpSelector}); err != nil {
+		err := r.Client.List(ctx, &tcpList, &client.ListOptions{Namespace: ns.GetName(), LabelSelector: tcpSelector})
+		if err != nil {
 			return kamajiv1alpha1.KubeconfigGeneratorStatus{}, fmt.Errorf("cannot filter TenantControlPlane objects using provided selector: %w", err)
 		}
 
@@ -137,7 +141,8 @@ func (r *KubeconfigGeneratorReconciler) handle(ctx context.Context, generator *k
 	}
 
 	for _, tcp := range targets {
-		if err := r.process(ctx, generator, tcp); err != nil {
+		err := r.process(ctx, generator, tcp)
+		if err != nil {
 			status.Errors = append(status.Errors, *err)
 			status.AvailableResources--
 		}
@@ -159,7 +164,8 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 		return &statusErr
 	}
 
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: tcp.Status.KubeConfig.Admin.SecretName, Namespace: tcp.GetNamespace()}, &adminSecret); err != nil {
+	err := r.Client.Get(ctx, types.NamespacedName{Name: tcp.Status.KubeConfig.Admin.SecretName, Namespace: tcp.GetNamespace()}, &adminSecret)
+	if err != nil {
 		statusErr.Message = fmt.Sprintf("an error occurred retrieving the admin Kubeconfig: %s", err.Error())
 
 		return &statusErr
@@ -237,14 +243,16 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 
 	objectKey := client.ObjectKeyFromObject(&resultSecret)
 
-	if err := r.Client.Get(ctx, objectKey, &resultSecret); err != nil {
+	err = r.Client.Get(ctx, objectKey, &resultSecret)
+	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			statusErr.Message = fmt.Sprintf("the secret %q cannot be generated", objectKey.String())
 
 			return &statusErr
 		}
 
-		if generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, groups, user); generateErr != nil {
+		generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, groups, user)
+		if generateErr != nil {
 			statusErr.Message = fmt.Sprintf("an error occurred generating the %q Secret: %s", objectKey.String(), generateErr.Error())
 
 			return &statusErr
@@ -256,7 +264,8 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 	isValid, validateErr := r.isValid(&resultSecret, kubeconfigTmpl, groups, user)
 	switch {
 	case !isValid:
-		if generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, groups, user); generateErr != nil {
+		generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, groups, user)
+		if generateErr != nil {
 			statusErr.Message = fmt.Sprintf("an error occurred regenerating the %q Secret: %s", objectKey.String(), generateErr.Error())
 
 			return &statusErr
@@ -289,7 +298,8 @@ func (r *KubeconfigGeneratorReconciler) generate(ctx context.Context, generator 
 	}
 
 	var caSecret corev1.Secret
-	if caErr := r.Client.Get(ctx, types.NamespacedName{Namespace: tcp.Namespace, Name: tcp.Status.Certificates.CA.SecretName}, &caSecret); caErr != nil {
+	caErr := r.Client.Get(ctx, types.NamespacedName{Namespace: tcp.Namespace, Name: tcp.Status.Certificates.CA.SecretName}, &caSecret)
+	if caErr != nil {
 		return fmt.Errorf("cannot retrieve Certificate Authority: %w", caErr)
 	}
 
@@ -348,7 +358,8 @@ func (r *KubeconfigGeneratorReconciler) generate(ctx context.Context, generator 
 			utilities.SetLastRotationTimestamp(secret)
 		}
 
-		if orErr := controllerutil.SetOwnerReference(tcp, secret, r.Client.Scheme()); orErr != nil {
+		orErr := controllerutil.SetOwnerReference(tcp, secret, r.Client.Scheme())
+		if orErr != nil {
 			return orErr
 		}
 

--- a/controllers/kubeconfiggenerator_watcher.go
+++ b/controllers/kubeconfiggenerator_watcher.go
@@ -29,7 +29,8 @@ func (r *KubeconfigGeneratorWatcher) Reconcile(ctx context.Context, req ctrl.Req
 	logger.Info("reconciling resource")
 
 	var tcp kamajiv1alpha1.TenantControlPlane
-	if err := r.Client.Get(ctx, req.NamespacedName, &tcp); err != nil {
+	err := r.Client.Get(ctx, req.NamespacedName, &tcp)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("resource may have been deleted, skipping")
 
@@ -42,7 +43,8 @@ func (r *KubeconfigGeneratorWatcher) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	var generators kamajiv1alpha1.KubeconfigGeneratorList
-	if err := r.Client.List(ctx, &generators); err != nil {
+	err = r.Client.List(ctx, &generators)
+	if err != nil {
 		logger.Error(err, "cannot list generators")
 
 		return ctrl.Result{}, err

--- a/controllers/soot/controllers/coredns.go
+++ b/controllers/soot/controllers/coredns.go
@@ -11,7 +11,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,7 +67,8 @@ func (c *CoreDNS) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile
 		return reconcile.Result{}, nil
 	}
 
-	if err = utils.UpdateStatus(ctx, c.AdminClient, tcp, resource); err != nil {
+	err = utils.UpdateStatus(ctx, c.AdminClient, tcp, resource)
+	if err != nil {
 		c.Logger.Error(err, "update status failed", "resource", resource.GetName())
 
 		return reconcile.Result{}, err
@@ -82,7 +82,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile
 func (c *CoreDNS) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(c.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		For(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == kubeadm.CoreDNSClusterRoleBindingName
 		}))).

--- a/controllers/soot/controllers/coredns.go
+++ b/controllers/soot/controllers/coredns.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,8 +68,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile
 		return reconcile.Result{}, nil
 	}
 
-	err = utils.UpdateStatus(ctx, c.AdminClient, tcp, resource)
-	if err != nil {
+	if err = utils.UpdateStatus(ctx, c.AdminClient, tcp, resource); err != nil {
 		c.Logger.Error(err, "update status failed", "resource", resource.GetName())
 
 		return reconcile.Result{}, err
@@ -82,7 +82,7 @@ func (c *CoreDNS) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile
 func (c *CoreDNS) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(c.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == kubeadm.CoreDNSClusterRoleBindingName
 		}))).

--- a/controllers/soot/controllers/konnectivity.go
+++ b/controllers/soot/controllers/konnectivity.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,7 +73,8 @@ func (k *KonnectivityAgent) Reconcile(ctx context.Context, _ reconcile.Request) 
 			continue
 		}
 
-		if err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource); err != nil {
+		err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource)
+		if err != nil {
 			k.Logger.Error(err, "update status failed", "resource", resource.GetName())
 
 			return reconcile.Result{}, err
@@ -89,7 +89,7 @@ func (k *KonnectivityAgent) Reconcile(ctx context.Context, _ reconcile.Request) 
 func (k *KonnectivityAgent) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(k.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		For(&appsv1.DaemonSet{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == konnectivity.AgentName && object.GetNamespace() == konnectivity.AgentNamespace
 		}))).

--- a/controllers/soot/controllers/konnectivity.go
+++ b/controllers/soot/controllers/konnectivity.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,8 +74,7 @@ func (k *KonnectivityAgent) Reconcile(ctx context.Context, _ reconcile.Request) 
 			continue
 		}
 
-		err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource)
-		if err != nil {
+		if err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource); err != nil {
 			k.Logger.Error(err, "update status failed", "resource", resource.GetName())
 
 			return reconcile.Result{}, err
@@ -89,7 +89,7 @@ func (k *KonnectivityAgent) Reconcile(ctx context.Context, _ reconcile.Request) 
 func (k *KonnectivityAgent) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(k.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&appsv1.DaemonSet{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == konnectivity.AgentName && object.GetNamespace() == konnectivity.AgentNamespace
 		}))).

--- a/controllers/soot/controllers/kubeadm_phase.go
+++ b/controllers/soot/controllers/kubeadm_phase.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
-	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -61,7 +60,8 @@ func (k *KubeadmPhase) Reconcile(ctx context.Context, _ reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	if err = utils.UpdateStatus(ctx, k.Phase.GetClient(), tcp, k.Phase); err != nil {
+	err = utils.UpdateStatus(ctx, k.Phase.GetClient(), tcp, k.Phase)
+	if err != nil {
 		k.logger.Error(err, "update status failed")
 
 		return reconcile.Result{}, err
@@ -77,7 +77,7 @@ func (k *KubeadmPhase) SetupWithManager(mgr manager.Manager) error {
 
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(k.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		For(k.Phase.GetWatchedObject(), builder.WithPredicates(predicate.NewPredicateFuncs(k.Phase.GetPredicateFunc()))).
 		WatchesRawSource(source.Channel(k.TriggerChannel, &handler.EnqueueRequestForObject{})).
 		Complete(k)

--- a/controllers/soot/controllers/kubeadm_phase.go
+++ b/controllers/soot/controllers/kubeadm_phase.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -60,8 +61,7 @@ func (k *KubeadmPhase) Reconcile(ctx context.Context, _ reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	err = utils.UpdateStatus(ctx, k.Phase.GetClient(), tcp, k.Phase)
-	if err != nil {
+	if err = utils.UpdateStatus(ctx, k.Phase.GetClient(), tcp, k.Phase); err != nil {
 		k.logger.Error(err, "update status failed")
 
 		return reconcile.Result{}, err
@@ -77,7 +77,7 @@ func (k *KubeadmPhase) SetupWithManager(mgr manager.Manager) error {
 
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(k.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(k.Phase.GetWatchedObject(), builder.WithPredicates(predicate.NewPredicateFuncs(k.Phase.GetPredicateFunc()))).
 		WatchesRawSource(source.Channel(k.TriggerChannel, &handler.EnqueueRequestForObject{})).
 		Complete(k)

--- a/controllers/soot/controllers/kubeproxy.go
+++ b/controllers/soot/controllers/kubeproxy.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,8 +70,7 @@ func (k *KubeProxy) Reconcile(ctx context.Context, _ reconcile.Request) (reconci
 		return reconcile.Result{}, nil
 	}
 
-	err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource)
-	if err != nil {
+	if err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource); err != nil {
 		k.Logger.Error(err, "update status failed")
 
 		return reconcile.Result{}, err
@@ -84,7 +84,7 @@ func (k *KubeProxy) Reconcile(ctx context.Context, _ reconcile.Request) (reconci
 func (k *KubeProxy) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(k.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == kubeadm.KubeProxyClusterRoleBindingName
 		}))).

--- a/controllers/soot/controllers/kubeproxy.go
+++ b/controllers/soot/controllers/kubeproxy.go
@@ -11,7 +11,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,7 +69,8 @@ func (k *KubeProxy) Reconcile(ctx context.Context, _ reconcile.Request) (reconci
 		return reconcile.Result{}, nil
 	}
 
-	if err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource); err != nil {
+	err = utils.UpdateStatus(ctx, k.AdminClient, tcp, resource)
+	if err != nil {
 		k.Logger.Error(err, "update status failed")
 
 		return reconcile.Result{}, err
@@ -84,7 +84,7 @@ func (k *KubeProxy) Reconcile(ctx context.Context, _ reconcile.Request) (reconci
 func (k *KubeProxy) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(k.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		For(&rbacv1.ClusterRoleBinding{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == kubeadm.KubeProxyClusterRoleBindingName
 		}))).

--- a/controllers/soot/controllers/migrate.go
+++ b/controllers/soot/controllers/migrate.go
@@ -13,7 +13,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,7 +74,8 @@ func (m *Migrate) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile
 }
 
 func (m *Migrate) cleanup(ctx context.Context) error {
-	if err := m.Client.Delete(ctx, m.object()); err != nil {
+	err := m.Client.Delete(ctx, m.object())
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -94,7 +94,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 			{
 				Name: "leases.migrate.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
+					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
 					CABundle: m.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -138,7 +138,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 			{
 				Name: "catchall.migrate.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
+					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
 					CABundle: m.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -189,7 +189,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 func (m *Migrate) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(m.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: pointer.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		For(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			vwc := m.object()
 

--- a/controllers/soot/controllers/migrate.go
+++ b/controllers/soot/controllers/migrate.go
@@ -13,6 +13,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pointer "k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -94,7 +95,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 			{
 				Name: "leases.migrate.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
+					URL:      pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
 					CABundle: m.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -138,7 +139,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 			{
 				Name: "catchall.migrate.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
+					URL:      pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
 					CABundle: m.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -189,7 +190,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 func (m *Migrate) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(m.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: pointer.To(true)}).
 		For(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			vwc := m.object()
 

--- a/controllers/soot/controllers/write_permissions.go
+++ b/controllers/soot/controllers/write_permissions.go
@@ -83,7 +83,7 @@ func (r *WritePermissions) createOrUpdate(ctx context.Context, writePermissions 
 			{
 				Name: "leases.write-permissions.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      ptr.To(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
+					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
 					CABundle: r.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -119,7 +119,7 @@ func (r *WritePermissions) createOrUpdate(ctx context.Context, writePermissions 
 			{
 				Name: "catchall.write-permissions.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      ptr.To(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
+					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
 					CABundle: r.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -176,7 +176,8 @@ func (r *WritePermissions) createOrUpdate(ctx context.Context, writePermissions 
 }
 
 func (r *WritePermissions) cleanup(ctx context.Context) error {
-	if err := r.Client.Delete(ctx, r.object()); err != nil {
+	err := r.Client.Delete(ctx, r.object())
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -190,7 +191,7 @@ func (r *WritePermissions) cleanup(ctx context.Context) error {
 func (r *WritePermissions) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(r.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		For(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == r.object().GetName()
 		}))).

--- a/controllers/soot/controllers/write_permissions.go
+++ b/controllers/soot/controllers/write_permissions.go
@@ -83,7 +83,7 @@ func (r *WritePermissions) createOrUpdate(ctx context.Context, writePermissions 
 			{
 				Name: "leases.write-permissions.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
+					URL:      ptr.To(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
 					CABundle: r.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -119,7 +119,7 @@ func (r *WritePermissions) createOrUpdate(ctx context.Context, writePermissions 
 			{
 				Name: "catchall.write-permissions.kamaji.clastix.io",
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      new(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
+					URL:      ptr.To(fmt.Sprintf("https://%s.%s.svc:443/write-permission", r.WebhookServiceName, r.WebhookNamespace)),
 					CABundle: r.WebhookCABundle,
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{
@@ -191,7 +191,7 @@ func (r *WritePermissions) cleanup(ctx context.Context) error {
 func (r *WritePermissions) SetupWithManager(mgr manager.Manager) error {
 	return controllerruntime.NewControllerManagedBy(mgr).
 		Named(r.ControllerName).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		For(&admissionregistrationv1.ValidatingWebhookConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return object.GetName() == r.object().GetName()
 		}))).

--- a/controllers/soot/manager.go
+++ b/controllers/soot/manager.go
@@ -68,8 +68,7 @@ func (m *Manager) retrieveTenantControlPlane(ctx context.Context, request reconc
 	return func() (*kamajiv1alpha1.TenantControlPlane, error) {
 		tcp := &kamajiv1alpha1.TenantControlPlane{}
 
-		err := m.AdminClient.Get(ctx, request.NamespacedName, tcp)
-		if err != nil {
+		if err := m.AdminClient.Get(ctx, request.NamespacedName, tcp); err != nil {
 			return nil, err
 		}
 
@@ -281,8 +280,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-writepermissions", controllerNamePrefix),
 	}
-	err = writePermissions.SetupWithManager(mgr)
-	if err != nil {
+	if err = writePermissions.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -296,8 +294,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-migrate", controllerNamePrefix),
 	}
-	err = migrate.SetupWithManager(mgr)
-	if err != nil {
+	if err = migrate.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -308,8 +305,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-konnectivity", controllerNamePrefix),
 	}
-	err = konnectivityAgent.SetupWithManager(mgr)
-	if err != nil {
+	if err = konnectivityAgent.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -320,8 +316,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-kubeproxy", controllerNamePrefix),
 	}
-	err = kubeProxy.SetupWithManager(mgr)
-	if err != nil {
+	if err = kubeProxy.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -332,8 +327,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-coredns", controllerNamePrefix),
 	}
-	err = coreDNS.SetupWithManager(mgr)
-	if err != nil {
+	if err = coreDNS.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -346,8 +340,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeadmconfig", controllerNamePrefix),
 	}
-	err = uploadKubeadmConfig.SetupWithManager(mgr)
-	if err != nil {
+	if err = uploadKubeadmConfig.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -360,8 +353,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeletconfig", controllerNamePrefix),
 	}
-	err = uploadKubeletConfig.SetupWithManager(mgr)
-	if err != nil {
+	if err = uploadKubeletConfig.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -374,8 +366,7 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-bootstraptoken", controllerNamePrefix),
 	}
-	err = bootstrapToken.SetupWithManager(mgr)
-	if err != nil {
+	if err = bootstrapToken.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -388,15 +379,13 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeadmrbac", controllerNamePrefix),
 	}
-	err = kubeadmRbac.SetupWithManager(mgr)
-	if err != nil {
+	if err = kubeadmRbac.SetupWithManager(mgr); err != nil {
 		return reconcile.Result{}, err
 	}
 	completedCh := make(chan struct{})
 	// Starting the manager
 	go func() {
-		err = mgr.Start(tcpCtx)
-		if err != nil {
+		if err = mgr.Start(tcpCtx); err != nil {
 			logger.Error(err, "unable to start soot manager")
 			// The sootManagerAnnotation is used to propagate the error between reconciliations with its state:
 			// this is required to avoid mutex and prevent concurrent read/write on the soot map
@@ -444,7 +433,7 @@ func (m *Manager) SetupWithManager(mgr manager.Manager) error {
 	m.sootMap = make(map[string]sootItem)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
 		WatchesRawSource(source.Channel(m.sootManagerErrChan, &handler.EnqueueRequestForObject{})).
 		For(&kamajiv1alpha1.TenantControlPlane{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			obj := object.(*kamajiv1alpha1.TenantControlPlane) //nolint:forcetypeassert

--- a/controllers/soot/manager.go
+++ b/controllers/soot/manager.go
@@ -68,7 +68,8 @@ func (m *Manager) retrieveTenantControlPlane(ctx context.Context, request reconc
 	return func() (*kamajiv1alpha1.TenantControlPlane, error) {
 		tcp := &kamajiv1alpha1.TenantControlPlane{}
 
-		if err := m.AdminClient.Get(ctx, request.NamespacedName, tcp); err != nil {
+		err := m.AdminClient.Get(ctx, request.NamespacedName, tcp)
+		if err != nil {
 			return nil, err
 		}
 
@@ -155,7 +156,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 	// Retrieving the TenantControlPlane:
 	// in case of deletion, we must be sure to properly remove from the memory the soot manager.
 	tcp := &kamajiv1alpha1.TenantControlPlane{}
-	if err = m.AdminClient.Get(ctx, request.NamespacedName, tcp); err != nil {
+	err = m.AdminClient.Get(ctx, request.NamespacedName, tcp)
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, m.cleanup(ctx, request, nil)
 		}
@@ -279,7 +281,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-writepermissions", controllerNamePrefix),
 	}
-	if err = writePermissions.SetupWithManager(mgr); err != nil {
+	err = writePermissions.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -293,7 +296,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-migrate", controllerNamePrefix),
 	}
-	if err = migrate.SetupWithManager(mgr); err != nil {
+	err = migrate.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -304,7 +308,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-konnectivity", controllerNamePrefix),
 	}
-	if err = konnectivityAgent.SetupWithManager(mgr); err != nil {
+	err = konnectivityAgent.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -315,7 +320,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-kubeproxy", controllerNamePrefix),
 	}
-	if err = kubeProxy.SetupWithManager(mgr); err != nil {
+	err = kubeProxy.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -326,7 +332,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel:            make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName:            fmt.Sprintf("%s-coredns", controllerNamePrefix),
 	}
-	if err = coreDNS.SetupWithManager(mgr); err != nil {
+	err = coreDNS.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -339,7 +346,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeadmconfig", controllerNamePrefix),
 	}
-	if err = uploadKubeadmConfig.SetupWithManager(mgr); err != nil {
+	err = uploadKubeadmConfig.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -352,7 +360,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeletconfig", controllerNamePrefix),
 	}
-	if err = uploadKubeletConfig.SetupWithManager(mgr); err != nil {
+	err = uploadKubeletConfig.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -365,7 +374,8 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-bootstraptoken", controllerNamePrefix),
 	}
-	if err = bootstrapToken.SetupWithManager(mgr); err != nil {
+	err = bootstrapToken.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -378,13 +388,15 @@ func (m *Manager) Reconcile(ctx context.Context, request reconcile.Request) (res
 		TriggerChannel: make(chan event.GenericEvent, utils.CoalesceTriggerChannelBufferSize),
 		ControllerName: fmt.Sprintf("%s-kubeadmrbac", controllerNamePrefix),
 	}
-	if err = kubeadmRbac.SetupWithManager(mgr); err != nil {
+	err = kubeadmRbac.SetupWithManager(mgr)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 	completedCh := make(chan struct{})
 	// Starting the manager
 	go func() {
-		if err = mgr.Start(tcpCtx); err != nil {
+		err = mgr.Start(tcpCtx)
+		if err != nil {
 			logger.Error(err, "unable to start soot manager")
 			// The sootManagerAnnotation is used to propagate the error between reconciliations with its state:
 			// this is required to avoid mutex and prevent concurrent read/write on the soot map
@@ -432,7 +444,7 @@ func (m *Manager) SetupWithManager(mgr manager.Manager) error {
 	m.sootMap = make(map[string]sootItem)
 
 	return controllerruntime.NewControllerManagedBy(mgr).
-		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: ptr.To(true)}).
+		WithOptions(controller.TypedOptions[reconcile.Request]{SkipNameValidation: new(true)}).
 		WatchesRawSource(source.Channel(m.sootManagerErrChan, &handler.EnqueueRequestForObject{})).
 		For(&kamajiv1alpha1.TenantControlPlane{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			obj := object.(*kamajiv1alpha1.TenantControlPlane) //nolint:forcetypeassert

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -30,7 +30,8 @@ type TelemetryController struct {
 
 func (m *TelemetryController) retrieveControllerUID(ctx context.Context) (string, error) {
 	var defaultSvc corev1.Service
-	if err := m.Client.Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, &defaultSvc); err != nil {
+	err := m.Client.Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, &defaultSvc)
+	if err != nil {
 		return "", fmt.Errorf("cannot start the telemetry controller: %w", err)
 	}
 
@@ -74,7 +75,8 @@ func (m *TelemetryController) collectStats(ctx context.Context, uid string) {
 	}
 
 	var tcpList kamajiv1alpha1.TenantControlPlaneList
-	if err := m.Client.List(ctx, &tcpList); err != nil {
+	err := m.Client.List(ctx, &tcpList)
+	if err != nil {
 		logger.Error(err, "cannot list TenantControlPlane")
 
 		return
@@ -94,7 +96,8 @@ func (m *TelemetryController) collectStats(ctx context.Context, uid string) {
 	}
 
 	var datastoreList kamajiv1alpha1.DataStoreList
-	if err := m.Client.List(ctx, &datastoreList); err != nil {
+	err = m.Client.List(ctx, &datastoreList)
+	if err != nil {
 		logger.Error(err, "cannot list DataStores")
 
 		return

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -100,7 +100,8 @@ func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		metricCtx, cancelMetricCtx := metrics.NewRefreshContextFrom(c)
 		defer cancelMetricCtx()
 
-		if err := r.refreshTenantControlPlaneMetrics(metricCtx); err != nil {
+		err := r.refreshTenantControlPlaneMetrics(metricCtx)
+		if err != nil {
 			log.WithName("metrics").Error(err, "cannot refresh TenantControlPlane metrics")
 		}
 	}(ctx)
@@ -213,7 +214,8 @@ func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		for _, resource := range GetDeletableResources(tenantControlPlane, groupDeletableResourceBuilderConfiguration) {
-			if err = resources.HandleDeletion(ctx, resource, tenantControlPlane); err != nil {
+			err = resources.HandleDeletion(ctx, resource, tenantControlPlane)
+			if err != nil {
 				log.Error(err, "resource deletion failed", "resource", resource.GetName())
 
 				return ctrl.Result{}, err
@@ -260,7 +262,8 @@ func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			continue
 		}
 
-		if err = utils.UpdateStatus(ctx, r.Client, tenantControlPlane, resource); err != nil {
+		err = utils.UpdateStatus(ctx, r.Client, tenantControlPlane, resource)
+		if err != nil {
 			if kamajierrors.ShouldReconcileErrorBeIgnored(err) {
 				log.V(1).Info("sentinel error, enqueuing back request", "error", err.Error())
 
@@ -286,15 +289,17 @@ func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Set ObservedGeneration only on successful reconciliation completion.
 	// This follows Cluster API conventions where ObservedGeneration indicates
 	// the controller has fully processed the given generation.
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if getErr := r.Client.Get(ctx, req.NamespacedName, tenantControlPlane); getErr != nil {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		getErr := r.Client.Get(ctx, req.NamespacedName, tenantControlPlane)
+		if getErr != nil {
 			return getErr
 		}
 
 		tenantControlPlane.Status.ObservedGeneration = tenantControlPlane.Generation
 
 		return r.Client.Status().Update(ctx, tenantControlPlane)
-	}); err != nil {
+	})
+	if err != nil {
 		log.Error(err, "failed to update ObservedGeneration")
 
 		return ctrl.Result{}, err
@@ -317,16 +322,18 @@ func (r *TenantControlPlaneReconciler) mutexSpec(obj client.Object) mutex.Spec {
 func (r *TenantControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	r.clock = clock.RealClock{}
 
-	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+	err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		metricCtx, cancelMetricCtx := metrics.NewRefreshContextFrom(ctx)
 		defer cancelMetricCtx()
 
-		if err := r.refreshTenantControlPlaneMetrics(metricCtx); err != nil {
+		err := r.refreshTenantControlPlaneMetrics(metricCtx)
+		if err != nil {
 			ctrl.Log.WithName("metrics").Error(err, "cannot initialize TenantControlPlane metrics")
 		}
 
 		return nil
-	})); err != nil {
+	}))
+	if err != nil {
 		return err
 	}
 
@@ -403,7 +410,8 @@ func (r *TenantControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr
 func (r *TenantControlPlaneReconciler) refreshTenantControlPlaneMetrics(ctx context.Context) error {
 	var tcpList kamajiv1alpha1.TenantControlPlaneList
 
-	if err := r.Client.List(ctx, &tcpList); err != nil {
+	err := r.Client.List(ctx, &tcpList)
+	if err != nil {
 		return err
 	}
 
@@ -490,7 +498,8 @@ func formatHTTPSAddress(host string, port int32) string {
 func (r *TenantControlPlaneReconciler) getTenantControlPlane(ctx context.Context, namespacedName k8stypes.NamespacedName) utils.TenantControlPlaneRetrievalFn {
 	return func() (*kamajiv1alpha1.TenantControlPlane, error) {
 		tcp := &kamajiv1alpha1.TenantControlPlane{}
-		if err := r.APIReader.Get(ctx, namespacedName, tcp); err != nil {
+		err := r.APIReader.Get(ctx, namespacedName, tcp)
+		if err != nil {
 			return nil, err
 		}
 
@@ -518,7 +527,8 @@ func (r *TenantControlPlaneReconciler) dataStore(ctx context.Context, tenantCont
 	}
 
 	var ds kamajiv1alpha1.DataStore
-	if err := r.Client.Get(ctx, k8stypes.NamespacedName{Name: tenantControlPlane.Spec.DataStore}, &ds); err != nil {
+	err := r.Client.Get(ctx, k8stypes.NamespacedName{Name: tenantControlPlane.Spec.DataStore}, &ds)
+	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve *kamajiv1alpha.DataStore object: %w", err)
 	}
 
@@ -530,7 +540,8 @@ func (r *TenantControlPlaneReconciler) dataStoreOverride(ctx context.Context, te
 
 	for _, dso := range tenantControlPlane.Spec.DataStoreOverrides {
 		var ds kamajiv1alpha1.DataStore
-		if err := r.Client.Get(ctx, k8stypes.NamespacedName{Name: dso.DataStore}, &ds); err != nil {
+		err := r.Client.Get(ctx, k8stypes.NamespacedName{Name: dso.DataStore}, &ds)
+		if err != nil {
 			return nil, fmt.Errorf("cannot retrieve *kamajiv1alpha.DataStore object: %w", err)
 		}
 		if ds.Spec.Driver != kamajiv1alpha1.EtcdDriver {

--- a/controllers/utils/update_status.go
+++ b/controllers/utils/update_status.go
@@ -23,11 +23,13 @@ func UpdateStatus(ctx context.Context, client client.Client, tcp *kamajiv1alpha1
 			}
 		}()
 
-		if err = resource.UpdateTenantControlPlaneStatus(ctx, tcp); err != nil {
+		err = resource.UpdateTenantControlPlaneStatus(ctx, tcp)
+		if err != nil {
 			return fmt.Errorf("error applying TenantcontrolPlane status: %w", err)
 		}
 
-		if err = client.Status().Update(ctx, tcp); err != nil {
+		err = client.Status().Update(ctx, tcp)
+		if err != nil {
 			return fmt.Errorf("error updating tenantControlPlane status: %w", err)
 		}
 

--- a/e2e/tcp_gateway_konnectivity_ready_test.go
+++ b/e2e/tcp_gateway_konnectivity_ready_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: new(int32(1)),
+						Replicas: pointer.To(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "ClusterIP",

--- a/e2e/tcp_gateway_konnectivity_ready_test.go
+++ b/e2e/tcp_gateway_konnectivity_ready_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: pointer.To(int32(1)),
+						Replicas: new(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "ClusterIP",
@@ -100,10 +100,11 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 	It("Should create control plane TLSRoute preserving user-provided parentRef fields", func() {
 		Eventually(func() error {
 			route := &gatewayv1.TLSRoute{}
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
-			}, route); err != nil {
+			}, route)
+			if err != nil {
 				return err
 			}
 			if len(route.Spec.ParentRefs) == 0 {
@@ -129,10 +130,11 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 	It("Should create Konnectivity TLSRoute with correct sectionName", func() {
 		Eventually(func() error {
 			route := &gatewayv1.TLSRoute{}
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",
 				Namespace: tcp.Namespace,
-			}, route); err != nil {
+			}, route)
+			if err != nil {
 				return err
 			}
 			if len(route.Spec.ParentRefs) == 0 {
@@ -152,18 +154,20 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API and Konnectivity"
 	It("Should use same hostname for both TLSRoutes", func() {
 		Eventually(func() error {
 			controlPlaneRoute := &gatewayv1.TLSRoute{}
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
-			}, controlPlaneRoute); err != nil {
+			}, controlPlaneRoute)
+			if err != nil {
 				return err
 			}
 
 			konnectivityRoute := &gatewayv1.TLSRoute{}
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			err = k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name + "-konnectivity",
 				Namespace: tcp.Namespace,
-			}, konnectivityRoute); err != nil {
+			}, konnectivityRoute)
+			if err != nil {
 				return err
 			}
 

--- a/e2e/tcp_gateway_ready_test.go
+++ b/e2e/tcp_gateway_ready_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: pointer.To(int32(1)),
+						Replicas: new(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "ClusterIP",
@@ -95,10 +95,11 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 		Eventually(func() error {
 			route := &gatewayv1.TLSRoute{}
 			// TODO: Check ownership.
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{
+			err := k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      tcp.Name,
 				Namespace: tcp.Namespace,
-			}, route); err != nil {
+			}, route)
+			if err != nil {
 				return err
 			}
 			if len(route.Spec.ParentRefs) == 0 {

--- a/e2e/tcp_gateway_ready_test.go
+++ b/e2e/tcp_gateway_ready_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Deploy a TenantControlPlane with Gateway API", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: new(int32(1)),
+						Replicas: pointer.To(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "ClusterIP",

--- a/e2e/tcp_migration_test.go
+++ b/e2e/tcp_migration_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
+	pointer "k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
@@ -36,7 +37,7 @@ func featureTestMigration(driver string) {
 				DataStore: fmt.Sprintf("%s-bronze", driver),
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: new(int32(1)),
+						Replicas: pointer.To(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "NodePort",

--- a/e2e/tcp_migration_test.go
+++ b/e2e/tcp_migration_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
-	pointer "k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
@@ -37,7 +36,7 @@ func featureTestMigration(driver string) {
 				DataStore: fmt.Sprintf("%s-bronze", driver),
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: pointer.To(int32(1)),
+						Replicas: new(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "NodePort",
@@ -88,7 +87,8 @@ func featureTestMigration(driver string) {
 
 		By("start migration to a new DataStore")
 		Eventually(func() error {
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp); err != nil {
+			err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp)
+			if err != nil {
 				return err
 			}
 
@@ -115,7 +115,8 @@ func featureTestMigration(driver string) {
 
 		By("checking the DataStore of the TCP")
 		Eventually(func() string {
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: tcp.GetName(), Namespace: tcp.GetNamespace()}, tcp); err != nil {
+			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: tcp.GetName(), Namespace: tcp.GetNamespace()}, tcp)
+			if err != nil {
 				return ""
 			}
 

--- a/e2e/tcp_postgres_datastore_config_secret_test.go
+++ b/e2e/tcp_postgres_datastore_config_secret_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
-	pointer "k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
@@ -31,7 +30,7 @@ var _ = Describe("When the datastore-config Secret is corrupted for a PostgreSQL
 			DataStore: "postgresql-bronze",
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",
@@ -57,10 +56,11 @@ var _ = Describe("When the datastore-config Secret is corrupted for a PostgreSQL
 		initialPodUIDs := sets.New[types.UID]()
 		Eventually(func() int {
 			podList := &corev1.PodList{}
-			if err := k8sClient.List(context.Background(), podList,
+			err := k8sClient.List(context.Background(), podList,
 				client.InNamespace(tcp.GetNamespace()),
 				client.MatchingLabels{"kamaji.clastix.io/name": tcp.GetName()},
-			); err != nil {
+			)
+			if err != nil {
 				return 0
 			}
 
@@ -83,7 +83,8 @@ var _ = Describe("When the datastore-config Secret is corrupted for a PostgreSQL
 
 		By("corrupting the DB_PASSWORD in the datastore-config Secret")
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&secret), &secret); err != nil {
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&secret), &secret)
+			if err != nil {
 				return err
 			}
 
@@ -95,7 +96,8 @@ var _ = Describe("When the datastore-config Secret is corrupted for a PostgreSQL
 
 		By("waiting for the controller to detect the corruption and regenerate the Secret with a new checksum")
 		Eventually(func() string {
-			if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&secret), &secret); err != nil {
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&secret), &secret)
+			if err != nil {
 				return ""
 			}
 
@@ -105,10 +107,11 @@ var _ = Describe("When the datastore-config Secret is corrupted for a PostgreSQL
 		By("waiting for at least one new TenantControlPlane pod to replace the pre-existing ones")
 		Eventually(func() bool {
 			var podList corev1.PodList
-			if err := k8sClient.List(context.Background(), &podList,
+			err := k8sClient.List(context.Background(), &podList,
 				client.InNamespace(tcp.GetNamespace()),
 				client.MatchingLabels{"kamaji.clastix.io/name": tcp.GetName()},
-			); err != nil {
+			)
+			if err != nil {
 				return false
 			}
 			for _, pod := range podList.Items {

--- a/e2e/tcp_postgres_datastore_config_secret_test.go
+++ b/e2e/tcp_postgres_datastore_config_secret_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
+	pointer "k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
@@ -30,7 +31,7 @@ var _ = Describe("When the datastore-config Secret is corrupted for a PostgreSQL
 			DataStore: "postgresql-bronze",
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: new(int32(1)),
+					Replicas: pointer.To(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_ready_test.go
+++ b/e2e/tcp_ready_test.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	pointer "k8s.io/utils/ptr"
-
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
@@ -26,7 +24,7 @@ var _ = Describe("Deploy a TenantControlPlane resource", func() {
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",
@@ -64,7 +62,8 @@ var _ = Describe("Deploy a TenantControlPlane resource", func() {
 		// ObservedGeneration is set at the end of successful reconciliation,
 		// after status becomes Ready, so we need to wait for it.
 		Eventually(func() int64 {
-			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: tcp.GetName(), Namespace: tcp.GetNamespace()}, tcp); err != nil {
+			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: tcp.GetName(), Namespace: tcp.GetNamespace()}, tcp)
+			if err != nil {
 				return -1
 			}
 

--- a/e2e/tcp_ready_test.go
+++ b/e2e/tcp_ready_test.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	pointer "k8s.io/utils/ptr"
+
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
@@ -24,7 +26,7 @@ var _ = Describe("Deploy a TenantControlPlane resource", func() {
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: new(int32(1)),
+					Replicas: pointer.To(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/worker_tcp_change_port_test.go
+++ b/e2e/worker_tcp_change_port_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	pointer "k8s.io/utils/ptr"
+
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
@@ -37,7 +39,7 @@ var _ = Describe("validating kubeconfig", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: new(int32(1)),
+						Replicas: pointer.To(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "NodePort",
@@ -78,8 +80,7 @@ var _ = Describe("validating kubeconfig", func() {
 			Eventually(func() string {
 				By(fmt.Sprintf("ensuring TCP port is set to %d", port), func() {
 					Eventually(func() (err error) {
-						err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp)
-						if err != nil {
+						if err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp); err != nil {
 							_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: cannot retrieve TCP:", err.Error())
 
 							return err
@@ -115,8 +116,7 @@ var _ = Describe("validating kubeconfig", func() {
 
 						secret := &corev1.Secret{}
 
-						err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.Status.KubeConfig.Admin.SecretName}, secret)
-						if err != nil {
+						if err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.Status.KubeConfig.Admin.SecretName}, secret); err != nil {
 							_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: cannot retrieve kubeconfig secret name:", err.Error())
 
 							return err

--- a/e2e/worker_tcp_change_port_test.go
+++ b/e2e/worker_tcp_change_port_test.go
@@ -17,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	pointer "k8s.io/utils/ptr"
-
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
@@ -39,7 +37,7 @@ var _ = Describe("validating kubeconfig", func() {
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: pointer.To(int32(1)),
+						Replicas: new(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "NodePort",
@@ -80,7 +78,8 @@ var _ = Describe("validating kubeconfig", func() {
 			Eventually(func() string {
 				By(fmt.Sprintf("ensuring TCP port is set to %d", port), func() {
 					Eventually(func() (err error) {
-						if err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp); err != nil {
+						err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp)
+						if err != nil {
 							_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: cannot retrieve TCP:", err.Error())
 
 							return err
@@ -94,7 +93,8 @@ var _ = Describe("validating kubeconfig", func() {
 
 				By("ensuring port change is defined in the TCP status", func() {
 					Eventually(func() int32 {
-						if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp); err != nil {
+						err := k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp)
+						if err != nil {
 							_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: cannot retrieve TCP:", err.Error())
 
 							return 0
@@ -106,7 +106,8 @@ var _ = Describe("validating kubeconfig", func() {
 
 				By("ensuring downloading the updated kubeconfig", func() {
 					Eventually(func() (err error) {
-						if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp); err != nil {
+						err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp)
+						if err != nil {
 							_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: cannot retrieve TCP:", err.Error())
 
 							return err
@@ -114,7 +115,8 @@ var _ = Describe("validating kubeconfig", func() {
 
 						secret := &corev1.Secret{}
 
-						if err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.Status.KubeConfig.Admin.SecretName}, secret); err != nil {
+						err = k8sClient.Get(ctx, types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.Status.KubeConfig.Admin.SecretName}, secret)
+						if err != nil {
 							_, _ = fmt.Fprintln(GinkgoWriter, "DEBUG: cannot retrieve kubeconfig secret name:", err.Error())
 
 							return err

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"maps"
 	"path"
 	"sort"
 	"strings"
@@ -294,7 +293,7 @@ func (d Deployment) buildPKIVolume(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.T
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
 			Sources:     sources,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 }
@@ -310,7 +309,7 @@ func (d Deployment) buildCAVolume(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.Te
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Certificates.CA.SecretName,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 }
@@ -326,7 +325,7 @@ func (d Deployment) buildShareCAVolume(podSpec *corev1.PodSpec, tcp kamajiv1alph
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Certificates.CA.SecretName,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 }
@@ -342,7 +341,7 @@ func (d Deployment) buildLocalShareCAVolume(podSpec *corev1.PodSpec, tcp kamajiv
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Certificates.CA.SecretName,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 }
@@ -358,7 +357,7 @@ func (d Deployment) buildSchedulerVolume(podSpec *corev1.PodSpec, tcp kamajiv1al
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.KubeConfig.Scheduler.SecretName,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 }
@@ -374,7 +373,7 @@ func (d Deployment) buildControllerManagerVolume(podSpec *corev1.PodSpec, tcp ka
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.KubeConfig.ControllerManager.SecretName,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 }
@@ -421,13 +420,11 @@ func (d Deployment) buildScheduler(podSpec *corev1.PodSpec, tenantControlPlane k
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/healthz", 10259)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/healthz", 10259)
 
-	probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes
-	if probes != nil {
+	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.Scheduler)
 	}
 
-	containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts
-	if containerSecurityContexts != nil {
+	if containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts; containerSecurityContexts != nil {
 		podSpec.Containers[index].SecurityContext = containerSecurityContexts.Scheduler
 	} else {
 		podSpec.Containers[index].SecurityContext = nil
@@ -444,8 +441,7 @@ func (d Deployment) buildScheduler(podSpec *corev1.PodSpec, tenantControlPlane k
 	// Volume mounts
 	var extraVolumeMounts []corev1.VolumeMount
 
-	additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts
-	if additionalVolumeMounts != nil {
+	if additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts; additionalVolumeMounts != nil {
 		extraVolumeMounts = append(extraVolumeMounts, additionalVolumeMounts.Scheduler...)
 	}
 
@@ -493,8 +489,7 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 		"--use-service-account-credentials":  "true",
 	}
 
-	extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs
-	if extraArgs != nil && len(extraArgs.ControllerManager) > 0 {
+	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil && len(extraArgs.ControllerManager) > 0 {
 		args = utilities.MergeMaps(args, utilities.ArgsFromSliceToMap(extraArgs.ControllerManager))
 	}
 
@@ -506,13 +501,11 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/healthz", 10257)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/healthz", 10257)
 
-	probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes
-	if probes != nil {
+	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.ControllerManager)
 	}
 
-	containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts
-	if containerSecurityContexts != nil {
+	if containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts; containerSecurityContexts != nil {
 		podSpec.Containers[index].SecurityContext = containerSecurityContexts.ControllerManager
 	} else {
 		podSpec.Containers[index].SecurityContext = nil
@@ -529,8 +522,7 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 	// Volume mounts
 	var extraVolumeMounts []corev1.VolumeMount
 
-	additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts
-	if additionalVolumeMounts != nil {
+	if additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts; additionalVolumeMounts != nil {
 		extraVolumeMounts = append(extraVolumeMounts, additionalVolumeMounts.ControllerManager...)
 	}
 
@@ -612,13 +604,11 @@ func (d Deployment) buildKubeAPIServer(podSpec *corev1.PodSpec, tenantControlPla
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/readyz", tenantControlPlane.Spec.NetworkProfile.Port)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/livez", tenantControlPlane.Spec.NetworkProfile.Port)
 
-	probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes
-	if probes != nil {
+	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.APIServer)
 	}
 
-	containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts
-	if containerSecurityContexts != nil {
+	if containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts; containerSecurityContexts != nil {
 		podSpec.Containers[index].SecurityContext = containerSecurityContexts.APIServer
 	} else {
 		podSpec.Containers[index].SecurityContext = nil
@@ -628,8 +618,7 @@ func (d Deployment) buildKubeAPIServer(podSpec *corev1.PodSpec, tenantControlPla
 	// Volume mounts
 	var extraVolumeMounts []corev1.VolumeMount
 
-	additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts
-	if additionalVolumeMounts != nil {
+	if additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts; additionalVolumeMounts != nil {
 		extraVolumeMounts = append(extraVolumeMounts, additionalVolumeMounts.APIServer...)
 	}
 
@@ -907,7 +896,7 @@ func (d Deployment) buildKineVolume(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Storage.Certificate.SecretName,
-			DefaultMode: new(int32(420)),
+			DefaultMode: pointer.To(int32(420)),
 		},
 	}
 	// Adding the volume to read Kine certificates:
@@ -1017,7 +1006,9 @@ func (d Deployment) buildKine(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.Tenant
 		utilArgs := utilities.ArgsFromSliceToMap(tcp.Spec.ControlPlane.Deployment.ExtraArgs.Kine)
 
 		// Merging the user-space arguments with the Kamaji ones.
-		maps.Copy(args, utilArgs)
+		for k, v := range utilArgs {
+			args[k] = v
+		}
 	}
 
 	switch d.DataStore.Spec.Driver {
@@ -1096,7 +1087,7 @@ func (d Deployment) setReplicas(deploymentSpec *appsv1.DeploymentSpec, tcp kamaj
 
 func (d Deployment) setRuntimeClass(spec *corev1.PodSpec, tcp kamajiv1alpha1.TenantControlPlane) {
 	if len(tcp.Spec.ControlPlane.Deployment.RuntimeClassName) > 0 {
-		spec.RuntimeClassName = new(tcp.Spec.ControlPlane.Deployment.RuntimeClassName)
+		spec.RuntimeClassName = pointer.To(tcp.Spec.ControlPlane.Deployment.RuntimeClassName)
 
 		return
 	}

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
+	"maps"
 	"path"
 	"sort"
 	"strings"
@@ -293,7 +294,7 @@ func (d Deployment) buildPKIVolume(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.T
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
 			Sources:     sources,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 }
@@ -309,7 +310,7 @@ func (d Deployment) buildCAVolume(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.Te
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Certificates.CA.SecretName,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 }
@@ -325,7 +326,7 @@ func (d Deployment) buildShareCAVolume(podSpec *corev1.PodSpec, tcp kamajiv1alph
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Certificates.CA.SecretName,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 }
@@ -341,7 +342,7 @@ func (d Deployment) buildLocalShareCAVolume(podSpec *corev1.PodSpec, tcp kamajiv
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Certificates.CA.SecretName,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 }
@@ -357,7 +358,7 @@ func (d Deployment) buildSchedulerVolume(podSpec *corev1.PodSpec, tcp kamajiv1al
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.KubeConfig.Scheduler.SecretName,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 }
@@ -373,7 +374,7 @@ func (d Deployment) buildControllerManagerVolume(podSpec *corev1.PodSpec, tcp ka
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.KubeConfig.ControllerManager.SecretName,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 }
@@ -420,11 +421,13 @@ func (d Deployment) buildScheduler(podSpec *corev1.PodSpec, tenantControlPlane k
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/healthz", 10259)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/healthz", 10259)
 
-	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
+	probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes
+	if probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.Scheduler)
 	}
 
-	if containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts; containerSecurityContexts != nil {
+	containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts
+	if containerSecurityContexts != nil {
 		podSpec.Containers[index].SecurityContext = containerSecurityContexts.Scheduler
 	} else {
 		podSpec.Containers[index].SecurityContext = nil
@@ -441,7 +444,8 @@ func (d Deployment) buildScheduler(podSpec *corev1.PodSpec, tenantControlPlane k
 	// Volume mounts
 	var extraVolumeMounts []corev1.VolumeMount
 
-	if additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts; additionalVolumeMounts != nil {
+	additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts
+	if additionalVolumeMounts != nil {
 		extraVolumeMounts = append(extraVolumeMounts, additionalVolumeMounts.Scheduler...)
 	}
 
@@ -489,7 +493,8 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 		"--use-service-account-credentials":  "true",
 	}
 
-	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil && len(extraArgs.ControllerManager) > 0 {
+	extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs
+	if extraArgs != nil && len(extraArgs.ControllerManager) > 0 {
 		args = utilities.MergeMaps(args, utilities.ArgsFromSliceToMap(extraArgs.ControllerManager))
 	}
 
@@ -501,11 +506,13 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/healthz", 10257)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/healthz", 10257)
 
-	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
+	probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes
+	if probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.ControllerManager)
 	}
 
-	if containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts; containerSecurityContexts != nil {
+	containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts
+	if containerSecurityContexts != nil {
 		podSpec.Containers[index].SecurityContext = containerSecurityContexts.ControllerManager
 	} else {
 		podSpec.Containers[index].SecurityContext = nil
@@ -522,7 +529,8 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 	// Volume mounts
 	var extraVolumeMounts []corev1.VolumeMount
 
-	if additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts; additionalVolumeMounts != nil {
+	additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts
+	if additionalVolumeMounts != nil {
 		extraVolumeMounts = append(extraVolumeMounts, additionalVolumeMounts.ControllerManager...)
 	}
 
@@ -604,11 +612,13 @@ func (d Deployment) buildKubeAPIServer(podSpec *corev1.PodSpec, tenantControlPla
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/readyz", tenantControlPlane.Spec.NetworkProfile.Port)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/livez", tenantControlPlane.Spec.NetworkProfile.Port)
 
-	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
+	probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes
+	if probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.APIServer)
 	}
 
-	if containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts; containerSecurityContexts != nil {
+	containerSecurityContexts := tenantControlPlane.Spec.ControlPlane.Deployment.ContainerSecurityContexts
+	if containerSecurityContexts != nil {
 		podSpec.Containers[index].SecurityContext = containerSecurityContexts.APIServer
 	} else {
 		podSpec.Containers[index].SecurityContext = nil
@@ -618,7 +628,8 @@ func (d Deployment) buildKubeAPIServer(podSpec *corev1.PodSpec, tenantControlPla
 	// Volume mounts
 	var extraVolumeMounts []corev1.VolumeMount
 
-	if additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts; additionalVolumeMounts != nil {
+	additionalVolumeMounts := tenantControlPlane.Spec.ControlPlane.Deployment.AdditionalVolumeMounts
+	if additionalVolumeMounts != nil {
 		extraVolumeMounts = append(extraVolumeMounts, additionalVolumeMounts.APIServer...)
 	}
 
@@ -896,7 +907,7 @@ func (d Deployment) buildKineVolume(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.
 	podSpec.Volumes[index].VolumeSource = corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
 			SecretName:  tcp.Status.Storage.Certificate.SecretName,
-			DefaultMode: pointer.To(int32(420)),
+			DefaultMode: new(int32(420)),
 		},
 	}
 	// Adding the volume to read Kine certificates:
@@ -1006,9 +1017,7 @@ func (d Deployment) buildKine(podSpec *corev1.PodSpec, tcp kamajiv1alpha1.Tenant
 		utilArgs := utilities.ArgsFromSliceToMap(tcp.Spec.ControlPlane.Deployment.ExtraArgs.Kine)
 
 		// Merging the user-space arguments with the Kamaji ones.
-		for k, v := range utilArgs {
-			args[k] = v
-		}
+		maps.Copy(args, utilArgs)
 	}
 
 	switch d.DataStore.Spec.Driver {
@@ -1087,7 +1096,7 @@ func (d Deployment) setReplicas(deploymentSpec *appsv1.DeploymentSpec, tcp kamaj
 
 func (d Deployment) setRuntimeClass(spec *corev1.PodSpec, tcp kamajiv1alpha1.TenantControlPlane) {
 	if len(tcp.Spec.ControlPlane.Deployment.RuntimeClassName) > 0 {
-		spec.RuntimeClassName = pointer.To(tcp.Spec.ControlPlane.Deployment.RuntimeClassName)
+		spec.RuntimeClassName = new(tcp.Spec.ControlPlane.Deployment.RuntimeClassName)
 
 		return
 	}
@@ -1122,7 +1131,8 @@ func (d Deployment) templateLabels(ctx context.Context, tenantControlPlane *kama
 // secretHashValue function returns the md5 value for the secret of the given name and namespace.
 func (d Deployment) secretHashValue(ctx context.Context, client client.Client, namespace, name string) (string, error) {
 	secret := &corev1.Secret{}
-	if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret); err != nil {
+	err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret)
+	if err != nil {
 		return "", fmt.Errorf("cannot retrieve *corev1.Secret for resource version retrieval: %w", err)
 	}
 

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -56,7 +56,8 @@ func CheckCertificateNamesAndIPs(certificateBytes []byte, entries []string) (boo
 	dns := sets.New[string](crt.DNSNames...)
 
 	for _, e := range entries {
-		if ip := net.ParseIP(e); ip != nil {
+		ip := net.ParseIP(e)
+		if ip != nil {
 			if !ips.Has(ip.String()) {
 				return false, nil
 			}
@@ -231,20 +232,22 @@ func generateCertificateKeyPairBytes(template *x509.Certificate, caCert *x509.Ce
 	}
 
 	certPEM := &bytes.Buffer{}
-	if err = pem.Encode(certPEM, &pem.Block{
+	err = pem.Encode(certPEM, &pem.Block{
 		Type:    "CERTIFICATE",
 		Headers: nil,
 		Bytes:   certBytes,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, nil, fmt.Errorf("cannot encode the generate certificate bytes: %w", err)
 	}
 
 	certPrivKeyPEM := &bytes.Buffer{}
-	if err = pem.Encode(certPrivKeyPEM, &pem.Block{
+	err = pem.Encode(certPrivKeyPEM, &pem.Block{
 		Type:    "RSA PRIVATE KEY",
 		Headers: nil,
 		Bytes:   x509.MarshalPKCS1PrivateKey(certPrivKey),
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, nil, fmt.Errorf("cannot encode private key: %w", err)
 	}
 

--- a/internal/datastore/etcd.go
+++ b/internal/datastore/etcd.go
@@ -6,6 +6,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"go.etcd.io/etcd/api/v3/authpb"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -42,7 +43,8 @@ type EtcdClient struct {
 }
 
 func (e *EtcdClient) CreateUser(ctx context.Context, user, password string) error {
-	if _, err := e.Client.Auth.UserAddWithOptions(ctx, user, password, &etcdclient.UserAddOptions{NoPassword: true}); err != nil {
+	_, err := e.Client.Auth.UserAddWithOptions(ctx, user, password, &etcdclient.UserAddOptions{NoPassword: true})
+	if err != nil {
 		return dserrors.NewCreateUserError(err)
 	}
 
@@ -58,18 +60,21 @@ func (e *EtcdClient) CreateDB(context.Context, string) error {
 }
 
 func (e *EtcdClient) GrantPrivileges(ctx context.Context, user, dbName string) error {
-	if _, err := e.Client.Auth.RoleAdd(ctx, dbName); err != nil {
+	_, err := e.Client.Auth.RoleAdd(ctx, dbName)
+	if err != nil {
 		return dserrors.NewGrantPrivilegesError(err)
 	}
 
 	permission := etcdclient.PermissionType(authpb.READWRITE)
 	key := e.buildKey(dbName)
 
-	if _, err := e.Client.RoleGrantPermission(ctx, dbName, key, etcdclient.GetPrefixRangeEnd(key), permission); err != nil {
+	_, err = e.Client.RoleGrantPermission(ctx, dbName, key, etcdclient.GetPrefixRangeEnd(key), permission)
+	if err != nil {
 		return dserrors.NewGrantPrivilegesError(err)
 	}
 
-	if _, err := e.Client.UserGrantRole(ctx, user, dbName); err != nil {
+	_, err = e.Client.UserGrantRole(ctx, user, dbName)
+	if err != nil {
 		return dserrors.NewGrantPrivilegesError(err)
 	}
 
@@ -77,7 +82,8 @@ func (e *EtcdClient) GrantPrivileges(ctx context.Context, user, dbName string) e
 }
 
 func (e *EtcdClient) UserExists(ctx context.Context, user string) (bool, error) {
-	if _, err := e.Client.UserGet(ctx, user); err != nil {
+	_, err := e.Client.UserGet(ctx, user)
+	if err != nil {
 		// Convert gRPC error to comparable EtcdError using rpctypes.Error(),
 		// then compare against the client-side error constant.
 		// The == comparison is correct here as rpctypes.Error() normalizes
@@ -115,17 +121,16 @@ func (e *EtcdClient) GrantPrivilegesExists(ctx context.Context, username, dbName
 		return false, dserrors.NewCheckGrantExistsError(err)
 	}
 
-	for _, i := range user.Roles {
-		if i == dbName {
-			return true, nil
-		}
+	if slices.Contains(user.Roles, dbName) {
+		return true, nil
 	}
 
 	return false, nil
 }
 
 func (e *EtcdClient) DeleteUser(ctx context.Context, user string) error {
-	if _, err := e.Client.Auth.UserDelete(ctx, user); err != nil {
+	_, err := e.Client.Auth.UserDelete(ctx, user)
+	if err != nil {
 		return dserrors.NewDeleteUserError(err)
 	}
 
@@ -134,7 +139,8 @@ func (e *EtcdClient) DeleteUser(ctx context.Context, user string) error {
 
 func (e *EtcdClient) DeleteDB(ctx context.Context, dbName string) error {
 	prefix := e.buildKey(dbName)
-	if _, err := e.Client.Delete(ctx, prefix, etcdclient.WithPrefix()); err != nil {
+	_, err := e.Client.Delete(ctx, prefix, etcdclient.WithPrefix())
+	if err != nil {
 		return dserrors.NewCannotDeleteDatabaseError(err)
 	}
 
@@ -142,7 +148,8 @@ func (e *EtcdClient) DeleteDB(ctx context.Context, dbName string) error {
 }
 
 func (e *EtcdClient) RevokePrivileges(ctx context.Context, _, dbName string) error {
-	if _, err := e.Client.Auth.RoleDelete(ctx, dbName); err != nil {
+	_, err := e.Client.Auth.RoleDelete(ctx, dbName)
+	if err != nil {
 		return dserrors.NewRevokePrivilegesError(err)
 	}
 
@@ -156,7 +163,8 @@ func (e *EtcdClient) GetConnectionString() string {
 }
 
 func (e *EtcdClient) Close() error {
-	if err := e.Client.Close(); err != nil {
+	err := e.Client.Close()
+	if err != nil {
 		return dserrors.NewCloseConnectionError(err)
 	}
 
@@ -164,7 +172,8 @@ func (e *EtcdClient) Close() error {
 }
 
 func (e *EtcdClient) Check(ctx context.Context) error {
-	if _, err := e.Client.AuthStatus(ctx); err != nil {
+	_, err := e.Client.AuthStatus(ctx)
+	if err != nil {
 		return dserrors.NewCheckConnectionError(err)
 	}
 
@@ -189,7 +198,8 @@ func (e *EtcdClient) buildKey(key string) string {
 func (e *EtcdClient) Migrate(ctx context.Context, tcp kamajiv1alpha1.TenantControlPlane, target Connection) error {
 	targetClient := target.(*EtcdClient) //nolint:forcetypeassert
 
-	if err := target.Check(ctx); err != nil {
+	err := target.Check(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -199,7 +209,8 @@ func (e *EtcdClient) Migrate(ctx context.Context, tcp kamajiv1alpha1.TenantContr
 	}
 
 	for _, kv := range response.Kvs {
-		if _, err = targetClient.Client.Put(ctx, string(kv.Key), string(kv.Value)); err != nil {
+		_, err = targetClient.Client.Put(ctx, string(kv.Key), string(kv.Value))
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/datastore/mysql.go
+++ b/internal/datastore/mysql.go
@@ -59,12 +59,14 @@ type MySQLConnection struct {
 
 func (c *MySQLConnection) Migrate(ctx context.Context, tcp kamajiv1alpha1.TenantControlPlane, target Connection) error {
 	// Ensuring the connection is working as expected
-	if err := target.Check(ctx); err != nil {
+	err := target.Check(ctx)
+	if err != nil {
 		return err
 	}
 	// Creating the target schema if it doesn't exist
 	if ok, _ := target.DBExists(ctx, tcp.Status.Storage.Setup.Schema); !ok {
-		if err := target.CreateDB(ctx, tcp.Status.Storage.Setup.Schema); err != nil {
+		err := target.CreateDB(ctx, tcp.Status.Storage.Setup.Schema)
+		if err != nil {
 			return err
 		}
 	}
@@ -75,7 +77,8 @@ func (c *MySQLConnection) Migrate(ctx context.Context, tcp kamajiv1alpha1.Tenant
 	}
 	defer os.RemoveAll(dir)
 
-	if _, err = c.db.ExecContext(ctx, fmt.Sprintf("USE %s", quoteMySQLIdentifier(tcp.Status.Storage.Setup.Schema))); err != nil {
+	_, err = c.db.ExecContext(ctx, fmt.Sprintf("USE %s", quoteMySQLIdentifier(tcp.Status.Storage.Setup.Schema)))
+	if err != nil {
 		return fmt.Errorf("unable to switch DB for MySQL migration: %w", err)
 	}
 
@@ -107,11 +110,13 @@ func (c *MySQLConnection) Migrate(ctx context.Context, tcp kamajiv1alpha1.Tenant
 	}
 	defer importDB.Close()
 
-	if _, err = importDB.ExecContext(ctx, fmt.Sprintf("USE %s", quoteMySQLIdentifier(tcp.Status.Storage.Setup.Schema))); err != nil {
+	_, err = importDB.ExecContext(ctx, fmt.Sprintf("USE %s", quoteMySQLIdentifier(tcp.Status.Storage.Setup.Schema)))
+	if err != nil {
 		return fmt.Errorf("unable to switch DB for MySQL migration: %w", err)
 	}
 
-	if _, err = importDB.ExecContext(ctx, string(statements)); err != nil {
+	_, err = importDB.ExecContext(ctx, string(statements))
+	if err != nil {
 		return fmt.Errorf("cannot execute dump statements for MySQL: %w", err)
 	}
 
@@ -140,7 +145,8 @@ func NewMySQLConnection(config ConnectionConfig) (Connection, error) {
 	tlsKey := "mysql"
 
 	if config.TLSConfig != nil {
-		if err = mysql.RegisterTLSConfig(tlsKey, config.TLSConfig); err != nil {
+		err = mysql.RegisterTLSConfig(tlsKey, config.TLSConfig)
+		if err != nil {
 			return nil, err
 		}
 		mysqlConfig.TLSConfig = tlsKey
@@ -186,7 +192,8 @@ func (c *MySQLConnection) GetConnectionString() string {
 }
 
 func (c *MySQLConnection) Close() error {
-	if err := c.db.Close(); err != nil {
+	err := c.db.Close()
+	if err != nil {
 		return errors.NewCloseConnectionError(err)
 	}
 
@@ -194,7 +201,8 @@ func (c *MySQLConnection) Close() error {
 }
 
 func (c *MySQLConnection) Check(ctx context.Context) error {
-	if err := c.db.PingContext(ctx); err != nil {
+	err := c.db.PingContext(ctx)
+	if err != nil {
 		return errors.NewCheckConnectionError(err)
 	}
 
@@ -202,7 +210,8 @@ func (c *MySQLConnection) Check(ctx context.Context) error {
 }
 
 func (c *MySQLConnection) CreateUser(ctx context.Context, user, password string) error {
-	if err := c.mutate(ctx, mysqlCreateUserStatement, quoteMySQLIdentifier(user), escapeMySQLString(password)); err != nil {
+	err := c.mutate(ctx, mysqlCreateUserStatement, quoteMySQLIdentifier(user), escapeMySQLString(password))
+	if err != nil {
 		return errors.NewCreateUserError(err)
 	}
 
@@ -210,7 +219,8 @@ func (c *MySQLConnection) CreateUser(ctx context.Context, user, password string)
 }
 
 func (c *MySQLConnection) UpdateUser(ctx context.Context, user, password string) error {
-	if err := c.mutate(ctx, mysqlUpdateUserStatement, quoteMySQLIdentifier(user), escapeMySQLString(password)); err != nil {
+	err := c.mutate(ctx, mysqlUpdateUserStatement, quoteMySQLIdentifier(user), escapeMySQLString(password))
+	if err != nil {
 		return errors.NewUpdateUserError(err)
 	}
 
@@ -218,7 +228,8 @@ func (c *MySQLConnection) UpdateUser(ctx context.Context, user, password string)
 }
 
 func (c *MySQLConnection) CreateDB(ctx context.Context, dbName string) error {
-	if err := c.mutate(ctx, mysqlCreateDBStatement, quoteMySQLIdentifier(dbName)); err != nil {
+	err := c.mutate(ctx, mysqlCreateDBStatement, quoteMySQLIdentifier(dbName))
+	if err != nil {
 		return errors.NewCreateDBError(err)
 	}
 
@@ -226,7 +237,8 @@ func (c *MySQLConnection) CreateDB(ctx context.Context, dbName string) error {
 }
 
 func (c *MySQLConnection) GrantPrivileges(ctx context.Context, user, dbName string) error {
-	if err := c.mutate(ctx, mysqlGrantPrivilegesStatement, quoteMySQLIdentifier(dbName), quoteMySQLIdentifier(user)); err != nil {
+	err := c.mutate(ctx, mysqlGrantPrivilegesStatement, quoteMySQLIdentifier(dbName), quoteMySQLIdentifier(user))
+	if err != nil {
 		return errors.NewGrantPrivilegesError(err)
 	}
 
@@ -236,7 +248,8 @@ func (c *MySQLConnection) GrantPrivileges(ctx context.Context, user, dbName stri
 func (c *MySQLConnection) UserExists(ctx context.Context, user string) (bool, error) {
 	checker := func(row *sql.Row) (bool, error) {
 		var name string
-		if err := row.Scan(&name); err != nil {
+		err := row.Scan(&name)
+		if err != nil {
 			if c.checkEmptyQueryResult(err) {
 				return false, nil
 			}
@@ -258,7 +271,8 @@ func (c *MySQLConnection) UserExists(ctx context.Context, user string) (bool, er
 func (c *MySQLConnection) DBExists(ctx context.Context, dbName string) (bool, error) {
 	checker := func(row *sql.Row) (bool, error) {
 		var name string
-		if err := row.Scan(&name); err != nil {
+		err := row.Scan(&name)
+		if err != nil {
 			if c.checkEmptyQueryResult(err) {
 				return false, nil
 			}
@@ -280,7 +294,8 @@ func (c *MySQLConnection) DBExists(ctx context.Context, dbName string) (bool, er
 func (c *MySQLConnection) GrantPrivilegesExists(ctx context.Context, user, dbName string) (bool, error) {
 	var exists int
 
-	if err := c.db.QueryRowContext(ctx, mysqlCheckGrantsStatement, user, dbName).Scan(&exists); err != nil {
+	err := c.db.QueryRowContext(ctx, mysqlCheckGrantsStatement, user, dbName).Scan(&exists)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
 		}
@@ -292,7 +307,8 @@ func (c *MySQLConnection) GrantPrivilegesExists(ctx context.Context, user, dbNam
 }
 
 func (c *MySQLConnection) DeleteUser(ctx context.Context, user string) error {
-	if err := c.mutate(ctx, mysqlDropUserStatement, quoteMySQLIdentifier(user)); err != nil {
+	err := c.mutate(ctx, mysqlDropUserStatement, quoteMySQLIdentifier(user))
+	if err != nil {
 		return errors.NewDeleteUserError(err)
 	}
 
@@ -300,7 +316,8 @@ func (c *MySQLConnection) DeleteUser(ctx context.Context, user string) error {
 }
 
 func (c *MySQLConnection) DeleteDB(ctx context.Context, dbName string) error {
-	if err := c.mutate(ctx, mysqlDropDBStatement, quoteMySQLIdentifier(dbName)); err != nil {
+	err := c.mutate(ctx, mysqlDropDBStatement, quoteMySQLIdentifier(dbName))
+	if err != nil {
 		return errors.NewCannotDeleteDatabaseError(err)
 	}
 
@@ -308,7 +325,8 @@ func (c *MySQLConnection) DeleteDB(ctx context.Context, dbName string) error {
 }
 
 func (c *MySQLConnection) RevokePrivileges(ctx context.Context, user, dbName string) error {
-	if err := c.mutate(ctx, mysqlRevokePrivilegesStatement, quoteMySQLIdentifier(dbName), quoteMySQLIdentifier(user)); err != nil {
+	err := c.mutate(ctx, mysqlRevokePrivilegesStatement, quoteMySQLIdentifier(dbName), quoteMySQLIdentifier(user))
+	if err != nil {
 		return errors.NewRevokePrivilegesError(err)
 	}
 
@@ -329,7 +347,8 @@ func (c *MySQLConnection) check(ctx context.Context, nonFilledStatement string, 
 
 func (c *MySQLConnection) mutate(ctx context.Context, nonFilledStatement string, args ...any) error {
 	statement := fmt.Sprintf(nonFilledStatement, args...)
-	if _, err := c.db.ExecContext(ctx, statement); err != nil {
+	_, err := c.db.ExecContext(ctx, statement)
+	if err != nil {
 		return err
 	}
 

--- a/internal/datastore/nats.go
+++ b/internal/datastore/nats.go
@@ -162,7 +162,8 @@ func (nc *NATSConnection) Migrate(ctx context.Context, tcp kamajiv1alpha1.Tenant
 		return err
 	}
 
-	if err := target.Check(ctx); err != nil {
+	err = target.Check(ctx)
+	if err != nil {
 		return err
 	}
 

--- a/internal/datastore/postgresql.go
+++ b/internal/datastore/postgresql.go
@@ -45,19 +45,21 @@ type PostgreSQLConnection struct {
 
 func (r *PostgreSQLConnection) Migrate(ctx context.Context, tcp kamajiv1alpha1.TenantControlPlane, target Connection) error {
 	// Ensuring the connection is working as expected
-	if err := target.Check(ctx); err != nil {
+	err := target.Check(ctx)
+	if err != nil {
 		return fmt.Errorf("unable to check target datastore: %w", err)
 	}
 	// Creating the target schema if it doesn't exist
 	if ok, _ := target.DBExists(ctx, tcp.Status.Storage.Setup.Schema); !ok {
-		if err := target.CreateDB(ctx, tcp.Status.Storage.Setup.Schema); err != nil {
+		err := target.CreateDB(ctx, tcp.Status.Storage.Setup.Schema)
+		if err != nil {
 			return err
 		}
 	}
 
 	targetConn := target.(*PostgreSQLConnection).switchDatabaseFn(tcp.Status.Storage.Setup.Schema) //nolint:forcetypeassert
 
-	err := targetConn.RunInTransaction(ctx, func(tx *pg.Tx) error {
+	err = targetConn.RunInTransaction(ctx, func(tx *pg.Tx) error {
 		for _, stm := range []string{
 			`CREATE TABLE IF NOT EXISTS kine (
 				id SERIAL PRIMARY KEY,
@@ -77,18 +79,21 @@ func (r *PostgreSQLConnection) Migrate(ctx context.Context, tcp kamajiv1alpha1.T
 			`CREATE INDEX IF NOT EXISTS kine_prev_revision_index ON kine (prev_revision)`,
 			`CREATE UNIQUE INDEX IF NOT EXISTS kine_name_prev_revision_uindex ON kine (name, prev_revision)`,
 		} {
-			if _, err := tx.ExecContext(ctx, stm); err != nil {
+			_, err := tx.ExecContext(ctx, stm)
+			if err != nil {
 				return fmt.Errorf("unable to perform schema creation: %w", err)
 			}
 		}
 		// Dumping the old datastore in a local buffer
 		var buf bytes.Buffer
 
-		if _, err := r.switchDatabaseFn(tcp.Status.Storage.Setup.Schema).WithContext(ctx).CopyTo(&buf, "COPY kine TO STDOUT"); err != nil {
+		_, err := r.switchDatabaseFn(tcp.Status.Storage.Setup.Schema).WithContext(ctx).CopyTo(&buf, "COPY kine TO STDOUT")
+		if err != nil {
 			return fmt.Errorf("unable to copy from the origin datastore: %w", err)
 		}
 
-		if _, err := tx.CopyFrom(&buf, "COPY kine FROM STDIN"); err != nil {
+		_, err = tx.CopyFrom(&buf, "COPY kine FROM STDIN")
+		if err != nil {
 			return fmt.Errorf("unable to copy to the target datastore: %w", err)
 		}
 
@@ -188,7 +193,8 @@ func (r *PostgreSQLConnection) GrantPrivilegesExists(ctx context.Context, user, 
 
 	var isOwner string
 
-	if _, err = r.db.QueryContext(ctx, pg.Scan(&isOwner), postgresqlShowOwnershipStatement, dbName, user); err != nil {
+	_, err = r.db.QueryContext(ctx, pg.Scan(&isOwner), postgresqlShowOwnershipStatement, dbName, user)
+	if err != nil {
 		return false, errors.NewCheckGrantExistsError(err)
 	}
 
@@ -203,7 +209,8 @@ func (r *PostgreSQLConnection) GrantPrivilegesExists(ctx context.Context, user, 
 	}
 
 	if tableExists {
-		if _, err = dbConn.QueryContext(ctx, pg.Scan(&isTableOwner), postgresqlShowTableOwnershipStatement, user, "kine"); err != nil {
+		_, err = dbConn.QueryContext(ctx, pg.Scan(&isTableOwner), postgresqlShowTableOwnershipStatement, user, "kine")
+		if err != nil {
 			return false, errors.NewCheckGrantExistsError(err)
 		}
 
@@ -214,14 +221,16 @@ func (r *PostgreSQLConnection) GrantPrivilegesExists(ctx context.Context, user, 
 }
 
 func (r *PostgreSQLConnection) GrantPrivileges(ctx context.Context, user, dbName string) error {
-	if _, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlGrantPrivilegesStatement, quotePostgreSQLIdentifier(dbName), quotePostgreSQLIdentifier(user))); err != nil {
+	_, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlGrantPrivilegesStatement, quotePostgreSQLIdentifier(dbName), quotePostgreSQLIdentifier(user)))
+	if err != nil {
 		return errors.NewGrantPrivilegesError(err)
 	}
 
 	dbConn := r.switchDatabaseFn(dbName)
 	defer dbConn.Close()
 
-	if _, err := dbConn.ExecContext(ctx, fmt.Sprintf(postgresqlChangeOwnerStatement, quotePostgreSQLIdentifier(dbName), quotePostgreSQLIdentifier(user))); err != nil {
+	_, err = dbConn.ExecContext(ctx, fmt.Sprintf(postgresqlChangeOwnerStatement, quotePostgreSQLIdentifier(dbName), quotePostgreSQLIdentifier(user)))
+	if err != nil {
 		return errors.NewGrantPrivilegesError(err)
 	}
 
@@ -231,7 +240,8 @@ func (r *PostgreSQLConnection) GrantPrivileges(ctx context.Context, user, dbName
 	}
 
 	if tableExists {
-		if _, err = dbConn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE kine OWNER TO %s", quotePostgreSQLIdentifier(user))); err != nil {
+		_, err = dbConn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE kine OWNER TO %s", quotePostgreSQLIdentifier(user)))
+		if err != nil {
 			return errors.NewGrantPrivilegesError(err)
 		}
 	}
@@ -240,7 +250,8 @@ func (r *PostgreSQLConnection) GrantPrivileges(ctx context.Context, user, dbName
 }
 
 func (r *PostgreSQLConnection) DeleteUser(ctx context.Context, user string) error {
-	if _, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlDropRoleStatement, quotePostgreSQLIdentifier(user))); err != nil {
+	_, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlDropRoleStatement, quotePostgreSQLIdentifier(user)))
+	if err != nil {
 		return errors.NewDeleteUserError(err)
 	}
 
@@ -248,11 +259,13 @@ func (r *PostgreSQLConnection) DeleteUser(ctx context.Context, user string) erro
 }
 
 func (r *PostgreSQLConnection) DeleteDB(ctx context.Context, dbName string) error {
-	if err := r.GrantPrivileges(ctx, r.rootUser, dbName); err != nil {
+	err := r.GrantPrivileges(ctx, r.rootUser, dbName)
+	if err != nil {
 		return errors.NewCannotDeleteDatabaseError(fmt.Errorf("cannot grant privileges to root user: %w", err))
 	}
 
-	if _, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlDropDBStatement, quotePostgreSQLIdentifier(dbName))); err != nil {
+	_, err = r.db.ExecContext(ctx, fmt.Sprintf(postgresqlDropDBStatement, quotePostgreSQLIdentifier(dbName)))
+	if err != nil {
 		return errors.NewCannotDeleteDatabaseError(err)
 	}
 
@@ -260,7 +273,8 @@ func (r *PostgreSQLConnection) DeleteDB(ctx context.Context, dbName string) erro
 }
 
 func (r *PostgreSQLConnection) RevokePrivileges(ctx context.Context, user, dbName string) error {
-	if _, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlRevokePrivilegesStatement, quotePostgreSQLIdentifier(dbName), quotePostgreSQLIdentifier(user))); err != nil {
+	_, err := r.db.ExecContext(ctx, fmt.Sprintf(postgresqlRevokePrivilegesStatement, quotePostgreSQLIdentifier(dbName), quotePostgreSQLIdentifier(user)))
+	if err != nil {
 		return errors.NewRevokePrivilegesError(err)
 	}
 
@@ -272,7 +286,8 @@ func (r *PostgreSQLConnection) GetConnectionString() string {
 }
 
 func (r *PostgreSQLConnection) Close() error {
-	if err := r.db.Close(); err != nil {
+	err := r.db.Close()
+	if err != nil {
 		return errors.NewCloseConnectionError(err)
 	}
 
@@ -280,7 +295,8 @@ func (r *PostgreSQLConnection) Close() error {
 }
 
 func (r *PostgreSQLConnection) Check(ctx context.Context) error {
-	if err := r.db.Ping(ctx); err != nil {
+	err := r.db.Ping(ctx)
+	if err != nil {
 		return errors.NewCheckConnectionError(err)
 	}
 
@@ -290,7 +306,8 @@ func (r *PostgreSQLConnection) Check(ctx context.Context) error {
 func (r *PostgreSQLConnection) kineTableExists(ctx context.Context, db *pg.DB) (bool, error) {
 	var tableExists string
 
-	if _, err := db.QueryContext(ctx, pg.Scan(&tableExists), postgresqlKineTableExistsStatement, "public", "kine"); err != nil {
+	_, err := db.QueryContext(ctx, pg.Scan(&tableExists), postgresqlKineTableExistsStatement, "public", "kine")
+	if err != nil {
 		return false, err
 	}
 

--- a/internal/kubeadm/addon.go
+++ b/internal/kubeadm/addon.go
@@ -30,13 +30,15 @@ const (
 func AddCoreDNS(client kubernetes.Interface, config *Configuration) ([]byte, error) {
 	// We're passing the values from the parameters here because they wouldn't be hashed by the YAML encoder:
 	// the struct kubeadm.ClusterConfiguration hasn't struct tags, and it wouldn't be hashed properly.
-	if opts := config.Parameters.CoreDNSOptions; opts != nil {
+	opts := config.Parameters.CoreDNSOptions
+	if opts != nil {
 		config.InitConfiguration.DNS.ImageRepository = opts.Repository
 		config.InitConfiguration.DNS.ImageTag = opts.Tag
 	}
 
 	b := bytes.NewBuffer([]byte{})
-	if err := dns.EnsureDNSAddon(&config.InitConfiguration.ClusterConfiguration, client, "", b, true); err != nil {
+	err := dns.EnsureDNSAddon(&config.InitConfiguration.ClusterConfiguration, client, "", b, true)
+	if err != nil {
 		return nil, err
 	}
 
@@ -50,7 +52,8 @@ func AddKubeProxy(client kubernetes.Interface, config *Configuration) ([]byte, e
 	config.InitConfiguration.KubernetesVersion = config.Parameters.KubeProxyOptions.Tag
 
 	b := bytes.NewBuffer([]byte{})
-	if err := proxy.EnsureProxyAddon(&config.InitConfiguration.ClusterConfiguration, &config.InitConfiguration.LocalAPIEndpoint, client, b, true); err != nil {
+	err := proxy.EnsureProxyAddon(&config.InitConfiguration.ClusterConfiguration, &config.InitConfiguration.LocalAPIEndpoint, client, b, true)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/kubeadm/bootstraptoken.go
+++ b/internal/kubeadm/bootstraptoken.go
@@ -20,27 +20,33 @@ import (
 func BootstrapToken(client kubernetes.Interface, config *Configuration) error {
 	initConfiguration := config.InitConfiguration
 
-	if err := node.UpdateOrCreateTokens(client, false, initConfiguration.BootstrapTokens); err != nil {
+	err := node.UpdateOrCreateTokens(client, false, initConfiguration.BootstrapTokens)
+	if err != nil {
 		return fmt.Errorf("error updating or creating token: %w", err)
 	}
 
-	if err := node.AllowBootstrapTokensToGetNodes(client); err != nil {
+	err = node.AllowBootstrapTokensToGetNodes(client)
+	if err != nil {
 		return fmt.Errorf("error allowing bootstrap tokens to get Nodes: %w", err)
 	}
 
-	if err := node.AllowBootstrapTokensToPostCSRs(client); err != nil {
+	err = node.AllowBootstrapTokensToPostCSRs(client)
+	if err != nil {
 		return fmt.Errorf("error allowing bootstrap tokens to post CSRs: %w", err)
 	}
 
-	if err := node.AutoApproveNodeBootstrapTokens(client); err != nil {
+	err = node.AutoApproveNodeBootstrapTokens(client)
+	if err != nil {
 		return fmt.Errorf("error auto-approving node bootstrap tokens: %w", err)
 	}
 
-	if err := node.AutoApproveNodeCertificateRotation(client); err != nil {
+	err = node.AutoApproveNodeCertificateRotation(client)
+	if err != nil {
 		return err
 	}
 
-	if err := node.AllowAPIServerToAccessKubeletAPI(client); err != nil {
+	err = node.AllowAPIServerToAccessKubeletAPI(client)
+	if err != nil {
 		return fmt.Errorf("error allowing API server kubelet client to access the kubelet API: %w", err)
 	}
 
@@ -70,7 +76,8 @@ func BootstrapToken(client kubernetes.Interface, config *Configuration) error {
 		return err
 	}
 
-	if err := clusterinfo.CreateClusterInfoRBACRules(client); err != nil {
+	err = clusterinfo.CreateClusterInfoRBACRules(client)
+	if err != nil {
 		return fmt.Errorf("error creating clusterinfo RBAC rules: %w", err)
 	}
 

--- a/internal/kubeadm/certificates.go
+++ b/internal/kubeadm/certificates.go
@@ -24,7 +24,8 @@ func GenerateCACertificatePrivateKeyPair(baseName string, config *Configuration)
 		return nil, err
 	}
 
-	if _, _, err = initPhaseAsCA(kubeadmCert, config); err != nil {
+	_, _, err = initPhaseAsCA(kubeadmCert, config)
+	if err != nil {
 		return nil, err
 	}
 
@@ -59,7 +60,8 @@ func GenerateCertificatePrivateKeyPair(baseName string, config *Configuration, c
 		return nil, fmt.Errorf("failed to get kubeadm cert: %w", err)
 	}
 
-	if err = initPhaseFromCA(kubeadmCert, config, certificate, signer); err != nil {
+	err = initPhaseFromCA(kubeadmCert, config, certificate, signer)
+	if err != nil {
 		return nil, fmt.Errorf("failed to initialize phase from CA: %w", err)
 	}
 
@@ -100,7 +102,8 @@ func getKubeadmCert(baseName string) (*certs.KubeadmCert, error) {
 func GeneratePublicKeyPrivateKeyPair(baseName string, config *Configuration) (*PublicKeyPrivateKeyPair, error) {
 	defer deleteCertificateDirectory(config.InitConfiguration.CertificatesDir)
 
-	if err := initPhaseCertsSA(config); err != nil {
+	err := initPhaseCertsSA(config)
+	if err != nil {
 		return nil, err
 	}
 
@@ -146,7 +149,8 @@ func readCertificateFiles(name string, directory string, extensions ...string) (
 }
 
 func deleteCertificateDirectory(certificateDirectory string) {
-	if err := os.RemoveAll(certificateDirectory); err != nil {
+	err := os.RemoveAll(certificateDirectory)
+	if err != nil {
 		// TODO(prometherion): we should log rather than printing to stdout
 		fmt.Printf("Error removing %s: %s", certificateDirectory, err.Error()) //nolint:forbidigo
 	}

--- a/internal/kubeadm/configuration.go
+++ b/internal/kubeadm/configuration.go
@@ -102,11 +102,13 @@ func GetKubeadmInitConfigurationFromMap(conf map[string]string) (*Configuration,
 	}
 
 	initConfiguration := kubeadmapi.InitConfiguration{}
-	if err := utilities.DecodeFromJSON(initConfigurationString, &initConfiguration); err != nil {
+	err := utilities.DecodeFromJSON(initConfigurationString, &initConfiguration)
+	if err != nil {
 		return nil, err
 	}
 
-	if err := utilities.DecodeFromJSON(clusterConfigurationString, &initConfiguration.ClusterConfiguration); err != nil {
+	err = utilities.DecodeFromJSON(clusterConfigurationString, &initConfiguration.ClusterConfiguration)
+	if err != nil {
 		return nil, err
 	}
 	// Due to some weird issues with unmarshaling of the ComponentConfigs struct,

--- a/internal/kubeadm/kubeconfig.go
+++ b/internal/kubeadm/kubeconfig.go
@@ -18,12 +18,14 @@ import (
 )
 
 func buildCertificateDirectoryWithCA(ca CertificatePrivateKeyPair, directory string) error {
-	if err := os.MkdirAll(directory, os.FileMode(0o755)); err != nil {
+	err := os.MkdirAll(directory, os.FileMode(0o755))
+	if err != nil {
 		return err
 	}
 
 	certPath := path.Join(directory, kubeadmconstants.CACertName)
-	if err := os.WriteFile(certPath, ca.Certificate, os.FileMode(0o600)); err != nil {
+	err = os.WriteFile(certPath, ca.Certificate, os.FileMode(0o600))
+	if err != nil {
 		return err
 	}
 
@@ -33,13 +35,15 @@ func buildCertificateDirectoryWithCA(ca CertificatePrivateKeyPair, directory str
 }
 
 func CreateKubeconfig(kubeconfigName string, ca CertificatePrivateKeyPair, config *Configuration) ([]byte, error) {
-	if err := buildCertificateDirectoryWithCA(ca, config.InitConfiguration.CertificatesDir); err != nil {
+	err := buildCertificateDirectoryWithCA(ca, config.InitConfiguration.CertificatesDir)
+	if err != nil {
 		return nil, err
 	}
 
 	defer deleteCertificateDirectory(config.InitConfiguration.CertificatesDir)
 
-	if err := kubeconfig.CreateKubeConfigFile(kubeconfigName, config.InitConfiguration.CertificatesDir, &config.InitConfiguration); err != nil {
+	err = kubeconfig.CreateKubeConfigFile(kubeconfigName, config.InitConfiguration.CertificatesDir, &config.InitConfiguration)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/kubeadm/uploadconfig.go
+++ b/internal/kubeadm/uploadconfig.go
@@ -61,11 +61,13 @@ func UploadKubeletConfig(client kubernetes.Interface, config *Configuration, pat
 		},
 	}
 
-	if err = apiclient.CreateOrUpdate[*corev1.ConfigMap](client.CoreV1().ConfigMaps(metav1.NamespaceSystem), configMap); err != nil {
+	err = apiclient.CreateOrUpdate[*corev1.ConfigMap](client.CoreV1().ConfigMaps(metav1.NamespaceSystem), configMap)
+	if err != nil {
 		return nil, err
 	}
 
-	if err = createConfigMapRBACRules(client, configMapName); err != nil {
+	err = createConfigMapRBACRules(client, configMapName)
+	if err != nil {
 		return nil, fmt.Errorf("error creating kubelet configuration configmap RBAC rules: %w", err)
 	}
 
@@ -95,12 +97,14 @@ func getKubeletConfigmapContent(kubeletConfiguration KubeletConfiguration, patch
 			return nil, fmt.Errorf("unable to encode KubeletConfiguration to JSON for JSON patching: %w", patchErr)
 		}
 
-		if kubeletConfig, patchErr = patch.Apply(kubeletConfig); patchErr != nil {
+		kubeletConfig, patchErr = patch.Apply(kubeletConfig)
+		if patchErr != nil {
 			return nil, fmt.Errorf("unable to apply JSON patching to KubeletConfiguration: %w", patchErr)
 		}
 
 		kc = kubelettypes.KubeletConfiguration{}
-		if patchErr = utilities.DecodeFromJSON(string(kubeletConfig), &kc); patchErr != nil {
+		patchErr = utilities.DecodeFromJSON(string(kubeletConfig), &kc)
+		if patchErr != nil {
 			return nil, fmt.Errorf("unable to decode JSON to KubeletConfiguration: %w", patchErr)
 		}
 	}
@@ -111,7 +115,7 @@ func getKubeletConfigmapContent(kubeletConfiguration KubeletConfiguration, patch
 func createConfigMapRBACRules(client kubernetes.Interface, configMapName string) error {
 	configMapRBACName := kubeadmconstants.KubeletBaseConfigMapRole
 
-	if err := apiclient.CreateOrUpdate[*rbacv1.Role](client.RbacV1().Roles(metav1.NamespaceSystem), &rbacv1.Role{
+	err := apiclient.CreateOrUpdate[*rbacv1.Role](client.RbacV1().Roles(metav1.NamespaceSystem), &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapRBACName,
 			Namespace: metav1.NamespaceSystem,
@@ -124,7 +128,8 @@ func createConfigMapRBACRules(client kubernetes.Interface, configMapName string)
 				ResourceNames: []string{configMapName},
 			},
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 

--- a/internal/resources/addons/coredns.go
+++ b/internal/resources/addons/coredns.go
@@ -103,17 +103,20 @@ func (c *CoreDNS) CleanUp(ctx context.Context, tcp *kamajiv1alpha1.TenantControl
 	for _, obj := range []client.Object{c.serviceAccount, c.clusterRoleBinding, c.clusterRole, c.service, c.configMap, c.deployment} {
 		objectKey := client.ObjectKeyFromObject(obj)
 
-		if err = tenantClient.Get(ctx, objectKey, obj); err != nil {
+		err = tenantClient.Get(ctx, objectKey, obj)
+		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				continue
 			}
 		}
 		// Don't delete resource if it is not managed by Kamaji
-		if labels := obj.GetLabels(); labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
+		labels := obj.GetLabels()
+		if labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
 			continue
 		}
 
-		if err = tenantClient.Delete(ctx, obj); err != nil {
+		err = tenantClient.Delete(ctx, obj)
+		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				continue
 			}
@@ -141,7 +144,8 @@ func (c *CoreDNS) CreateOrUpdate(ctx context.Context, tcp *kamajiv1alpha1.Tenant
 		return controllerutil.OperationResultNone, err
 	}
 
-	if err = c.decodeManifests(ctx, tcp); err != nil {
+	err = c.decodeManifests(ctx, tcp)
+	if err != nil {
 		logger.Error(err, "manifest decoding failed")
 
 		return controllerutil.OperationResultNone, err
@@ -264,32 +268,38 @@ func (c *CoreDNS) decodeManifests(ctx context.Context, tcp *kamajiv1alpha1.Tenan
 
 	parts := bytes.Split(manifests, []byte("---"))
 
-	if err = utilities.DecodeFromYAML(string(parts[1]), c.deployment); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[1]), c.deployment)
+	if err != nil {
 		return fmt.Errorf("unable to decode Deployment manifest: %w", err)
 	}
 	addons_utils.SetKamajiManagedLabels(c.deployment)
 
-	if err = utilities.DecodeFromYAML(string(parts[2]), c.configMap); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[2]), c.configMap)
+	if err != nil {
 		return fmt.Errorf("unable to decode ConfigMap manifest: %w", err)
 	}
 	addons_utils.SetKamajiManagedLabels(c.configMap)
 
-	if err = utilities.DecodeFromYAML(string(parts[3]), c.service); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[3]), c.service)
+	if err != nil {
 		return fmt.Errorf("unable to decode Service manifest: %w", err)
 	}
 	addons_utils.SetKamajiManagedLabels(c.service)
 
-	if err = utilities.DecodeFromYAML(string(parts[4]), c.clusterRole); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[4]), c.clusterRole)
+	if err != nil {
 		return fmt.Errorf("unable to decode ClusterRole manifest: %w", err)
 	}
 	addons_utils.SetKamajiManagedLabels(c.clusterRole)
 
-	if err = utilities.DecodeFromYAML(string(parts[5]), c.clusterRoleBinding); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[5]), c.clusterRoleBinding)
+	if err != nil {
 		return fmt.Errorf("unable to decode ClusterRoleBinding manifest: %w", err)
 	}
 	addons_utils.SetKamajiManagedLabels(c.clusterRoleBinding)
 
-	if err = utilities.DecodeFromYAML(string(parts[6]), c.serviceAccount); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[6]), c.serviceAccount)
+	if err != nil {
 		return fmt.Errorf("unable to decode ServiceAccount manifest: %w", err)
 	}
 	addons_utils.SetKamajiManagedLabels(c.serviceAccount)
@@ -320,7 +330,8 @@ func (c *CoreDNS) mutateDeployment(ctx context.Context, tenantClient client.Clie
 	deployment.Name = c.deployment.Name
 	deployment.Namespace = c.deployment.Namespace
 
-	if err := tenantClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment); err != nil {
+	err := tenantClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &deployment)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return utilities.CreateOrUpdateWithConflict(ctx, tenantClient, c.deployment, func() error {
 				return controllerutil.SetControllerReference(c.clusterRoleBinding, c.deployment, tenantClient.Scheme())
@@ -330,7 +341,8 @@ func (c *CoreDNS) mutateDeployment(ctx context.Context, tenantClient client.Clie
 		return controllerutil.OperationResultNone, err
 	}
 
-	if err := controllerutil.SetControllerReference(c.clusterRoleBinding, c.deployment, tenantClient.Scheme()); err != nil {
+	err = controllerutil.SetControllerReference(c.clusterRoleBinding, c.deployment, tenantClient.Scheme())
+	if err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 	//nolint:staticcheck
@@ -356,7 +368,8 @@ func (c *CoreDNS) mutateService(ctx context.Context, tenantClient client.Client)
 	svc.Name = c.service.Name
 	svc.Namespace = c.service.Namespace
 
-	if err := tenantClient.Get(ctx, client.ObjectKeyFromObject(&svc), &svc); err != nil {
+	err := tenantClient.Get(ctx, client.ObjectKeyFromObject(&svc), &svc)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return utilities.CreateOrUpdateWithConflict(ctx, tenantClient, c.service, func() error {
 				return controllerutil.SetControllerReference(c.clusterRoleBinding, c.service, tenantClient.Scheme())
@@ -366,7 +379,8 @@ func (c *CoreDNS) mutateService(ctx context.Context, tenantClient client.Client)
 		return controllerutil.OperationResultNone, err
 	}
 
-	if err := controllerutil.SetControllerReference(c.clusterRoleBinding, c.service, tenantClient.Scheme()); err != nil {
+	err = controllerutil.SetControllerReference(c.clusterRoleBinding, c.service, tenantClient.Scheme())
+	if err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 	//nolint:staticcheck

--- a/internal/resources/addons/kube_proxy.go
+++ b/internal/resources/addons/kube_proxy.go
@@ -102,18 +102,21 @@ func (k *KubeProxy) CleanUp(ctx context.Context, tcp *kamajiv1alpha1.TenantContr
 	var deleted bool
 
 	for _, obj := range []client.Object{k.serviceAccount, k.clusterRoleBinding, k.role, k.roleBinding, k.configMap, k.daemonSet} {
-		if err = tenantClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
+		err = tenantClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				continue
 			}
 		}
 		// Skipping deletion:
 		// the kubeproxy addons is not managed by Kamaji.
-		if labels := obj.GetLabels(); labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
+		labels := obj.GetLabels()
+		if labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
 			continue
 		}
 
-		if err = tenantClient.Delete(ctx, obj); err != nil {
+		err = tenantClient.Delete(ctx, obj)
+		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				continue
 			}
@@ -141,7 +144,8 @@ func (k *KubeProxy) CreateOrUpdate(ctx context.Context, tcp *kamajiv1alpha1.Tena
 		return controllerutil.OperationResultNone, err
 	}
 
-	if err = k.decodeManifests(ctx, tcp); err != nil {
+	err = k.decodeManifests(ctx, tcp)
+	if err != nil {
 		logger.Error(err, "manifest decoding failed")
 
 		return controllerutil.OperationResultNone, err
@@ -301,7 +305,8 @@ func (k *KubeProxy) mutateDaemonSet(ctx context.Context, tenantClient client.Cli
 	ds.Name = k.daemonSet.Name
 	ds.Namespace = k.daemonSet.Namespace
 
-	if err := tenantClient.Get(ctx, client.ObjectKeyFromObject(&ds), &ds); err != nil {
+	err := tenantClient.Get(ctx, client.ObjectKeyFromObject(&ds), &ds)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return utilities.CreateOrUpdateWithConflict(ctx, tenantClient, k.daemonSet, func() error {
 				return controllerutil.SetControllerReference(k.clusterRoleBinding, k.daemonSet, tenantClient.Scheme())
@@ -311,7 +316,8 @@ func (k *KubeProxy) mutateDaemonSet(ctx context.Context, tenantClient client.Cli
 		return controllerutil.OperationResultNone, err
 	}
 
-	if err := controllerutil.SetControllerReference(k.clusterRoleBinding, k.daemonSet, tenantClient.Scheme()); err != nil {
+	err = controllerutil.SetControllerReference(k.clusterRoleBinding, k.daemonSet, tenantClient.Scheme())
+	if err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 	//nolint:staticcheck
@@ -345,32 +351,38 @@ func (k *KubeProxy) decodeManifests(ctx context.Context, tcp *kamajiv1alpha1.Ten
 
 	parts := bytes.Split(manifests, []byte("---"))
 
-	if err = utilities.DecodeFromYAML(string(parts[1]), k.serviceAccount); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[1]), k.serviceAccount)
+	if err != nil {
 		return fmt.Errorf("unable to decode ServiceAccount manifest: %w", err)
 	}
 	addon_utils.SetKamajiManagedLabels(k.serviceAccount)
 
-	if err = utilities.DecodeFromYAML(string(parts[2]), k.clusterRoleBinding); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[2]), k.clusterRoleBinding)
+	if err != nil {
 		return fmt.Errorf("unable to decode ClusterRoleBinding manifest: %w", err)
 	}
 	addon_utils.SetKamajiManagedLabels(k.clusterRoleBinding)
 
-	if err = utilities.DecodeFromYAML(string(parts[3]), k.role); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[3]), k.role)
+	if err != nil {
 		return fmt.Errorf("unable to decode Role manifest: %w", err)
 	}
 	addon_utils.SetKamajiManagedLabels(k.role)
 
-	if err = utilities.DecodeFromYAML(string(parts[4]), k.roleBinding); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[4]), k.roleBinding)
+	if err != nil {
 		return fmt.Errorf("unable to decode RoleBinding manifest: %w", err)
 	}
 	addon_utils.SetKamajiManagedLabels(k.roleBinding)
 
-	if err = utilities.DecodeFromYAML(string(parts[5]), k.configMap); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[5]), k.configMap)
+	if err != nil {
 		return fmt.Errorf("unable to decode ConfigMap manifest: %w", err)
 	}
 	addon_utils.SetKamajiManagedLabels(k.configMap)
 
-	if err = utilities.DecodeFromYAML(string(parts[6]), k.daemonSet); err != nil {
+	err = utilities.DecodeFromYAML(string(parts[6]), k.daemonSet)
+	if err != nil {
 		return fmt.Errorf("unable to decode DaemonSet manifest: %w", err)
 	}
 	addon_utils.SetKamajiManagedLabels(k.daemonSet)

--- a/internal/resources/api_server_certificate.go
+++ b/internal/resources/api_server_certificate.go
@@ -76,7 +76,8 @@ func (r *APIServerCertificate) GetTmpDirectory() string {
 }
 
 func (r *APIServerCertificate) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) (res controllerutil.OperationResult, err error) {
-	if err = (handlers.TenantControlPlaneCertSANs{}).ValidateCertSANs(tenantControlPlane); err != nil {
+	err = (handlers.TenantControlPlaneCertSANs{}).ValidateCertSANs(tenantControlPlane)
+	if err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 
@@ -110,7 +111,8 @@ func (r *APIServerCertificate) mutate(ctx context.Context, tenantControlPlane *k
 		// this is required to trigger a new generation in case of Certificate Authority rotation.
 		namespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Certificates.CA.SecretName}
 		secretCA := &corev1.Secret{}
-		if err := r.Client.Get(ctx, namespacedName, secretCA); err != nil {
+		err := r.Client.Get(ctx, namespacedName, secretCA)
+		if err != nil {
 			logger.Error(err, "cannot retrieve CA secret")
 
 			return err
@@ -124,7 +126,8 @@ func (r *APIServerCertificate) mutate(ctx context.Context, tenantControlPlane *k
 			},
 		))
 
-		if err := ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+		err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+		if err != nil {
 			logger.Error(err, "cannot set controller reference", "resource", r.GetName())
 
 			return err

--- a/internal/resources/api_server_kubelet_client_certificate.go
+++ b/internal/resources/api_server_kubelet_client_certificate.go
@@ -97,7 +97,8 @@ func (r *APIServerKubeletClientCertificate) mutate(ctx context.Context, tenantCo
 		// this is required to trigger a new generation in case of Certificate Authority rotation.
 		namespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Certificates.CA.SecretName}
 		secretCA := &corev1.Secret{}
-		if err := r.Client.Get(ctx, namespacedName, secretCA); err != nil {
+		err := r.Client.Get(ctx, namespacedName, secretCA)
+		if err != nil {
 			logger.Error(err, "cannot retrieve CA secret")
 
 			return err
@@ -111,7 +112,8 @@ func (r *APIServerKubeletClientCertificate) mutate(ctx context.Context, tenantCo
 			},
 		))
 
-		if err := ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+		err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+		if err != nil {
 			logger.Error(err, "cannot set controller reference", "resource", r.GetName())
 
 			return err

--- a/internal/resources/datastore/datastore_certificate.go
+++ b/internal/resources/datastore/datastore_certificate.go
@@ -113,7 +113,8 @@ func (r *Certificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1al
 				},
 			))
 
-			if err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+			err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+			if err != nil {
 				logger.Error(err, "cannot set controller reference", "resource", r.GetName())
 
 				return err
@@ -134,13 +135,15 @@ func (r *Certificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1al
 				var privateKey []byte
 				// When dealing with the etcd storage we cannot use the basic authentication, thus the generation of a
 				// certificate used for authentication is mandatory, along with the CA private key.
-				if privateKey, err = r.DataStore.Spec.TLSConfig.CertificateAuthority.PrivateKey.GetContent(ctx, r.Client); err != nil {
+				privateKey, err = r.DataStore.Spec.TLSConfig.CertificateAuthority.PrivateKey.GetContent(ctx, r.Client)
+				if err != nil {
 					logger.Error(err, "unable to retrieve CA private key content")
 
 					return err
 				}
 
-				if crt, key, err = crypto.GenerateCertificatePrivateKeyPair(crypto.NewCertificateTemplate(tenantControlPlane.Status.Storage.Setup.User), ca, privateKey); err != nil {
+				crt, key, err = crypto.GenerateCertificatePrivateKeyPair(crypto.NewCertificateTemplate(tenantControlPlane.Status.Storage.Setup.User), ca, privateKey)
+				if err != nil {
 					logger.Error(err, "unable to generate certificate and private key")
 
 					return err
@@ -151,7 +154,8 @@ func (r *Certificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1al
 				// to connect to the desired schema and database.
 
 				if r.DataStore.Spec.TLSConfig.ClientCertificate != nil {
-					if crtBytes, err = r.DataStore.Spec.TLSConfig.ClientCertificate.Certificate.GetContent(ctx, r.Client); err != nil {
+					crtBytes, err = r.DataStore.Spec.TLSConfig.ClientCertificate.Certificate.GetContent(ctx, r.Client)
+					if err != nil {
 						logger.Error(err, "unable to retrieve certificate content")
 
 						return err
@@ -159,7 +163,8 @@ func (r *Certificate) mutate(ctx context.Context, tenantControlPlane *kamajiv1al
 
 					crt = bytes.NewBuffer(crtBytes)
 
-					if keyBytes, err = r.DataStore.Spec.TLSConfig.ClientCertificate.PrivateKey.GetContent(ctx, r.Client); err != nil {
+					keyBytes, err = r.DataStore.Spec.TLSConfig.ClientCertificate.PrivateKey.GetContent(ctx, r.Client)
+					if err != nil {
 						logger.Error(err, "unable to retrieve private key content")
 
 						return err

--- a/internal/resources/datastore/datastore_migrate.go
+++ b/internal/resources/datastore/datastore_migrate.go
@@ -61,14 +61,16 @@ func (d *Migrate) Define(ctx context.Context, tenantControlPlane *kamajiv1alpha1
 		return nil
 	}
 
-	if err := d.Client.Get(ctx, types.NamespacedName{Name: d.job.GetName(), Namespace: d.job.GetNamespace()}, d.job); err != nil {
+	err := d.Client.Get(ctx, types.NamespacedName{Name: d.job.GetName(), Namespace: d.job.GetNamespace()}, d.job)
+	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	}
 
 	d.actualDatastore = &kamajiv1alpha1.DataStore{}
-	if err := d.Client.Get(ctx, types.NamespacedName{Name: tenantControlPlane.Status.Storage.DataStoreName}, d.actualDatastore); err != nil {
+	err = d.Client.Get(ctx, types.NamespacedName{Name: tenantControlPlane.Status.Storage.DataStoreName}, d.actualDatastore)
+	if err != nil {
 		return err
 	}
 
@@ -124,11 +126,13 @@ func (d *Migrate) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamaji
 			fmt.Sprintf("--target-datastore=%s", tenantControlPlane.Spec.DataStore),
 		}
 
-		if annotations := tenantControlPlane.GetAnnotations(); annotations != nil {
+		annotations := tenantControlPlane.GetAnnotations()
+		if annotations != nil {
 			v, _ := strconv.ParseBool(annotations["kamaji.clastix.io/cleanup-prior-migration"])
 			d.job.Spec.Template.Spec.Containers[0].Args = append(d.job.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--cleanup-prior-migration=%t", v))
 
-			if timeout, tErr := time.ParseDuration(annotations["kamaji.clastix.io/migration-timeout"]); tErr == nil {
+			timeout, tErr := time.ParseDuration(annotations["kamaji.clastix.io/migration-timeout"])
+			if tErr == nil {
 				d.job.Spec.Template.Spec.Containers[0].Args = append(d.job.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("--timeout=%s", timeout.String()))
 			}
 		}

--- a/internal/resources/datastore/datastore_setup.go
+++ b/internal/resources/datastore/datastore_setup.go
@@ -65,7 +65,8 @@ func (r *Setup) Define(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 		Namespace: tenantControlPlane.GetNamespace(),
 		Name:      tenantControlPlane.Status.Storage.Config.SecretName,
 	}
-	if err := r.Client.Get(ctx, namespacedName, secret); err != nil {
+	err := r.Client.Get(ctx, namespacedName, secret)
+	if err != nil {
 		logger.Error(err, "cannot retrieve the DataStore Configuration secret")
 
 		return err
@@ -95,7 +96,8 @@ func (r *Setup) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			tcp := &kamajiv1alpha1.TenantControlPlane{}
 
-			if retryErr := r.Client.Get(ctx, types.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.GetName()}, tcp); retryErr != nil {
+			retryErr := r.Client.Get(ctx, types.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.GetName()}, tcp)
+			if retryErr != nil {
 				return retryErr
 			}
 
@@ -145,27 +147,31 @@ func (r *Setup) GetName() string {
 func (r *Setup) Delete(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.revokeGrantPrivileges(ctx, tenantControlPlane); err != nil {
+	err := r.revokeGrantPrivileges(ctx, tenantControlPlane)
+	if err != nil {
 		logger.Error(err, "unable to revoke privileges")
 
 		return err
 	}
 
-	if err := r.deleteDB(ctx, tenantControlPlane); err != nil {
+	err = r.deleteDB(ctx, tenantControlPlane)
+	if err != nil {
 		logger.Error(err, "unable to delete datastore data")
 
 		return err
 	}
 
-	if err := r.deleteUser(ctx, tenantControlPlane); err != nil {
+	err = r.deleteUser(ctx, tenantControlPlane)
+	if err != nil {
 		logger.Error(err, "unable to delete user")
 
 		return err
 	}
 
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		tcp := &kamajiv1alpha1.TenantControlPlane{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: tenantControlPlane.GetName(), Namespace: tenantControlPlane.GetNamespace()}, tcp); err != nil {
+		err := r.Client.Get(ctx, types.NamespacedName{Name: tenantControlPlane.GetName(), Namespace: tenantControlPlane.GetNamespace()}, tcp)
+		if err != nil {
 			return err
 		}
 
@@ -199,7 +205,8 @@ func (r *Setup) createDB(ctx context.Context, _ *kamajiv1alpha1.TenantControlPla
 		return controllerutil.OperationResultNone, nil
 	}
 
-	if err := r.Connection.CreateDB(ctx, r.resource.schema); err != nil {
+	err = r.Connection.CreateDB(ctx, r.resource.schema)
+	if err != nil {
 		return controllerutil.OperationResultNone, fmt.Errorf("unable to create the datastore: %w", err)
 	}
 
@@ -216,7 +223,8 @@ func (r *Setup) deleteDB(ctx context.Context, _ *kamajiv1alpha1.TenantControlPla
 		return nil
 	}
 
-	if err := r.Connection.DeleteDB(ctx, r.resource.schema); err != nil {
+	err = r.Connection.DeleteDB(ctx, r.resource.schema)
+	if err != nil {
 		return fmt.Errorf("unable to delete the datastore: %w", err)
 	}
 
@@ -230,14 +238,16 @@ func (r *Setup) createUser(ctx context.Context, _ *kamajiv1alpha1.TenantControlP
 	}
 
 	if exists {
-		if updateErr := r.Connection.UpdateUser(ctx, r.resource.user, r.resource.password); updateErr != nil {
+		updateErr := r.Connection.UpdateUser(ctx, r.resource.user, r.resource.password)
+		if updateErr != nil {
 			return controllerutil.OperationResultNone, fmt.Errorf("unable to update the user to : %w", updateErr)
 		}
 
 		return controllerutil.OperationResultNone, nil
 	}
 
-	if err := r.Connection.CreateUser(ctx, r.resource.user, r.resource.password); err != nil {
+	err = r.Connection.CreateUser(ctx, r.resource.user, r.resource.password)
+	if err != nil {
 		return controllerutil.OperationResultNone, fmt.Errorf("unable to create the user: %w", err)
 	}
 
@@ -254,7 +264,8 @@ func (r *Setup) deleteUser(ctx context.Context, _ *kamajiv1alpha1.TenantControlP
 		return nil
 	}
 
-	if err := r.Connection.DeleteUser(ctx, r.resource.user); err != nil {
+	err = r.Connection.DeleteUser(ctx, r.resource.user)
+	if err != nil {
 		return fmt.Errorf("unable to remove the user: %w", err)
 	}
 
@@ -271,7 +282,8 @@ func (r *Setup) createGrantPrivileges(ctx context.Context, _ *kamajiv1alpha1.Ten
 		return controllerutil.OperationResultNone, nil
 	}
 
-	if err := r.Connection.GrantPrivileges(ctx, r.resource.user, r.resource.schema); err != nil {
+	err = r.Connection.GrantPrivileges(ctx, r.resource.user, r.resource.schema)
+	if err != nil {
 		return controllerutil.OperationResultNone, fmt.Errorf("unable to grant privileges: %w", err)
 	}
 
@@ -288,7 +300,8 @@ func (r *Setup) revokeGrantPrivileges(ctx context.Context, _ *kamajiv1alpha1.Ten
 		return nil
 	}
 
-	if err := r.Connection.RevokePrivileges(ctx, r.resource.user, r.resource.schema); err != nil {
+	err = r.Connection.RevokePrivileges(ctx, r.resource.user, r.resource.schema)
+	if err != nil {
 		return fmt.Errorf("unable to revoke privileges: %w", err)
 	}
 

--- a/internal/resources/datastore/datastore_storage_config.go
+++ b/internal/resources/datastore/datastore_storage_config.go
@@ -77,7 +77,8 @@ func (r *Config) Delete(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlan
 	secret := r.resource.DeepCopy()
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: r.resource.Name, Namespace: r.resource.Namespace}, secret); err != nil {
+		err := r.Client.Get(ctx, types.NamespacedName{Name: r.resource.Name, Namespace: r.resource.Namespace}, secret)
+		if err != nil {
 			if kubeerrors.IsNotFound(err) {
 				return nil
 			}
@@ -87,7 +88,8 @@ func (r *Config) Delete(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlan
 
 		secret.SetFinalizers(nil)
 
-		if err := r.Client.Update(ctx, secret); err != nil {
+		err = r.Client.Update(ctx, secret)
+		if err != nil {
 			if kubeerrors.IsNotFound(err) {
 				return nil
 			}

--- a/internal/resources/front-proxy-client-certificate.go
+++ b/internal/resources/front-proxy-client-certificate.go
@@ -97,7 +97,8 @@ func (r *FrontProxyClientCertificate) mutate(ctx context.Context, tenantControlP
 		// this is required to trigger a new generation in case of Certificate Authority rotation.
 		namespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Certificates.FrontProxyCA.SecretName}
 		secretCA := &corev1.Secret{}
-		if err := r.Client.Get(ctx, namespacedName, secretCA); err != nil {
+		err := r.Client.Get(ctx, namespacedName, secretCA)
+		if err != nil {
 			logger.Error(err, "cannot retrieve CA secret")
 
 			return err
@@ -111,7 +112,8 @@ func (r *FrontProxyClientCertificate) mutate(ctx context.Context, tenantControlP
 			},
 		))
 
-		if err := ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+		err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+		if err != nil {
 			logger.Error(err, "cannot set controller reference", "resource", r.GetName())
 
 			return err

--- a/internal/resources/k8s_gateway_utils.go
+++ b/internal/resources/k8s_gateway_utils.go
@@ -36,9 +36,10 @@ func fetchGatewayByListener(ctx context.Context, c client.Client, ref gatewayv1.
 
 	// Query gateways using the indexer
 	gatewayList := &gatewayv1.GatewayList{}
-	if err := c.List(ctx, gatewayList, client.MatchingFieldsSelector{
+	err := c.List(ctx, gatewayList, client.MatchingFieldsSelector{
 		Selector: fields.OneTermEqualSelector(kamajiv1alpha1.GatewayListenerNameKey, listenerKey),
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("failed to list gateways by listener: %w", err)
 	}
 
@@ -145,10 +146,11 @@ func IsGatewayRouteStatusChanged(currentStatus *kamajiv1alpha1.KubernetesGateway
 // CleanupTLSRoute cleans up a TLSRoute resource if it's managed by the given TenantControlPlane.
 func CleanupTLSRoute(ctx context.Context, c client.Client, routeName, routeNamespace string, tcp metav1.Object) (bool, error) {
 	route := gatewayv1.TLSRoute{}
-	if err := c.Get(ctx, client.ObjectKey{
+	err := c.Get(ctx, client.ObjectKey{
 		Namespace: routeNamespace,
 		Name:      routeName,
-	}, &route); err != nil {
+	}, &route)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return false, fmt.Errorf("failed to get TLSRoute before cleanup: %w", err)
 		}
@@ -160,7 +162,8 @@ func CleanupTLSRoute(ctx context.Context, c client.Client, routeName, routeNames
 		return false, nil
 	}
 
-	if err := c.Delete(ctx, &route); err != nil {
+	err = c.Delete(ctx, &route)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return false, fmt.Errorf("cannot delete TLSRoute route: %w", err)
 		}
@@ -277,7 +280,8 @@ func resolveMatchingListeners(ctx context.Context, c client.Client, ref gatewayv
 	// SectionName unset: resolve the Gateway by namespace/name.
 	gateway := &gatewayv1.Gateway{}
 	key := k8stypes.NamespacedName{Namespace: string(*ref.Namespace), Name: string(ref.Name)}
-	if err := c.Get(ctx, key, gateway); err != nil {
+	err := c.Get(ctx, key, gateway)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/internal/resources/k8s_ingress_resource.go
+++ b/internal/resources/k8s_ingress_resource.go
@@ -90,10 +90,11 @@ func (r *KubernetesIngressResource) CleanUp(ctx context.Context, tcp *kamajiv1al
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
 	var ingress networkingv1.Ingress
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	err := r.Client.Get(ctx, client.ObjectKey{
 		Namespace: r.resource.GetNamespace(),
 		Name:      r.resource.GetName(),
-	}, &ingress); err != nil {
+	}, &ingress)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "failed to get ingress resource before cleanup")
 
@@ -109,7 +110,8 @@ func (r *KubernetesIngressResource) CleanUp(ctx context.Context, tcp *kamajiv1al
 		return false, nil
 	}
 
-	if err := r.Client.Delete(ctx, &ingress); err != nil {
+	err = r.Client.Delete(ctx, &ingress)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "cannot cleanup resource")
 

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -6,6 +6,7 @@ package konnectivity
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,7 +15,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	pointer "k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -63,7 +63,8 @@ func (r *Agent) ShouldCleanup(tenantControlPlane *kamajiv1alpha1.TenantControlPl
 func (r *Agent) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlane) (bool, error) {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.tenantClient.Get(ctx, client.ObjectKeyFromObject(r.resource), r.resource); err != nil {
+	err := r.tenantClient.Get(ctx, client.ObjectKeyFromObject(r.resource), r.resource)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -73,11 +74,13 @@ func (r *Agent) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlan
 		return false, err
 	}
 
-	if labels := r.resource.GetLabels(); labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
+	labels := r.resource.GetLabels()
+	if labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
 		return false, nil
 	}
 
-	if err := r.tenantClient.Delete(ctx, r.resource); err != nil {
+	err = r.tenantClient.Delete(ctx, r.resource)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -107,7 +110,8 @@ func (r *Agent) Define(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 	r.resource.SetNamespace(AgentNamespace)
 	r.resource.SetName(AgentName)
 
-	if r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane); err != nil {
+	r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane)
+	if err != nil {
 		logger.Error(err, "unable to retrieve the Tenant Control Plane client")
 
 		return err
@@ -130,7 +134,8 @@ func (r *Agent) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1
 			obj.SetName(r.resource.GetName())
 			obj.SetNamespace(r.resource.GetNamespace())
 
-			if cleanupErr := r.tenantClient.Delete(ctx, &obj); cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
+			cleanupErr := r.tenantClient.Delete(ctx, &obj)
+			if cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
 				log.FromContext(ctx, "resource", r.GetName()).Error(cleanupErr, "cannot cleanup older appsv1.Deployment")
 			}
 		case tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.Mode == kamajiv1alpha1.KonnectivityAgentModeDeployment &&
@@ -139,7 +144,8 @@ func (r *Agent) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1
 			obj.SetName(r.resource.GetName())
 			obj.SetNamespace(r.resource.GetNamespace())
 
-			if cleanupErr := r.tenantClient.Delete(ctx, &obj); cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
+			cleanupErr := r.tenantClient.Delete(ctx, &obj)
+			if cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
 				log.FromContext(ctx, "resource", r.GetName()).Error(cleanupErr, "cannot cleanup older appsv1.DaemonSet")
 			}
 		}
@@ -234,11 +240,11 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 									Path:              agentTokenName,
 									Audience:          tenantControlPlane.Status.Addons.Konnectivity.ClusterRoleBinding.Name,
-									ExpirationSeconds: pointer.To(int64(3600)),
+									ExpirationSeconds: new(int64(3600)),
 								},
 							},
 						},
-						DefaultMode: pointer.To(int32(420)),
+						DefaultMode: new(int32(420)),
 					},
 				},
 			},
@@ -264,9 +270,7 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 
 		extraArgs := utilities.ArgsFromSliceToMap(tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.ExtraArgs)
 
-		for k, v := range extraArgs {
-			args[k] = v
-		}
+		maps.Copy(args, extraArgs)
 
 		podTemplateSpec.Spec.Containers[0].Args = utilities.ArgsFromMapToSlice(args)
 		podTemplateSpec.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{

--- a/internal/resources/konnectivity/agent.go
+++ b/internal/resources/konnectivity/agent.go
@@ -6,7 +6,6 @@ package konnectivity
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,6 +14,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	pointer "k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -74,13 +74,11 @@ func (r *Agent) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlan
 		return false, err
 	}
 
-	labels := r.resource.GetLabels()
-	if labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
+	if labels := r.resource.GetLabels(); labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
 		return false, nil
 	}
 
-	err = r.tenantClient.Delete(ctx, r.resource)
-	if err != nil {
+	if err := r.tenantClient.Delete(ctx, r.resource); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -110,8 +108,7 @@ func (r *Agent) Define(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 	r.resource.SetNamespace(AgentNamespace)
 	r.resource.SetName(AgentName)
 
-	r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane)
-	if err != nil {
+	if r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane); err != nil {
 		logger.Error(err, "unable to retrieve the Tenant Control Plane client")
 
 		return err
@@ -134,8 +131,7 @@ func (r *Agent) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1
 			obj.SetName(r.resource.GetName())
 			obj.SetNamespace(r.resource.GetNamespace())
 
-			cleanupErr := r.tenantClient.Delete(ctx, &obj)
-			if cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
+			if cleanupErr := r.tenantClient.Delete(ctx, &obj); cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
 				log.FromContext(ctx, "resource", r.GetName()).Error(cleanupErr, "cannot cleanup older appsv1.Deployment")
 			}
 		case tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.Mode == kamajiv1alpha1.KonnectivityAgentModeDeployment &&
@@ -144,8 +140,7 @@ func (r *Agent) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamajiv1
 			obj.SetName(r.resource.GetName())
 			obj.SetNamespace(r.resource.GetNamespace())
 
-			cleanupErr := r.tenantClient.Delete(ctx, &obj)
-			if cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
+			if cleanupErr := r.tenantClient.Delete(ctx, &obj); cleanupErr != nil && !k8serrors.IsNotFound(cleanupErr) {
 				log.FromContext(ctx, "resource", r.GetName()).Error(cleanupErr, "cannot cleanup older appsv1.DaemonSet")
 			}
 		}
@@ -240,11 +235,11 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 									Path:              agentTokenName,
 									Audience:          tenantControlPlane.Status.Addons.Konnectivity.ClusterRoleBinding.Name,
-									ExpirationSeconds: new(int64(3600)),
+									ExpirationSeconds: pointer.To(int64(3600)),
 								},
 							},
 						},
-						DefaultMode: new(int32(420)),
+						DefaultMode: pointer.To(int32(420)),
 					},
 				},
 			},
@@ -270,7 +265,9 @@ func (r *Agent) mutate(ctx context.Context, tenantControlPlane *kamajiv1alpha1.T
 
 		extraArgs := utilities.ArgsFromSliceToMap(tenantControlPlane.Spec.Addons.Konnectivity.KonnectivityAgentSpec.ExtraArgs)
 
-		maps.Copy(args, extraArgs)
+		for k, v := range extraArgs {
+			args[k] = v
+		}
 
 		podTemplateSpec.Spec.Containers[0].Args = utilities.ArgsFromMapToSlice(args)
 		podTemplateSpec.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{

--- a/internal/resources/konnectivity/certificate_resource.go
+++ b/internal/resources/konnectivity/certificate_resource.go
@@ -51,7 +51,8 @@ func (r *CertificateResource) ShouldCleanup(tenantControlPlane *kamajiv1alpha1.T
 func (r *CertificateResource) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlane) (bool, error) {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.Client.Delete(ctx, r.resource); err != nil {
+	err := r.Client.Delete(ctx, r.resource)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "cannot delete the required resource")
 
@@ -107,7 +108,8 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 		// this is required to trigger a new generation in case of Certificate Authority rotation.
 		namespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Certificates.CA.SecretName}
 		secretCA := &corev1.Secret{}
-		if err := r.Client.Get(ctx, namespacedName, secretCA); err != nil {
+		err := r.Client.Get(ctx, namespacedName, secretCA)
+		if err != nil {
 			logger.Error(err, "cannot retrieve the CA secret")
 
 			return err
@@ -121,7 +123,8 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 			},
 		))
 
-		if err := ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+		err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+		if err != nil {
 			logger.Error(err, "cannot set controller reference", "resource", r.GetName())
 
 			return err

--- a/internal/resources/konnectivity/cluster_role_binding_resource.go
+++ b/internal/resources/konnectivity/cluster_role_binding_resource.go
@@ -46,7 +46,8 @@ func (r *ClusterRoleBindingResource) ShouldCleanup(tenantControlPlane *kamajiv1a
 func (r *ClusterRoleBindingResource) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlane) (bool, error) {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.tenantClient.Get(ctx, client.ObjectKeyFromObject(r.resource), r.resource); err != nil {
+	err := r.tenantClient.Get(ctx, client.ObjectKeyFromObject(r.resource), r.resource)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -56,11 +57,13 @@ func (r *ClusterRoleBindingResource) CleanUp(ctx context.Context, _ *kamajiv1alp
 		return false, err
 	}
 
-	if labels := r.resource.GetLabels(); labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
+	labels := r.resource.GetLabels()
+	if labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
 		return false, nil
 	}
 
-	if err := r.tenantClient.Delete(ctx, r.resource); err != nil {
+	err = r.tenantClient.Delete(ctx, r.resource)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -82,7 +85,8 @@ func (r *ClusterRoleBindingResource) Define(ctx context.Context, tenantControlPl
 		},
 	}
 
-	if r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane); err != nil {
+	r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane)
+	if err != nil {
 		logger.Error(err, "cannot get Tenant Control Plane client")
 
 		return err

--- a/internal/resources/konnectivity/egress_selector_configuration_resource.go
+++ b/internal/resources/konnectivity/egress_selector_configuration_resource.go
@@ -49,7 +49,8 @@ func (r *EgressSelectorConfigurationResource) ShouldCleanup(tenantControlPlane *
 func (r *EgressSelectorConfigurationResource) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlane) (bool, error) {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.Client.Delete(ctx, r.resource); err != nil {
+	err := r.Client.Delete(ctx, r.resource)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "cannot delete the requested resource")
 

--- a/internal/resources/konnectivity/kubeconfig_resource.go
+++ b/internal/resources/konnectivity/kubeconfig_resource.go
@@ -48,7 +48,8 @@ func (r *KubeconfigResource) ShouldCleanup(tenantControlPlane *kamajiv1alpha1.Te
 func (r *KubeconfigResource) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlane) (bool, error) {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.Client.Delete(ctx, r.resource); err != nil {
+	err := r.Client.Delete(ctx, r.resource)
+	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "cannot delete the requested resource")
 
@@ -108,7 +109,8 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 			},
 		))
 
-		if err := ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+		err := ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+		if err != nil {
 			logger.Error(err, "cannot set controller reference for kubeconfig", "resource", r.GetName())
 
 			return err
@@ -118,7 +120,8 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 
 		caNamespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Certificates.CA.SecretName}
 		secretCA := &corev1.Secret{}
-		if err := r.Client.Get(ctx, caNamespacedName, secretCA); err != nil {
+		err = r.Client.Get(ctx, caNamespacedName, secretCA)
+		if err != nil {
 			logger.Error(err, "cannot retrieve the CA secret")
 
 			return err
@@ -132,7 +135,8 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 
 		certificateNamespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Addons.Konnectivity.Certificate.SecretName}
 		secretCertificate := &corev1.Secret{}
-		if err := r.Client.Get(ctx, certificateNamespacedName, secretCertificate); err != nil {
+		err = r.Client.Get(ctx, certificateNamespacedName, secretCertificate)
+		if err != nil {
 			logger.Error(err, "cannot retrieve the Konnectivity Certificate secret")
 
 			return err

--- a/internal/resources/konnectivity/service_account_resource.go
+++ b/internal/resources/konnectivity/service_account_resource.go
@@ -45,7 +45,8 @@ func (r *ServiceAccountResource) ShouldCleanup(tenantControlPlane *kamajiv1alpha
 func (r *ServiceAccountResource) CleanUp(ctx context.Context, _ *kamajiv1alpha1.TenantControlPlane) (bool, error) {
 	logger := log.FromContext(ctx, "resource", r.GetName())
 
-	if err := r.tenantClient.Get(ctx, client.ObjectKeyFromObject(r.resource), r.resource); err != nil {
+	err := r.tenantClient.Get(ctx, client.ObjectKeyFromObject(r.resource), r.resource)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -55,11 +56,13 @@ func (r *ServiceAccountResource) CleanUp(ctx context.Context, _ *kamajiv1alpha1.
 		return false, err
 	}
 
-	if labels := r.resource.GetLabels(); labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
+	labels := r.resource.GetLabels()
+	if labels == nil || labels[constants.ProjectNameLabelKey] != constants.ProjectNameLabelValue {
 		return false, nil
 	}
 
-	if err := r.tenantClient.Delete(ctx, r.resource); err != nil {
+	err = r.tenantClient.Delete(ctx, r.resource)
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -82,7 +85,8 @@ func (r *ServiceAccountResource) Define(ctx context.Context, tenantControlPlane 
 		},
 	}
 
-	if r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane); err != nil {
+	r.tenantClient, err = utilities.GetTenantClient(ctx, r.Client, tenantControlPlane)
+	if err != nil {
 		logger.Error(err, "cannot generate tenant client")
 
 		return err

--- a/internal/resources/kubeadm_config.go
+++ b/internal/resources/kubeadm_config.go
@@ -148,7 +148,8 @@ func (r *KubeadmConfigResource) mutate(ctx context.Context, tenantControlPlane *
 		if err != nil {
 			return err
 		}
-		if r.resource.Data, err = kubeadm.GetKubeadmInitConfigurationMap(*config); err != nil {
+		r.resource.Data, err = kubeadm.GetKubeadmInitConfigurationMap(*config)
+		if err != nil {
 			logger.Error(err, "cannot retrieve kubeadm init configuration")
 
 			return err

--- a/internal/resources/kubeadm_phases.go
+++ b/internal/resources/kubeadm_phases.go
@@ -160,7 +160,8 @@ func (r *KubeadmPhase) GetKubeadmFunction(ctx context.Context, tcp *kamajiv1alph
 				if patchErr != nil {
 					return nil, fmt.Errorf("cannot encode JSON Patches to JSON: %w", patchErr)
 				}
-				if patch, patchErr = jsonpatchv5.DecodePatch(jsonP); patchErr != nil {
+				patch, patchErr = jsonpatchv5.DecodePatch(jsonP)
+				if patchErr != nil {
 					return nil, fmt.Errorf("cannot decode JSON Patches: %w", patchErr)
 				}
 			}
@@ -183,7 +184,8 @@ func (r *KubeadmPhase) GetKubeadmFunction(ctx context.Context, tcp *kamajiv1alph
 			defer func() { _ = os.Remove(tmp) }()
 
 			var caSecret corev1.Secret
-			if err = r.Client.Get(ctx, types.NamespacedName{Name: tcp.Status.Certificates.CA.SecretName, Namespace: tcp.Namespace}, &caSecret); err != nil {
+			err = r.Client.Get(ctx, types.NamespacedName{Name: tcp.Status.Certificates.CA.SecretName, Namespace: tcp.Namespace}, &caSecret)
+			if err != nil {
 				return nil, err
 			}
 
@@ -208,9 +210,10 @@ func (r *KubeadmPhase) GetKubeadmFunction(ctx context.Context, tcp *kamajiv1alph
 				BindPort:         tcp.Spec.NetworkProfile.Port,
 			}
 
-			if _, err = kubeconfig.EnsureAdminClusterRoleBinding(tmp, &localAPIEndpoint, func(_ context.Context, _ clientset.Interface, _ clientset.Interface, retryInterval time.Duration, retryTimeout time.Duration) (clientset.Interface, error) {
+			_, err = kubeconfig.EnsureAdminClusterRoleBinding(tmp, &localAPIEndpoint, func(_ context.Context, _ clientset.Interface, _ clientset.Interface, retryInterval time.Duration, retryTimeout time.Duration) (clientset.Interface, error) {
 				return kubeconfig.EnsureAdminClusterRoleBindingImpl(ctx, c, c, retryInterval, retryTimeout)
-			}); err != nil {
+			})
+			if err != nil {
 				return nil, err
 			}
 

--- a/internal/resources/kubeadm_upgrade.go
+++ b/internal/resources/kubeadm_upgrade.go
@@ -68,7 +68,8 @@ func (k *KubernetesUpgrade) CreateOrUpdate(ctx context.Context, tenantControlPla
 		return controllerutil.OperationResultNone, nil
 	}
 	// An upgrade is in progress, let it go
-	if status := tenantControlPlane.Status.Kubernetes.Version.Status; status != nil && *status == kamajiv1alpha1.VersionUpgrading {
+	status := tenantControlPlane.Status.Kubernetes.Version.Status
+	if status != nil && *status == kamajiv1alpha1.VersionUpgrading {
 		return controllerutil.OperationResultNone, nil
 	}
 	// Checking if the upgrade is allowed, or not
@@ -84,11 +85,13 @@ func (k *KubernetesUpgrade) CreateOrUpdate(ctx context.Context, tenantControlPla
 
 	versionGetter := kamajiupgrade.NewKamajiKubeVersionGetter(clientSet, tenantControlPlane.Status.Kubernetes.Version.Version, coreDNSVersion, tenantControlPlane.Status.Kubernetes.Version.Status)
 
-	if _, err = upgrade.GetAvailableUpgrades(versionGetter, false, false, &printers.Discard{}); err != nil {
+	_, err = upgrade.GetAvailableUpgrades(versionGetter, false, false, &printers.Discard{})
+	if err != nil {
 		return controllerutil.OperationResultNone, fmt.Errorf("cannot retrieve available Upgrades for Kubernetes upgrade plan: %w", err)
 	}
 
-	if err = k.isUpgradable(); err != nil {
+	err = k.isUpgradable()
+	if err != nil {
 		return controllerutil.OperationResultNone, fmt.Errorf("the required upgrade plan is not available")
 	}
 

--- a/internal/resources/kubeadm_utils.go
+++ b/internal/resources/kubeadm_utils.go
@@ -53,7 +53,8 @@ func GetKubeadmManifestDeps(ctx context.Context, client client.Client, tenantCon
 		TenantControlPlaneCGroupDriver: tenantControlPlane.Spec.Kubernetes.Kubelet.CGroupFS.String(), //nolint:staticcheck
 	}
 	// If CoreDNS addon is enabled and with an override, adding these to the kubeadm init configuration
-	if coreDNS := tenantControlPlane.Spec.Addons.CoreDNS; coreDNS != nil {
+	coreDNS := tenantControlPlane.Spec.Addons.CoreDNS
+	if coreDNS != nil {
 		config.Parameters.CoreDNSOptions = &kubeadm.AddonOptions{}
 
 		if len(coreDNS.ImageRepository) > 0 {
@@ -65,7 +66,8 @@ func GetKubeadmManifestDeps(ctx context.Context, client client.Client, tenantCon
 		}
 	}
 	// If the kube-proxy addon is enabled and with overrides, adding it to the kubeadm parameters
-	if kubeProxy := tenantControlPlane.Spec.Addons.KubeProxy; kubeProxy != nil {
+	kubeProxy := tenantControlPlane.Spec.Addons.KubeProxy
+	if kubeProxy != nil {
 		config.Parameters.KubeProxyOptions = &kubeadm.AddonOptions{}
 
 		if len(kubeProxy.ImageRepository) > 0 {
@@ -100,7 +102,8 @@ func KubeadmBootstrap(ctx context.Context, r KubeadmPhaseResource, logger logr.L
 	}
 
 	var clusterInfo corev1.ConfigMap
-	if cmErr := tntClient.Get(ctx, types.NamespacedName{Name: bootstrapapi.ConfigMapClusterInfo, Namespace: metav1.NamespacePublic}, &clusterInfo); cmErr != nil {
+	cmErr := tntClient.Get(ctx, types.NamespacedName{Name: bootstrapapi.ConfigMapClusterInfo, Namespace: metav1.NamespacePublic}, &clusterInfo)
+	if cmErr != nil {
 		if !k8serrors.IsNotFound(cmErr) {
 			logger.Error(cmErr, "cannot retrieve cluster-info ConfigMap")
 		}
@@ -153,7 +156,8 @@ func KubeadmBootstrap(ctx context.Context, r KubeadmPhaseResource, logger logr.L
 		return controllerutil.OperationResultNone, err
 	}
 
-	if _, err = fun(client, config); err != nil {
+	_, err = fun(client, config)
+	if err != nil {
 		logger.Error(err, "kubeadm function failed")
 
 		return controllerutil.OperationResultNone, err
@@ -242,7 +246,8 @@ func KubeadmPhaseCreate(ctx context.Context, r KubeadmPhaseResource, logger logr
 
 		return controllerutil.OperationResultNone, err
 	}
-	if _, err = fun(client, config); err != nil {
+	_, err = fun(client, config)
+	if err != nil {
 		logger.Error(err, "kubeadm function failed")
 
 		return controllerutil.OperationResultNone, err

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -149,7 +149,8 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 			return err
 		}
 
-		if err = r.customizeConfig(config); err != nil {
+		err = r.customizeConfig(config)
+		if err != nil {
 			logger.Error(err, "cannot customize the configuration")
 
 			return err
@@ -157,7 +158,8 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 
 		caSecretNamespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Certificates.CA.SecretName}
 		caCertificatesSecret := &corev1.Secret{}
-		if err = r.Client.Get(ctx, caSecretNamespacedName, caCertificatesSecret); err != nil {
+		err = r.Client.Get(ctx, caSecretNamespacedName, caCertificatesSecret)
+		if err != nil {
 			logger.Error(err, "cannot retrieve the CA")
 
 			return err
@@ -181,7 +183,8 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 		))
 		r.resource.SetAnnotations(utilities.MergeMaps(r.resource.GetAnnotations(), map[string]string{constants.Checksum: checksum}))
 
-		if err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme()); err != nil {
+		err = ctrl.SetControllerReference(tenantControlPlane, r.resource, r.Client.Scheme())
+		if err != nil {
 			logger.Error(err, "cannot set controller reference", "resource", r.GetName())
 
 			return err

--- a/internal/resources/resource.go
+++ b/internal/resources/resource.go
@@ -72,7 +72,8 @@ func Handle(ctx context.Context, resource Resource, tenantControlPlane *kamajiv1
 		resource.GetHistogram().Observe(time.Since(startTime).Seconds())
 	}()
 
-	if err := resource.Define(ctx, tenantControlPlane); err != nil {
+	err := resource.Define(ctx, tenantControlPlane)
+	if err != nil {
 		return "", err
 	}
 
@@ -94,7 +95,8 @@ func Handle(ctx context.Context, resource Resource, tenantControlPlane *kamajiv1
 
 // HandleDeletion handles the deletion of the given resource.
 func HandleDeletion(ctx context.Context, resource DeletableResource, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
-	if err := resource.Define(ctx, tenantControlPlane); err != nil {
+	err := resource.Define(ctx, tenantControlPlane)
+	if err != nil {
 		return err
 	}
 
@@ -117,7 +119,8 @@ func createOrUpdate(ctx context.Context, resource Resource, tenantControlPlane *
 func getStoredKubeadmConfiguration(ctx context.Context, client client.Client, tmpDirectory string, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) (*kubeadm.Configuration, error) {
 	var configmap corev1.ConfigMap
 	namespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.KubeadmConfig.ConfigmapName}
-	if err := client.Get(ctx, namespacedName, &configmap); err != nil {
+	err := client.Get(ctx, namespacedName, &configmap)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/utilities/checksum.go
+++ b/internal/utilities/checksum.go
@@ -7,7 +7,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"sort"
-	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -44,13 +43,11 @@ func SetObjectChecksum(obj client.Object, data any) {
 func CalculateStringSliceChecksum(data []string) (string, error) {
 	h := md5.New()
 	for _, s := range data {
-		_, err := h.Write([]byte(s))
-		if err != nil {
+		if _, err := h.Write([]byte(s)); err != nil {
 			return "", err
 		}
 		// Add separator to avoid collisions (e.g., ["ab", "c"] vs ["a", "bc"])
-		_, err = h.Write([]byte{0})
-		if err != nil {
+		if _, err := h.Write([]byte{0}); err != nil {
 			return "", err
 		}
 	}
@@ -79,13 +76,13 @@ func calculateMapStringString(data map[string]string) string {
 
 	sort.Strings(keys)
 
-	var checksum strings.Builder
+	var checksum string
 
 	for _, key := range keys {
-		checksum.WriteString(data[key])
+		checksum += data[key]
 	}
 
-	return md5Checksum([]byte(checksum.String()))
+	return md5Checksum([]byte(checksum))
 }
 
 func calculateMapStringByte(data map[string][]byte) string {
@@ -96,13 +93,13 @@ func calculateMapStringByte(data map[string][]byte) string {
 
 	sort.Strings(keys)
 
-	var checksum strings.Builder
+	var checksum string
 
 	for _, key := range keys {
-		checksum.WriteString(string(data[key]))
+		checksum += string(data[key])
 	}
 
-	return md5Checksum([]byte(checksum.String()))
+	return md5Checksum([]byte(checksum))
 }
 
 func md5Checksum(value []byte) string {

--- a/internal/utilities/checksum.go
+++ b/internal/utilities/checksum.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"sort"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -43,11 +44,13 @@ func SetObjectChecksum(obj client.Object, data any) {
 func CalculateStringSliceChecksum(data []string) (string, error) {
 	h := md5.New()
 	for _, s := range data {
-		if _, err := h.Write([]byte(s)); err != nil {
+		_, err := h.Write([]byte(s))
+		if err != nil {
 			return "", err
 		}
 		// Add separator to avoid collisions (e.g., ["ab", "c"] vs ["a", "bc"])
-		if _, err := h.Write([]byte{0}); err != nil {
+		_, err = h.Write([]byte{0})
+		if err != nil {
 			return "", err
 		}
 	}
@@ -76,13 +79,13 @@ func calculateMapStringString(data map[string]string) string {
 
 	sort.Strings(keys)
 
-	var checksum string
+	var checksum strings.Builder
 
 	for _, key := range keys {
-		checksum += data[key]
+		checksum.WriteString(data[key])
 	}
 
-	return md5Checksum([]byte(checksum))
+	return md5Checksum([]byte(checksum.String()))
 }
 
 func calculateMapStringByte(data map[string][]byte) string {
@@ -93,13 +96,13 @@ func calculateMapStringByte(data map[string][]byte) string {
 
 	sort.Strings(keys)
 
-	var checksum string
+	var checksum strings.Builder
 
 	for _, key := range keys {
-		checksum += string(data[key])
+		checksum.WriteString(string(data[key]))
 	}
 
-	return md5Checksum([]byte(checksum))
+	return md5Checksum([]byte(checksum.String()))
 }
 
 func md5Checksum(value []byte) string {

--- a/internal/utilities/create_or_update_conflict.go
+++ b/internal/utilities/create_or_update_conflict.go
@@ -18,7 +18,8 @@ import (
 // without enqueuing back the request in order to get the latest changes of the resource.
 func CreateOrUpdateWithConflict(ctx context.Context, client client.Client, resource client.Object, f controllerutil.MutateFn) (res controllerutil.OperationResult, err error) {
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() (scopeErr error) {
-		if scopeErr = client.Get(ctx, k8stypes.NamespacedName{Namespace: resource.GetNamespace(), Name: resource.GetName()}, resource); scopeErr != nil {
+		scopeErr = client.Get(ctx, k8stypes.NamespacedName{Namespace: resource.GetNamespace(), Name: resource.GetName()}, resource)
+		if scopeErr != nil {
 			if !errors.IsNotFound(scopeErr) {
 				return scopeErr
 			}

--- a/internal/utilities/kubeconfig.go
+++ b/internal/utilities/kubeconfig.go
@@ -24,7 +24,8 @@ func DecodeKubeconfig(secret corev1.Secret, key string) (*clientcmdapiv1.Config,
 
 func DecodeKubeconfigYAML(bytes []byte) (*clientcmdapiv1.Config, error) {
 	kubeconfig := &clientcmdapiv1.Config{}
-	if err := DecodeFromYAML(string(bytes), kubeconfig); err != nil {
+	err := DecodeFromYAML(string(bytes), kubeconfig)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/utilities/tenant_client.go
+++ b/internal/utilities/tenant_client.go
@@ -40,7 +40,8 @@ func GetTenantClientSet(ctx context.Context, client client.Client, tenantControl
 
 func GetTenantKubeconfig(ctx context.Context, client client.Client, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) (*clientcmdapiv1.Config, error) {
 	secretKubeconfig := &corev1.Secret{}
-	if err := client.Get(ctx, k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.KubeConfig.Admin.SecretName}, secretKubeconfig); err != nil {
+	err := client.Get(ctx, k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.KubeConfig.Admin.SecretName}, secretKubeconfig)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/utilities/utilities.go
+++ b/internal/utilities/utilities.go
@@ -6,6 +6,7 @@ package utilities
 import (
 	"bytes"
 	"fmt"
+	maps0 "maps"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,9 +33,7 @@ func MergeMaps(maps ...map[string]string) map[string]string {
 	result := map[string]string{}
 
 	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
+		maps0.Copy(result, m)
 	}
 
 	return result
@@ -56,7 +55,8 @@ func EncodeToYaml(o runtime.Object) ([]byte, error) {
 
 	buf := bytes.NewBuffer([]byte{})
 
-	if err := encoder.Encode(o, buf); err != nil {
+	err := encoder.Encode(o, buf)
+	if err != nil {
 		return nil, err
 	}
 
@@ -72,7 +72,8 @@ func DecodeFromYAML(o string, to runtime.Object) (err error) {
 		Strict: false,
 	})
 
-	if to, _, err = encoder.Decode([]byte(o), nil, to); err != nil { //nolint:ineffassign,staticcheck,wastedassign
+	to, _, err = encoder.Decode([]byte(o), nil, to)
+	if err != nil { //nolint:ineffassign,staticcheck,wastedassign
 		return
 	}
 
@@ -88,7 +89,8 @@ func DecodeFromJSON(o string, to runtime.Object) (err error) {
 		Strict: false,
 	})
 
-	if to, _, err = encoder.Decode([]byte(o), nil, to); err != nil { //nolint:ineffassign,staticcheck,wastedassign
+	to, _, err = encoder.Decode([]byte(o), nil, to)
+	if err != nil { //nolint:ineffassign,staticcheck,wastedassign
 		return
 	}
 
@@ -107,7 +109,8 @@ func EncodeToJSON(o runtime.Object) ([]byte, error) {
 
 	buf := bytes.NewBuffer([]byte{})
 
-	if err := encoder.Encode(o, buf); err != nil {
+	err := encoder.Encode(o, buf)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/webhook/chainer.go
+++ b/internal/webhook/chainer.go
@@ -32,11 +32,13 @@ func (h handlersChainer) Handler(object runtime.Object, routeHandlers ...handler
 			case admissionv1.Delete:
 				// When deleting the OldObject struct field contains the object being deleted:
 				// https://github.com/kubernetes/kubernetes/pull/76346
-				if err := h.decoder.DecodeRaw(req.OldObject, decodedObj); err != nil {
+				err := h.decoder.DecodeRaw(req.OldObject, decodedObj)
+				if err != nil {
 					return admission.Errored(http.StatusInternalServerError, fmt.Errorf("unable to decode deleted object into %T: %w", object, err))
 				}
 			default:
-				if err := h.decoder.Decode(req, decodedObj); err != nil {
+				err := h.decoder.Decode(req, decodedObj)
+				if err != nil {
 					return admission.Errored(http.StatusInternalServerError, fmt.Errorf("unable to decode into %T: %w", object, err))
 				}
 			}
@@ -68,7 +70,8 @@ func (h handlersChainer) Handler(object runtime.Object, routeHandlers ...handler
 				patches = append(patches, handlerPatches...)
 			}
 		case admissionv1.Update:
-			if err := h.decoder.DecodeRaw(req.OldObject, oldDecodedObj); err != nil {
+			err := h.decoder.DecodeRaw(req.OldObject, oldDecodedObj)
+			if err != nil {
 				return admission.Errored(http.StatusInternalServerError, fmt.Errorf("unable to decode old object into %T: %w", object, err))
 			}
 

--- a/internal/webhook/handlers/ds_secrets.go
+++ b/internal/webhook/handlers/ds_secrets.go
@@ -37,7 +37,8 @@ func (d DataStoreSecretValidation) OnUpdate(object runtime.Object, _ runtime.Obj
 
 		dsList := &kamajiv1alpha1.DataStoreList{}
 
-		if err := d.Client.List(ctx, dsList, client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(kamajiv1alpha1.DatastoreUsedSecretNamespacedNameKey, fmt.Sprintf("%s/%s", secret.GetNamespace(), secret.GetName()))}); err != nil {
+		err := d.Client.List(ctx, dsList, client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(kamajiv1alpha1.DatastoreUsedSecretNamespacedNameKey, fmt.Sprintf("%s/%s", secret.GetNamespace(), secret.GetName()))})
+		if err != nil {
 			return nil, fmt.Errorf("cannot list Tenant Control Plane using the provided Secret: %w", err)
 		}
 

--- a/internal/webhook/handlers/tcp_datastore.go
+++ b/internal/webhook/handlers/tcp_datastore.go
@@ -51,7 +51,8 @@ func (t TenantControlPlaneDataStore) OnUpdate(object runtime.Object, _ runtime.O
 }
 
 func (t TenantControlPlaneDataStore) check(ctx context.Context, dataStoreName string) error {
-	if err := t.Client.Get(ctx, types.NamespacedName{Name: dataStoreName}, &kamajiv1alpha1.DataStore{}); err != nil {
+	err := t.Client.Get(ctx, types.NamespacedName{Name: dataStoreName}, &kamajiv1alpha1.DataStore{})
+	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return fmt.Errorf("%s DataStore does not exist", dataStoreName)
 		}
@@ -70,7 +71,8 @@ func (t TenantControlPlaneDataStore) checkDataStoreOverrides(ctx context.Context
 		} else {
 			return fmt.Errorf("duplicate resource override in Spec.DataStoreOverrides")
 		}
-		if err := t.check(ctx, ds.DataStore); err != nil {
+		err := t.check(ctx, ds.DataStore)
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/webhook/handlers/tcp_deployment.go
+++ b/internal/webhook/handlers/tcp_deployment.go
@@ -62,7 +62,8 @@ func (t TenantControlPlaneDeployment) OnUpdate(newObject runtime.Object, oldObje
 		}
 
 		ds := kamajiv1alpha1.DataStore{}
-		if err := t.Client.Get(ctx, types.NamespacedName{Name: tcp.Spec.DataStore}, &ds); err != nil {
+		err := t.Client.Get(ctx, types.NamespacedName{Name: tcp.Spec.DataStore}, &ds)
+		if err != nil {
 			return nil, err
 		}
 		t.DeploymentBuilder.DataStore = ds
@@ -71,7 +72,8 @@ func (t TenantControlPlaneDeployment) OnUpdate(newObject runtime.Object, oldObje
 
 		for _, dso := range tcp.Spec.DataStoreOverrides {
 			ds := kamajiv1alpha1.DataStore{}
-			if err := t.Client.Get(ctx, types.NamespacedName{Name: dso.DataStore}, &ds); err != nil {
+			err := t.Client.Get(ctx, types.NamespacedName{Name: dso.DataStore}, &ds)
+			if err != nil {
 				return nil, err
 			}
 			dataStoreOverrides = append(dataStoreOverrides, controlplane.DataStoreOverrides{
@@ -85,7 +87,7 @@ func (t TenantControlPlaneDeployment) OnUpdate(newObject runtime.Object, oldObje
 		deployment.Name = tcp.Name
 		deployment.Namespace = tcp.Namespace
 
-		err := t.Client.Get(ctx, types.NamespacedName{Name: tcp.Name, Namespace: tcp.Namespace}, &deployment)
+		err = t.Client.Get(ctx, types.NamespacedName{Name: tcp.Name, Namespace: tcp.Namespace}, &deployment)
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/internal/webhook/handlers/tcp_dns.go
+++ b/internal/webhook/handlers/tcp_dns.go
@@ -34,7 +34,8 @@ func (t TenantControlPlaneDNS) validate(object runtime.Object) AdmissionResponse
 	return func(context.Context, admission.Request) ([]jsonpatch.JsonPatchOperation, error) {
 		tcp := object.(*kamajiv1alpha1.TenantControlPlane) //nolint:forcetypeassert
 
-		if err := validateDNSServiceIPs(tcp); err != nil {
+		err := validateDNSServiceIPs(tcp)
+		if err != nil {
 			return nil, err
 		}
 

--- a/internal/webhook/handlers/tcp_gateway_validate.go
+++ b/internal/webhook/handlers/tcp_gateway_validate.go
@@ -33,7 +33,8 @@ func (t TenantControlPlaneGatewayValidation) OnCreate(object runtime.Object) Adm
 		if tcp.Spec.ControlPlane.Gateway != nil {
 			// NOTE: Do we actually want to deny here if Gateway API is not available or a warning?
 			// Seems sensible to deny to avoid anything.
-			if err := t.validateGatewayAPIAvailability(ctx); err != nil {
+			err := t.validateGatewayAPIAvailability(ctx)
+			if err != nil {
 				return nil, err
 			}
 		}
@@ -50,7 +51,8 @@ func (t TenantControlPlaneGatewayValidation) OnUpdate(object runtime.Object, _ r
 		}
 
 		if tcp.Spec.ControlPlane.Gateway != nil {
-			if err := t.validateGatewayAPIAvailability(ctx); err != nil {
+			err := t.validateGatewayAPIAvailability(ctx)
+			if err != nil {
 				return nil, err
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,8 @@ func main() {
 	root.AddCommand(migrator)
 	root.AddCommand(kubeconfigGenerator)
 
-	if err := root.Execute(); err != nil {
+	err := root.Execute()
+	if err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Transforms inline error handling to plain assignment form. Handles simple := and multi-assignment (=) forms. Fixes 313 baseline issues to 0 remaining.