### PR TITLE
fix: install freeze webhook synchronously before datastore migration job

### DIFF
--- a/cmd/manager/cmd.go
+++ b/cmd/manager/cmd.go
@@ -174,6 +174,7 @@ func NewCmd(scheme *runtime.Scheme) *cobra.Command {
 				KamajiServiceAccount:    managerServiceAccountName,
 				KamajiService:           managerServiceName,
 				KamajiMigrateImage:      migrateJobImage,
+				KamajiMigrateCABundle:   webhookCABundle,
 				MaxConcurrentReconciles: maxConcurrentReconciles,
 				DiscoveryClient:         discoveryClient,
 			}

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -39,6 +39,7 @@ type GroupResourceBuilderConfiguration struct {
 	KamajiServiceAccount          string
 	KamajiService                 string
 	KamajiMigrateImage            string
+	KamajiMigrateCABundle         []byte
 	DiscoveryClient               discovery.DiscoveryInterface
 }
 
@@ -57,7 +58,7 @@ type GroupDeletableResourceBuilderConfiguration struct {
 func GetResources(ctx context.Context, config GroupResourceBuilderConfiguration) []resources.Resource {
 	resources := []resources.Resource{}
 
-	resources = append(resources, getDataStoreMigratingResources(config.client, config.KamajiNamespace, config.KamajiMigrateImage, config.KamajiServiceAccount, config.KamajiService)...)
+	resources = append(resources, getDataStoreMigratingResources(config.client, config.KamajiNamespace, config.KamajiMigrateImage, config.KamajiServiceAccount, config.KamajiService, config.KamajiMigrateCABundle)...)
 	resources = append(resources, getUpgradeResources(config.client)...)
 	resources = append(resources, getKubernetesServiceResources(config.client)...)
 	resources = append(resources, getKubeadmConfigResources(config.client, getTmpDirectory(config.tcpReconcilerConfig.TmpBaseDirectory, config.tenantControlPlane), config.DataStore)...)
@@ -111,7 +112,7 @@ func getDataStoreMigratingCleanup(c client.Client, kamajiNamespace string) []res
 	}
 }
 
