### PR TITLE
fix(chart): ignore issuerRef kind and group without an issuer name

### DIFF
--- a/charts/kamaji/templates/certmanager_certificate.yaml
+++ b/charts/kamaji/templates/certmanager_certificate.yaml
@@ -1,4 +1,12 @@
 {{- $issuerRef := (.Values.certManager | default dict).issuerRef | default dict }}
+{{- $issuerName := "kamaji-selfsigned-issuer" }}
+{{- $issuerKind := "Issuer" }}
+{{- $issuerGroup := "cert-manager.io" }}
+{{- if $issuerRef.name }}
+{{- $issuerName = $issuerRef.name }}
+{{- $issuerKind = $issuerRef.kind | default $issuerKind }}
+{{- $issuerGroup = $issuerRef.group | default $issuerGroup }}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -12,7 +20,7 @@ spec:
     - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
     - {{ include "kamaji.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
-    kind: {{ $issuerRef.kind | default "Issuer" | quote }}
-    name: {{ $issuerRef.name | default "kamaji-selfsigned-issuer" | quote }}
-    group: {{ $issuerRef.group | default "cert-manager.io" | quote }}
+    kind: {{ $issuerKind | quote }}
+    name: {{ $issuerName | quote }}
+    group: {{ $issuerGroup | quote }}
   secretName: {{ include "kamaji.webhookSecretName" . }}


### PR DESCRIPTION
Setting certManager.issuerRef.kind without a name pointed the webhook certificate at a ClusterIssuer of that name, while the chart still created a namespaced self-signed Issuer, so cert-manager never issued the certificate. Take kind and group from the values only when a name is set.