### PR TITLE
feat(chart): allow signing the webhook certificate with your own issuer

### DIFF
--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -74,6 +74,7 @@ Here the values you can override:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Kubernetes affinity rules to apply to Kamaji controller pods |
+| certManager.issuerRef | object | `{}` | Reference to an existing cert-manager issuer that signs the webhook serving certificate. When `name` is empty the chart creates a self-signed `Issuer` named `kamaji-selfsigned-issuer` and uses that. Set this to chain the webhook certificate to a certificate authority you own. `kind` defaults to `Issuer` and `group` to `cert-manager.io`. Note that the `kamaji-etcd` subchart has its own `kamaji-etcd.certManager.issuerRef`, which defaults to `kamaji-selfsigned-issuer` and has to be updated as well when the etcd certificates are issued by cert-manager. |
 | defaultDatastoreName | string | `"default"` | If specified, all the Kamaji instances with an unassigned DataStore will inherit this default value. |
 | extraArgs | list | `[]` | A list of extra arguments to add to the kamaji controller default ones |
 | fullnameOverride | string | `""` |  |

--- a/charts/kamaji/templates/certmanager_certificate.yaml
+++ b/charts/kamaji/templates/certmanager_certificate.yaml
@@ -1,3 +1,4 @@
+{{- $issuerRef := (.Values.certManager | default dict).issuerRef | default dict }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -11,6 +12,7 @@ spec:
     - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
     - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
-    kind: Issuer
-    name: kamaji-selfsigned-issuer
+    kind: {{ $issuerRef.kind | default "Issuer" | quote }}
+    name: {{ $issuerRef.name | default "kamaji-selfsigned-issuer" | quote }}
+    group: {{ $issuerRef.group | default "cert-manager.io" | quote }}
   secretName: {{ include "kamaji.webhookSecretName" . }}

--- a/charts/kamaji/templates/certmanager_issuer.yaml
+++ b/charts/kamaji/templates/certmanager_issuer.yaml
@@ -1,3 +1,15 @@
+{{- $issuerRef := (.Values.certManager | default dict).issuerRef | default dict }}
+{{- $etcd := (index .Values "kamaji-etcd") | default dict }}
+{{- $etcdCertManager := $etcd.certManager | default dict }}
+{{- $etcdIssuerRef := $etcdCertManager.issuerRef | default dict }}
+{{/*
+kamaji-etcd carries its own issuerRef and cannot be pointed at another issuer from here, because a
+parent chart cannot set the values of a subchart conditionally. Keep the self-signed issuer as long
+as either the webhook certificate or kamaji-etcd refers to it, so that configuring certManager.issuerRef
+never leaves kamaji-etcd without an issuer.
+*/}}
+{{- $etcdNeedsSelfSigned := and $etcd.deploy $etcdCertManager.enabled (eq ($etcdIssuerRef.name | default "") "kamaji-selfsigned-issuer") }}
+{{- if or (not $issuerRef.name) $etcdNeedsSelfSigned }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -8,3 +20,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+{{- end }}

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -98,6 +98,18 @@ loggingDevel:
 # -- If specified, all the Kamaji instances with an unassigned DataStore will inherit this default value.
 defaultDatastoreName: default
 
+certManager:
+  # -- Reference to an existing cert-manager issuer that signs the webhook serving certificate. When
+  # `name` is empty the chart creates a self-signed `Issuer` named `kamaji-selfsigned-issuer` and uses
+  # that. Set this to chain the webhook certificate to a certificate authority you own. `kind` defaults
+  # to `Issuer` and `group` to `cert-manager.io`. Note that the `kamaji-etcd` subchart has its own
+  # `kamaji-etcd.certManager.issuerRef`, which defaults to `kamaji-selfsigned-issuer` and has to be
+  # updated as well when the etcd certificates are issued by cert-manager.
+  issuerRef: {}
+    # name: my-issuer
+    # kind: ClusterIssuer
+    # group: cert-manager.io
+
 # -- Subchart: See https://github.com/clastix/kamaji-etcd/blob/master/charts/kamaji-etcd/values.yaml
 kamaji-etcd:
   deploy: true


### PR DESCRIPTION
Add certManager.issuerRef to point the webhook serving certificate at an existing cert-manager issuer. The self-signed kamaji-selfsigned-issuer is only created when no issuer is given, so the chart keeps its current behaviour by default.