### PR TITLE
fix(kubeadm): restore kube-proxy CIDR

### DIFF
--- a/internal/kubeadm/configuration.go
+++ b/internal/kubeadm/configuration.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
@@ -109,13 +110,14 @@ func GetKubeadmInitConfigurationFromMap(conf map[string]string) (*Configuration,
 	if err := utilities.DecodeFromJSON(clusterConfigurationString, &initConfiguration.ClusterConfiguration); err != nil {
 		return nil, err
 	}
-	// Due to some weird issues with unmarshaling of the ComponentConfigs struct,
-	// we have to extract the default value and assign it directly.
-	defaults, err := config.DefaultedStaticInitConfiguration()
-	if err != nil {
-		return nil, err
-	}
-	initConfiguration.ClusterConfiguration.ComponentConfigs = defaults.ComponentConfigs
+	// ComponentConfigs are omitted from storage because their interface values cannot be unmarshaled.
+	// Recreate them after the decoder loads the cluster configuration.
+	// This sequence applies the configured network settings.
+	componentconfigs.Default(
+		&initConfiguration.ClusterConfiguration,
+		&initConfiguration.LocalAPIEndpoint,
+		&initConfiguration.NodeRegistration,
+	)
 
 	return &Configuration{InitConfiguration: initConfiguration}, nil
 }

--- a/internal/kubeadm/configuration_test.go
+++ b/internal/kubeadm/configuration_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeadm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+)
+
+func TestGetKubeadmInitConfigurationFromMapDefaultsKubeProxyClusterCIDR(t *testing.T) {
+	testCases := []struct {
+		name     string
+		podCIDRs []string
+		expected string
+	}{
+		{
+			name:     "IPv4",
+			podCIDRs: []string{"10.244.0.0/16"},
+			expected: "10.244.0.0/16",
+		},
+		{
+			name:     "dual stack",
+			podCIDRs: []string{"10.244.0.0/16", "fd00:10:244::/56"},
+			expected: "10.244.0.0/16,fd00:10:244::/56",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			created, err := CreateKubeadmInitConfiguration(Parameters{
+				TenantControlPlaneName:          "tenant",
+				TenantControlPlaneNamespace:     "default",
+				TenantControlPlaneAddress:       "192.0.2.1",
+				TenantControlPlanePort:          6443,
+				TenantControlPlaneClusterDomain: "cluster.local",
+				TenantControlPlanePodCIDR:       testCase.podCIDRs,
+				TenantControlPlaneServiceCIDR:   []string{"10.96.0.0/12"},
+				TenantControlPlaneVersion:       "v1.36.1",
+				ETCDs:                           []string{"http://etcd.default.svc:2379"},
+			})
+			require.NoError(t, err)
+
+			stored, err := GetKubeadmInitConfigurationMap(*created)
+			require.NoError(t, err)
+
+			restored, err := GetKubeadmInitConfigurationFromMap(stored)
+			require.NoError(t, err)
+
+			componentConfig, ok := restored.InitConfiguration.ClusterConfiguration.ComponentConfigs[componentconfigs.KubeProxyGroup]
+			require.True(t, ok)
+
+			proxyConfig, ok := componentConfig.Get().(*kubeproxyconfig.KubeProxyConfiguration)
+			require.True(t, ok)
+			require.Equal(t, testCase.expected, proxyConfig.ClusterCIDR)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Kamaji omits kubeadm `ComponentConfigs` from its stored configuration.

Kamaji recreates these values when it reads the stored configuration. The current code copies them from `DefaultedStaticInitConfiguration`.

That static configuration does not contain the tenant pod CIDRs. Therefore, kubeadm creates the kube-proxy configuration with an empty `clusterCIDR`.

An empty `clusterCIDR` can cause incorrect source NAT decisions for traffic from host-networked control-plane components.

This affects admission webhooks when the API server reaches a webhook through its ClusterIP.

The issue also occurs with `podCidrs` and `serviceCidrs`. The singular and plural fields converge before kubeadm configuration generation.

closes: https://github.com/clastix/kamaji/issues/1289

## Solution

Recreate the component configurations after Kamaji decodes the stored tenant configuration.

Call `componentconfigs.Default` with these restored values:

- `ClusterConfiguration`
- `LocalAPIEndpoint`
- `NodeRegistration`

Kubeadm now derives `kubeProxy.config.clusterCIDR` from the tenant `Networking.PodSubnet`.

For dual-stack clusters, kubeadm preserves the comma-separated IPv4 and IPv6 pod CIDRs.

## Additional behavior

The restored tenant configuration also supplies other context-dependent defaults.

These defaults include:

- The kube-proxy bind address.
- The kubelet cluster DNS address.
- The kubelet cluster domain.
- The kubelet client CA path.

Previously, Kamaji derived these values from a synthetic static configuration.

## Tests

The regression test performs this sequence:

1. Create a kubeadm configuration.
2. Serialize the configuration.
3. Restore the configuration from that map.
4. Read the generated kube-proxy component configuration.
5. Verify that `clusterCIDR` matches the configured pod CIDRs.

The test covers these cases:

- Single-stack IPv4.
- Dual-stack IPv4 and IPv6.

Results: 

```text
go test ./internal/kubeadm/... ./internal/resources/addons
make golint
make test
...

Ran 30 of 30 Specs in 0.045 seconds
SUCCESS! -- 30 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
coverage: 35.2% of statements
composite coverage: 13.3% of statements

Ginkgo ran 12 suites in 19.612822041s
Test Suite Passed
```