### PR TITLE
fix: kubeconfig-generator reconcile timeout and add secure metrics option (#1229)

### DIFF
--- a/cmd/kubeconfig-generator/cmd.go
+++ b/cmd/kubeconfig-generator/cmd.go
@@ -21,8 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	cmdutils "github.com/clastix/kamaji/cmd/utils"
 	"github.com/clastix/kamaji/controllers"
 	"github.com/clastix/kamaji/internal"
 	"github.com/clastix/kamaji/internal/metrics"
@@ -32,6 +32,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	// CLI flags
 	var (
 		metricsBindAddress            string
+		metricsSecure                 bool
 		healthProbeBindAddress        string
 		leaderElect                   bool
 		controllerReconcileTimeout    time.Duration
@@ -54,6 +55,10 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				return fmt.Errorf("certificate expiration deadline must be at least 24 hours")
 			}
 
+			if controllerReconcileTimeout.Seconds() == 0 {
+				return fmt.Errorf("the controller reconcile timeout must be greater than zero")
+			}
+
 			return nil
 		},
 		RunE: func(*cobra.Command, []string) error {
@@ -68,10 +73,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", goRuntime.GOOS, goRuntime.GOARCH))
 
 			ctrlOpts := ctrl.Options{
-				Scheme: scheme,
-				Metrics: metricsserver.Options{
-					BindAddress: metricsBindAddress,
-				},
+				Scheme:                  scheme,
+				Metrics:                 cmdutils.MetricsServerOptions(metricsBindAddress, metricsSecure),
 				HealthProbeBindAddress:  healthProbeBindAddress,
 				LeaderElection:          leaderElect,
 				LeaderElectionNamespace: managerNamespace,
@@ -107,7 +110,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				}
 			}
 
-			certController := &controllers.CertificateLifecycle{Channel: triggerChan, Deadline: certificateExpirationDeadline, Metrics: metricsRecorder}
+			certController := &controllers.CertificateLifecycle{Channel: triggerChan, Deadline: certificateExpirationDeadline, ReconcileTimeout: controllerReconcileTimeout, Metrics: metricsRecorder}
 			certController.EnqueueFn = certController.EnqueueForKubeconfigGenerator
 			if err = certController.SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "CertificateLifecycle")