-func getDataStoreMigratingResources(c client.Client, kamajiNamespace, migrateImage string, kamajiServiceAccount, kamajiService string) []resources.Resource {
+func getDataStoreMigratingResources(c client.Client, kamajiNamespace, migrateImage string, kamajiServiceAccount, kamajiService string, migrateCABundle []byte) []resources.Resource {
 	return []resources.Resource{
 		&ds.Migrate{
 			Client:               c,
@@ -119,6 +120,7 @@ func getDataStoreMigratingResources(c client.Client, kamajiNamespace, migrateIma
 			KamajiNamespace:      kamajiNamespace,
 			KamajiServiceAccount: kamajiServiceAccount,
 			KamajiServiceName:    kamajiService,
+			WebhookCABundle:      migrateCABundle,
 		},
 	}
 }

--- a/controllers/soot/controllers/migrate.go
+++ b/controllers/soot/controllers/migrate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/clastix/kamaji/api/v1alpha1"
 	sooterrors "github.com/clastix/kamaji/controllers/soot/controllers/errors"
 	"github.com/clastix/kamaji/controllers/utils"
+	ds "github.com/clastix/kamaji/internal/resources/datastore"
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
@@ -90,95 +91,7 @@ func (m *Migrate) createOrUpdate(ctx context.Context) error {
 	obj := m.object()
 
 	_, err := utilities.CreateOrUpdateWithConflict(ctx, m.Client, obj, func() error {
-		obj.Webhooks = []admissionregistrationv1.ValidatingWebhook{
-			{
-				Name: "leases.migrate.kamaji.clastix.io",
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
-					CABundle: m.WebhookCABundle,
-				},
-				Rules: []admissionregistrationv1.RuleWithOperations{
-					{
-						Operations: []admissionregistrationv1.OperationType{
-							admissionregistrationv1.Create,
-							admissionregistrationv1.Delete,
-						},
-						Rule: admissionregistrationv1.Rule{
-							APIGroups:   []string{"*"},
-							APIVersions: []string{"*"},
-							Resources:   []string{"*"},
-							Scope: func(v admissionregistrationv1.ScopeType) *admissionregistrationv1.ScopeType {
-								return &v
-							}(admissionregistrationv1.NamespacedScope),
-						},
-					},
-				},
-				FailurePolicy: func(v admissionregistrationv1.FailurePolicyType) *admissionregistrationv1.FailurePolicyType {
-					return &v
-				}(admissionregistrationv1.Fail),
-				MatchPolicy: func(v admissionregistrationv1.MatchPolicyType) *admissionregistrationv1.MatchPolicyType {
-					return &v
-				}(admissionregistrationv1.Equivalent),
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      "kubernetes.io/metadata.name",
-							Operator: metav1.LabelSelectorOpIn,
-							Values: []string{
-								"kube-node-lease",
-							},
-						},
-					},
-				},
-				SideEffects: func(v admissionregistrationv1.SideEffectClass) *admissionregistrationv1.SideEffectClass {
-					return &v
-				}(admissionregistrationv1.SideEffectClassNoneOnDryRun),
-				AdmissionReviewVersions: []string{"v1"},
-			},
-			{
-				Name: "catchall.migrate.kamaji.clastix.io",
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					URL:      pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", m.WebhookServiceName, m.WebhookNamespace)),
-					CABundle: m.WebhookCABundle,
-				},
-				Rules: []admissionregistrationv1.RuleWithOperations{
-					{
-						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-						Rule: admissionregistrationv1.Rule{
-							APIGroups:   []string{"*"},
-							APIVersions: []string{"*"},
-							Resources:   []string{"*"},
-							Scope: func(v admissionregistrationv1.ScopeType) *admissionregistrationv1.ScopeType {
-								return &v
-							}(admissionregistrationv1.AllScopes),
-						},
-					},
-				},
-				FailurePolicy: func(v admissionregistrationv1.FailurePolicyType) *admissionregistrationv1.FailurePolicyType {
-					return &v
-				}(admissionregistrationv1.Fail),
-				MatchPolicy: func(v admissionregistrationv1.MatchPolicyType) *admissionregistrationv1.MatchPolicyType {
-					return &v
-				}(admissionregistrationv1.Equivalent),
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      "kubernetes.io/metadata.name",
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values: []string{
-								"kube-system",
-								"kube-node-lease",
-							},
-						},
-					},
-				},
-				SideEffects: func(v admissionregistrationv1.SideEffectClass) *admissionregistrationv1.SideEffectClass {
-					return &v
-				}(admissionregistrationv1.SideEffectClassNoneOnDryRun),
-				TimeoutSeconds:          nil,
-				AdmissionReviewVersions: []string{"v1"},
-			},
-		}
+		obj.Webhooks = ds.BuildFreezeValidatingWebhookConfiguration(m.WebhookNamespace, m.WebhookServiceName, m.WebhookCABundle)
 
 		return nil
 	})
