### PR TITLE
chore: gci import formatting

### DIFF
--- a/e2e/tcp_mysql_ready_test.go
+++ b/e2e/tcp_mysql_ready_test.go
@@ -6,12 +6,10 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane resource with the MySQL driver", func() {
@@ -25,7 +23,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with the MySQL driver", f
 			DataStore: "mysql-bronze",
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_nats_ready_no_tls_test.go
+++ b/e2e/tcp_nats_ready_no_tls_test.go
@@ -6,12 +6,10 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane resource with the NATS driver without TLS", func() {
@@ -25,7 +23,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with the NATS driver with
 			DataStore: "nats-notls",
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_nats_ready_test.go
+++ b/e2e/tcp_nats_ready_test.go
@@ -6,12 +6,10 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane resource with the NATS driver", func() {
@@ -25,7 +23,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with the NATS driver", fu
 			DataStore: "nats-bronze",
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_pod_additional_metadata_test.go
+++ b/e2e/tcp_pod_additional_metadata_test.go
@@ -6,12 +6,10 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane resource with additional pod metadata", func() {
@@ -24,7 +22,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with additional pod metad
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 					PodAdditionalMetadata: kamajiv1alpha1.AdditionalMetadata{
 						Labels: map[string]string{
 							"hello-label": "world",

--- a/e2e/tcp_postgres_ready_test.go
+++ b/e2e/tcp_postgres_ready_test.go
@@ -6,12 +6,10 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane resource with the PostgreSQL driver", func() {
@@ -25,7 +23,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with the PostgreSQL drive
 			DataStore: "postgresql-bronze",
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_scale_test.go
+++ b/e2e/tcp_scale_test.go
@@ -6,12 +6,10 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Scale a TenantControlPlane resource", func() {
@@ -24,7 +22,7 @@ var _ = Describe("Scale a TenantControlPlane resource", func() {
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_security_contexts_test.go
+++ b/e2e/tcp_security_contexts_test.go
@@ -6,29 +6,27 @@ package e2e
 import (
 	"context"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane resource with security contexts", func() {
 	// Contexts are chosen without overlap to allow to verify that context is set on the desired container
 	apiServerSecurityContext := &corev1.SecurityContext{
-		ReadOnlyRootFilesystem: pointer.To(true),
+		ReadOnlyRootFilesystem: new(true),
 	}
 
 	controllerManagerSecurityContext := &corev1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.To(false),
+		AllowPrivilegeEscalation: new(false),
 	}
 
 	schedulerSecurityContext := &corev1.SecurityContext{
-		Privileged: pointer.To(false),
+		Privileged: new(false),
 	}
 
 	konnectivitySecurityContext := &corev1.SecurityContext{
@@ -52,7 +50,7 @@ var _ = Describe("Deploy a TenantControlPlane resource with security contexts", 
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 					ContainerSecurityContexts: &kamajiv1alpha1.ControlPlaneContainerSecurityContexts{
 						APIServer:         apiServerSecurityContext,
 						ControllerManager: controllerManagerSecurityContext,

--- a/e2e/tcp_validation_preferredkubeletaddresstypes_test.go
+++ b/e2e/tcp_validation_preferredkubeletaddresstypes_test.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"time"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("Deploy a TenantControlPlane with wrong preferred kubelet address type entries", func() {
@@ -27,7 +25,7 @@ var _ = Describe("Deploy a TenantControlPlane with wrong preferred kubelet addre
 					DataStore: "default",
 					ControlPlane: kamajiv1alpha1.ControlPlane{
 						Deployment: kamajiv1alpha1.DeploymentSpec{
-							Replicas: pointer.To(int32(1)),
+							Replicas: new(int32(1)),
 						},
 						Service: kamajiv1alpha1.ServiceSpec{
 							ServiceType: "ClusterIP",
@@ -63,7 +61,7 @@ var _ = Describe("Deploy a TenantControlPlane with wrong preferred kubelet addre
 					DataStore: "default",
 					ControlPlane: kamajiv1alpha1.ControlPlane{
 						Deployment: kamajiv1alpha1.DeploymentSpec{
-							Replicas: pointer.To(int32(1)),
+							Replicas: new(int32(1)),
 						},
 						Service: kamajiv1alpha1.ServiceSpec{
 							ServiceType: "ClusterIP",

--- a/e2e/tcp_validation_version_downgrade_test.go
+++ b/e2e/tcp_validation_version_downgrade_test.go
@@ -7,13 +7,11 @@ import (
 	"context"
 	"time"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("downgrade of a TenantControlPlane Kubernetes version", func() {
@@ -26,7 +24,7 @@ var _ = Describe("downgrade of a TenantControlPlane Kubernetes version", func() 
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_validation_version_nonlinear_test.go
+++ b/e2e/tcp_validation_version_nonlinear_test.go
@@ -7,13 +7,11 @@ import (
 	"context"
 	"time"
 
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
 var _ = Describe("non-linear minor upgrade of a TenantControlPlane Kubernetes version", func() {
@@ -26,7 +24,7 @@ var _ = Describe("non-linear minor upgrade of a TenantControlPlane Kubernetes ve
 		Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 			ControlPlane: kamajiv1alpha1.ControlPlane{
 				Deployment: kamajiv1alpha1.DeploymentSpec{
-					Replicas: pointer.To(int32(1)),
+					Replicas: new(int32(1)),
 				},
 				Service: kamajiv1alpha1.ServiceSpec{
 					ServiceType: "ClusterIP",

--- a/e2e/tcp_validation_version_unsupport_test.go
+++ b/e2e/tcp_validation_version_unsupport_test.go
@@ -9,14 +9,12 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/upgrade"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	pointer "k8s.io/utils/ptr"
-
-	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
-	"github.com/clastix/kamaji/internal/upgrade"
 )
 
 var _ = Describe("using an unsupported TenantControlPlane Kubernetes version", func() {
@@ -36,7 +34,7 @@ var _ = Describe("using an unsupported TenantControlPlane Kubernetes version", f
 				Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 					ControlPlane: kamajiv1alpha1.ControlPlane{
 						Deployment: kamajiv1alpha1.DeploymentSpec{
-							Replicas: pointer.To(int32(1)),
+							Replicas: new(int32(1)),
 						},
 						Service: kamajiv1alpha1.ServiceSpec{
 							ServiceType: "ClusterIP",
@@ -64,7 +62,7 @@ var _ = Describe("using an unsupported TenantControlPlane Kubernetes version", f
 			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
 				ControlPlane: kamajiv1alpha1.ControlPlane{
 					Deployment: kamajiv1alpha1.DeploymentSpec{
-						Replicas: pointer.To(int32(1)),
+						Replicas: new(int32(1)),
 					},
 					Service: kamajiv1alpha1.ServiceSpec{
 						ServiceType: "ClusterIP",


### PR DESCRIPTION
GCI import formatting fixes to comply with gci linter rules.

- Add blank lines between import groups (standard library, third-party, local)
- Reorder imports to follow Go conventions