@@ -116,8 +119,9 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			}
 
 			if err = (&controllers.KubeconfigGeneratorWatcher{
-				Client:        mgr.GetClient(),
-				GeneratorChan: triggerChan,
+				Client:           mgr.GetClient(),
+				GeneratorChan:    triggerChan,
+				ReconcileTimeout: controllerReconcileTimeout,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "KubeconfigGeneratorWatcher")
 
@@ -127,6 +131,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			if err = (&controllers.KubeconfigGeneratorReconciler{
 				Client:            mgr.GetClient(),
 				NotValidThreshold: certificateExpirationDeadline,
+				ReconcileTimeout:  controllerReconcileTimeout,
 				CertificateChan:   triggerChan,
 			}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create controller", "controller", "KubeconfigGenerator")
@@ -154,6 +159,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	// Setting CLI flags
 	cmd.Flags().StringVar(&metricsBindAddress, "metrics-bind-address", ":8090", "The address the metric endpoint binds to.")
+	cmd.Flags().BoolVar(&metricsSecure, "metrics-secure", false, "If set, the metrics endpoint is served over HTTPS and requires a bearer token authorized against the manager's kamaji-metrics-reader ClusterRole, instead of being served in plaintext without authentication.")
 	cmd.Flags().StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8091", "The address the probe endpoint binds to.")
 	cmd.Flags().BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().DurationVar(&controllerReconcileTimeout, "controller-reconcile-timeout", 30*time.Second, "The reconciliation request timeout before the controller withdraw the external resource calls, such as dealing with the Datastore, or the Tenant Control Plane API endpoint.")

--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
@@ -45,6 +44,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	// CLI flags
 	var (
 		metricsBindAddress            string
+		metricsSecure                 bool
 		healthProbeBindAddress        string
 		pprofBindAddress              string
 		leaderElect                   bool
@@ -111,10 +111,8 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 			}
 
 			ctrlOpts := ctrl.Options{
-				Scheme: scheme,
-				Metrics: metricsserver.Options{
-					BindAddress: metricsBindAddress,
-				},
+				Scheme:           scheme,
+				Metrics:          cmdutils.MetricsServerOptions(metricsBindAddress, metricsSecure),
 				PprofBindAddress: pprofBindAddress,
 				WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{
 					Port: 9443,
@@ -328,6 +326,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	// Setting CLI flags
 	cmd.Flags().StringVar(&metricsBindAddress, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	cmd.Flags().BoolVar(&metricsSecure, "metrics-secure", false, "If set, the metrics endpoint is served over HTTPS and requires a bearer token authorized against the manager's kamaji-metrics-reader ClusterRole, instead of being served in plaintext without authentication.")
 	cmd.Flags().StringVar(&healthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	cmd.Flags().StringVar(&pprofBindAddress, "pprof-bind-address", "", "The address the pprof profiler binds to.")
 	cmd.Flags().BoolVar(&leaderElect, "leader-elect", true, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")

--- a/cmd/utils/metrics.go
+++ b/cmd/utils/metrics.go
@@ -1,0 +1,25 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// MetricsServerOptions builds the controller-runtime metrics server options for the given bind address.
+// When secure is true, the metrics endpoint is served over HTTPS and requires the caller to authenticate
+// with a bearer token authorized via SubjectAccessReview, instead of being served in plaintext with no auth.
+func MetricsServerOptions(bindAddress string, secure bool) metricsserver.Options {
+	opts := metricsserver.Options{
+		BindAddress: bindAddress,
+	}
+
+	if secure {
+		opts.SecureServing = true
+		opts.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+
+	return opts
+}

--- a/cmd/utils/metrics_test.go
+++ b/cmd/utils/metrics_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import "testing"
+
+func TestMetricsServerOptions(t *testing.T) {
+	t.Parallel()
+
+	insecure := MetricsServerOptions(":8080", false)
+
+	if insecure.BindAddress != ":8080" {
+		t.Fatalf("expected bind address to be preserved, got %q", insecure.BindAddress)
+	}
+	if insecure.SecureServing {
+		t.Fatalf("expected SecureServing to be false when secure is false")
+	}
+	if insecure.FilterProvider != nil {
+		t.Fatalf("expected no FilterProvider when secure is false")
+	}
+
+	secure := MetricsServerOptions(":8090", true)
+
+	if secure.BindAddress != ":8090" {
+		t.Fatalf("expected bind address to be preserved, got %q", secure.BindAddress)
+	}
+	if !secure.SecureServing {
+		t.Fatalf("expected SecureServing to be true when secure is true")
+	}
+	if secure.FilterProvider == nil {
+		t.Fatalf("expected FilterProvider to be set when secure is true")
+	}
+}

--- a/controllers/certificate_lifecycle_controller.go
+++ b/controllers/certificate_lifecycle_controller.go
@@ -33,10 +33,11 @@ import (
 )
 
 type CertificateLifecycle struct {
-	Channel   chan event.GenericEvent
-	Deadline  time.Duration
-	EnqueueFn func(secret *corev1.Secret)
-	Metrics   *metrics.Recorder
+	Channel          chan event.GenericEvent
+	Deadline         time.Duration
+	ReconcileTimeout time.Duration
+	EnqueueFn        func(secret *corev1.Secret)
+	Metrics          *metrics.Recorder
 
 	client client.Client
 }
@@ -51,6 +52,10 @@ func (s *CertificateLifecycle) Reconcile(ctx context.Context, request reconcile.
 			logger.WithName("metrics").Error(err, "cannot refresh certificate status gauges")
 		}
 	}(ctx)
+
+	var cancelFn context.CancelFunc
+	ctx, cancelFn = context.WithTimeout(ctx, s.ReconcileTimeout)
+	defer cancelFn()
 
 	logger.Info("starting CertificateLifecycle handling")
 

--- a/controllers/certificate_lifecycle_controller_reconcile_test.go
+++ b/controllers/certificate_lifecycle_controller_reconcile_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	"github.com/clastix/kamaji/internal/metrics"
+)
+
+func TestCertificateLifecycleReconcileAppliesReconcileTimeout(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed adding corev1 scheme: %v", err)
+	}
+	if err := kamajiv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed adding kamaji scheme: %v", err)
+	}
+
+	capturing := &contextCapturingClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	const reconcileTimeout = 5 * time.Second
+
+	s := &CertificateLifecycle{
+		Deadline:         24 * time.Hour,
+		ReconcileTimeout: reconcileTimeout,
+		Metrics:          metrics.NewRecorder(prometheus.NewRegistry()),
+		client:           capturing,
+	}
+
+	if _, err := s.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "missing"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContextDeadlineWithin(t, capturing.capturedDeadline, capturing.hasDeadline, reconcileTimeout)
+}

--- a/controllers/kubeconfiggenerator_controller.go
+++ b/controllers/kubeconfiggenerator_controller.go
@@ -47,6 +47,7 @@ import (
 type KubeconfigGeneratorReconciler struct {
 	Client            client.Client
 	NotValidThreshold time.Duration
+	ReconcileTimeout  time.Duration
 	CertificateChan   chan event.GenericEvent
 }
 
@@ -57,6 +58,10 @@ type KubeconfigGeneratorReconciler struct {
 
 func (r *KubeconfigGeneratorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	var cancelFn context.CancelFunc
+	ctx, cancelFn = context.WithTimeout(ctx, r.ReconcileTimeout)
+	defer cancelFn()
 
 	logger.Info("reconciling resource")
 

--- a/controllers/kubeconfiggenerator_controller_reconcile_test.go
+++ b/controllers/kubeconfiggenerator_controller_reconcile_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+)
+
+func TestKubeconfigGeneratorReconcilerReconcileAppliesReconcileTimeout(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := kamajiv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed adding kamaji scheme: %v", err)
+	}
+
+	capturing := &contextCapturingClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	const reconcileTimeout = 2 * time.Second
+
+	r := &KubeconfigGeneratorReconciler{
+		Client:            capturing,
+		NotValidThreshold: time.Hour,
+		ReconcileTimeout:  reconcileTimeout,
+		CertificateChan:   make(chan event.GenericEvent, 1),
+	}
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "missing"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContextDeadlineWithin(t, capturing.capturedDeadline, capturing.hasDeadline, reconcileTimeout)
+}

--- a/controllers/kubeconfiggenerator_watcher.go
+++ b/controllers/kubeconfiggenerator_watcher.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,12 +20,17 @@ import (
 )
 
 type KubeconfigGeneratorWatcher struct {
-	Client        client.Client
-	GeneratorChan chan event.GenericEvent
+	Client           client.Client
+	GeneratorChan    chan event.GenericEvent
+	ReconcileTimeout time.Duration
 }
 
 func (r *KubeconfigGeneratorWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	var cancelFn context.CancelFunc
+	ctx, cancelFn = context.WithTimeout(ctx, r.ReconcileTimeout)
+	defer cancelFn()
 
 	logger.Info("reconciling resource")
 

--- a/controllers/kubeconfiggenerator_watcher_reconcile_test.go
+++ b/controllers/kubeconfiggenerator_watcher_reconcile_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+)
+
+func TestKubeconfigGeneratorWatcherReconcileAppliesReconcileTimeout(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := kamajiv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed adding kamaji scheme: %v", err)
+	}
+
+	capturing := &contextCapturingClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	const reconcileTimeout = 3 * time.Second
+
+	w := &KubeconfigGeneratorWatcher{
+		Client:           capturing,
+		GeneratorChan:    make(chan event.GenericEvent, 1),
+		ReconcileTimeout: reconcileTimeout,
+	}
+
+	if _, err := w.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "missing"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContextDeadlineWithin(t, capturing.capturedDeadline, capturing.hasDeadline, reconcileTimeout)
+}

--- a/controllers/reconcile_timeout_test.go
+++ b/controllers/reconcile_timeout_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// contextCapturingClient wraps a client.Client and records the deadline of the context passed to Get,
+// so tests can assert a reconciler actually derives its client calls from ReconcileTimeout.
+type contextCapturingClient struct {
+	client.Client
+
+	capturedDeadline time.Time
+	hasDeadline      bool
+}
+
+func (c *contextCapturingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.capturedDeadline, c.hasDeadline = ctx.Deadline()
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func assertContextDeadlineWithin(t *testing.T, deadline time.Time, hasDeadline bool, want time.Duration) {
+	t.Helper()
+
+	if !hasDeadline {
+		t.Fatalf("expected the reconciler to have issued a Get call with a context carrying a deadline derived from ReconcileTimeout")
+	}
+
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > want {
+		t.Fatalf("expected context deadline within (0, %s], got %s", want, remaining)
+	}
+}

--- a/docs/content/guides/monitoring.md
+++ b/docs/content/guides/monitoring.md
@@ -49,6 +49,43 @@ A ready-to-use Grafana dashboard for these metrics is available [here](https://r
 
 ![Kamaji Monitoring Dashboard](../images/kamaji-monitoring-dashboard.png)
 
+### Securing the metrics endpoint
+
+By default, the `manager` and `kubeconfig-generator` metrics endpoints are served in plaintext with no authentication, reachable by any workload with network access to the pod. Pass `--metrics-secure=true` (via `extraArgs`/`kubeconfigGenerator.extraArgs` in the Helm chart) to serve metrics over HTTPS and require the caller to authenticate with a bearer token authorized against the bundled `kamaji-metrics-reader` ClusterRole:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kamaji-metrics-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kamaji-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: kube-prometheus-stack-prometheus
+  namespace: monitoring-system
+```
+
+With `--metrics-secure=true` enabled, update the `ServiceMonitor` endpoint to scrape over TLS with the scraper's own service account token:
+
+```yaml
+endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 15s
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+    authorization:
+      credentials:
+        key: token
+        name: kube-prometheus-stack-prometheus-token
+```
+
+If you'd rather keep the endpoint on plaintext HTTP, restrict access with a `NetworkPolicy` instead.
+
 ## Tenant Control Plane component metrics
 
 ## Enable metrics scraping


### PR DESCRIPTION
## Summary                                                                                                                           
                                                                                                                                       
  - The `kubeconfig-generator` controllers (`CertificateLifecycle`, `KubeconfigGeneratorReconciler`, `KubeconfigGeneratorWatcher`)     
  accepted a `--controller-reconcile-timeout` flag but never applied it to the reconcile context, so reconciles had no deadline.       
  - The `manager` and `kubeconfig-generator` metrics endpoints were always served in plaintext with no authentication.                 
                                                                                                                                       
  ## Changes                                                                                                                           
                                                                                                                                       
  - Wire `ReconcileTimeout` into `CertificateLifecycle`, `KubeconfigGeneratorReconciler`, and `KubeconfigGeneratorWatcher`, wrapping   
  each `Reconcile` context with `context.WithTimeout`.                                                                                 
  - Validate `--controller-reconcile-timeout` is greater than zero in `kubeconfig-generator`'s `PreRunE`.                              
  - Add `cmd/utils.MetricsServerOptions`, a shared helper that builds `metricsserver.Options` and, when `--metrics-secure` is set,     
  enables `SecureServing` with `filters.WithAuthenticationAndAuthorization`.                                                           
  - Add the `--metrics-secure` flag to both `manager` and `kubeconfig-generator` commands.                                             
  - Document securing the metrics endpoint (RBAC binding to `kamaji-metrics-reader` and the `ServiceMonitor` TLS/token config) in      
  `docs/content/guides/monitoring.md`.                                                                                                 
                                                                                                                                       
  ## Testing                                                                                                                           
                                                                                                                                       
  - Added unit tests: `cmd/utils/metrics_test.go`, `controllers/reconcile_timeout_test.go`, and reconcile tests for                    
  `certificate_lifecycle_controller`, `kubeconfiggenerator_controller`, and `kubeconfiggenerator_watcher`.  

closes: https://github.com/clastix/kamaji/issues/1229                           
 