@@ -202,7 +115,7 @@ func (m *Migrate) SetupWithManager(mgr manager.Manager) error {
 func (m *Migrate) object() *admissionregistrationv1.ValidatingWebhookConfiguration {
 	return &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kamaji-freeze",
+			Name: ds.FreezeWebhookName,
 		},
 	}
 }

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -59,6 +59,7 @@ type TenantControlPlaneReconciler struct {
 	KamajiServiceAccount    string
 	KamajiService           string
 	KamajiMigrateImage      string
+	KamajiMigrateCABundle   []byte
 	MaxConcurrentReconciles int
 	ReconcileTimeout        time.Duration
 	DiscoveryClient         discovery.DiscoveryInterface
@@ -238,6 +239,7 @@ func (r *TenantControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		KamajiServiceAccount:          r.KamajiServiceAccount,
 		KamajiService:                 r.KamajiService,
 		KamajiMigrateImage:            r.KamajiMigrateImage,
+		KamajiMigrateCABundle:         r.KamajiMigrateCABundle,
 		DiscoveryClient:               r.DiscoveryClient,
 	}
 	registeredResources := GetResources(ctx, groupResourceBuilderConfiguration)

--- a/internal/resources/datastore/datastore_migrate.go
+++ b/internal/resources/datastore/datastore_migrate.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -31,6 +32,10 @@ type Migrate struct {
 	KamajiServiceName    string
 	ShouldCleanUp        bool
 	MigrateImage         string
+	// WebhookCABundle is the CA bundle for the manager's admission webhook server, required to
+	// install the tenant-side "kamaji-freeze" ValidatingWebhookConfiguration prior to starting
+	// the migration Job: see ensureFreezeWebhook for why this must happen synchronously here.
+	WebhookCABundle []byte
 
 	actualDatastore  *kamajiv1alpha1.DataStore
 	desiredDatastore *kamajiv1alpha1.DataStore
@@ -101,6 +106,12 @@ func (d *Migrate) CreateOrUpdate(ctx context.Context, tenantControlPlane *kamaji
 
 	if d.actualDatastore.GetName() == d.desiredDatastore.GetName() {
 		return controllerutil.OperationResultNone, nil
+	}
+
+	// The freeze webhook must be active in the tenant cluster before the migration Job is allowed
+	// to start copying data: see ensureFreezeWebhook for why this has to be synchronous.
+	if err := d.ensureFreezeWebhook(ctx, tenantControlPlane); err != nil {
+		return controllerutil.OperationResultNone, fmt.Errorf("unable to install freeze webhook prior to migration: %w", err)
 	}
 
 	res, err := utilities.CreateOrUpdateWithConflict(ctx, d.Client, d.job, func() error {
@@ -184,4 +195,36 @@ func (d *Migrate) UpdateTenantControlPlaneStatus(_ context.Context, tenantContro
 	}
 
 	return nil
+}
+
+// ensureFreezeWebhook installs the tenant-side "kamaji-freeze" ValidatingWebhookConfiguration
+// and waits for it to be persisted before the caller is allowed to start the migration Job.
+//
+// The soot Migrate controller also reacts to VersionMigrating and installs the same webhook,
+// but it is level-triggered: it always reads the TenantControlPlane's *current* status rather
+// than the status at the time its trigger fired. If the migration Job runs to completion (status
+// flips Migrating -> Ready) faster than that controller's first reconcile after the transition,
+// it observes Ready directly and never installs the webhook at all - the migration then runs
+// with no write protection on the source datastore. Installing it here, synchronously and
+// before the Job (and therefore before VersionMigrating is ever observable by any watcher),
+// closes that race: by the time anything can see VersionMigrating, the webhook already exists.
+func (d *Migrate) ensureFreezeWebhook(ctx context.Context, tenantControlPlane *kamajiv1alpha1.TenantControlPlane) error {
+	tenantClient, err := utilities.GetTenantClient(ctx, d.Client, tenantControlPlane)
+	if err != nil {
+		return fmt.Errorf("unable to build tenant client: %w", err)
+	}
+
+	webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: FreezeWebhookName,
+		},
+	}
+
+	_, err = utilities.CreateOrUpdateWithConflict(ctx, tenantClient, webhook, func() error {
+		webhook.Webhooks = BuildFreezeValidatingWebhookConfiguration(d.KamajiNamespace, d.KamajiServiceName, d.WebhookCABundle)
+
+		return nil
+	})
+
+	return err
 }

--- a/internal/resources/datastore/freeze_webhook.go
+++ b/internal/resources/datastore/freeze_webhook.go
@@ -1,0 +1,98 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package datastore
+
+import (
+	"fmt"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pointer "k8s.io/utils/ptr"
+)
+
+// FreezeWebhookName is the name of the ValidatingWebhookConfiguration installed in the tenant
+// cluster to block writes while a datastore migration is in progress.
+const FreezeWebhookName = "kamaji-freeze"
+
+// BuildFreezeValidatingWebhookConfiguration returns the desired Webhooks for the tenant-side
+// "kamaji-freeze" ValidatingWebhookConfiguration. Shared by the host-side Migrate resource,
+// which installs it synchronously before starting the migration Job, and the soot Migrate
+// controller, which removes it once the TenantControlPlane is Ready again.
+func BuildFreezeValidatingWebhookConfiguration(namespace, serviceName string, caBundle []byte) []admissionregistrationv1.ValidatingWebhook {
+	url := pointer.To(fmt.Sprintf("https://%s.%s.svc:443/migrate", serviceName, namespace))
+
+	return []admissionregistrationv1.ValidatingWebhook{
+		{
+			Name: "leases.migrate.kamaji.clastix.io",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				URL:      url,
+				CABundle: caBundle,
+			},
+			Rules: []admissionregistrationv1.RuleWithOperations{
+				{
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+						admissionregistrationv1.Delete,
+					},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"*"},
+						APIVersions: []string{"*"},
+						Resources:   []string{"*"},
+						Scope:       pointer.To(admissionregistrationv1.NamespacedScope),
+					},
+				},
+			},
+			FailurePolicy: pointer.To(admissionregistrationv1.Fail),
+			MatchPolicy:   pointer.To(admissionregistrationv1.Equivalent),
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values: []string{
+							"kube-node-lease",
+						},
+					},
+				},
+			},
+			SideEffects:             pointer.To(admissionregistrationv1.SideEffectClassNoneOnDryRun),
+			AdmissionReviewVersions: []string{"v1"},
+		},
+		{
+			Name: "catchall.migrate.kamaji.clastix.io",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				URL:      url,
+				CABundle: caBundle,
+			},
+			Rules: []admissionregistrationv1.RuleWithOperations{
+				{
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"*"},
+						APIVersions: []string{"*"},
+						Resources:   []string{"*"},
+						Scope:       pointer.To(admissionregistrationv1.AllScopes),
+					},
+				},
+			},
+			FailurePolicy: pointer.To(admissionregistrationv1.Fail),
+			MatchPolicy:   pointer.To(admissionregistrationv1.Equivalent),
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values: []string{
+							"kube-system",
+							"kube-node-lease",
+						},
+					},
+				},
+			},
+			SideEffects:             pointer.To(admissionregistrationv1.SideEffectClassNoneOnDryRun),
+			TimeoutSeconds:          nil,
+			AdmissionReviewVersions: []string{"v1"},
+		},
+	}
+}


### PR DESCRIPTION
# Install freeze webhook synchronously before datastore migration job

## Problem

The tenant-side `kamaji-freeze` ValidatingWebhookConfiguration — the write-protection guarantee requested in #208 — is installed by the soot `Migrate` controller, which is **level-triggered**: it reconciles on the TenantControlPlane's *current* status, not the status at the time its trigger fired.

If the migration Job runs to completion (status flips `Migrating → Ready`) faster than that controller's first reconcile after the transition, the controller observes `Ready` directly and **never installs the webhook at all**. The migration then copies data with no write protection on the source datastore — exactly the inconsistency #208 set out to prevent.

## Fix

Install the webhook in the host-side `Migrate` resource, **synchronously and before the migration Job is created**. Since the Job is what drives the `VersionMigrating` status, this closes the race by construction: by the time anything can observe `VersionMigrating`, the webhook already exists.

- `internal/resources/datastore/datastore_migrate.go` — `ensureFreezeWebhook()` creates/updates the tenant-side `ValidatingWebhookConfiguration` via the tenant client before the Job is reconciled.
- `internal/resources/datastore/freeze_webhook.go` (new) — shared builder for the webhook definitions (`leases` + `catchall`) and the `FreezeWebhookName` constant, so the host-side installer and the soot controller cannot drift apart.
- `controllers/soot/controllers/migrate.go` — now consumes the shared builder (no behaviour change: it still removes the webhook once the TCP is Ready again, and still reconciles the same definitions).
- `cmd/manager/cmd.go`, `controllers/resources.go`, `controllers/tenantcontrolplane_controller.go` — plumb the manager's webhook CA bundle through to the `Migrate` resource so the webhook's `ClientConfig.CABundle` points at the manager's admission endpoint.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/resources/datastore/... ./controllers/...` passes.
- Exercised locally against a kind cluster: datastore migration specs pass, and the `kamaji-freeze` webhook is present in the tenant cluster before the migration Job starts.

Completes the freeze guarantee from #208.
