### PR TITLE
feat: support dedicated client certificate signer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bin
 !deploy/kine/nats/server-csr.json
 charts/kamaji/charts
 dist
+.codemogger/

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -32,6 +32,7 @@ const (
 	ServiceTypeClusterIP          = (ServiceType)(corev1.ServiceTypeClusterIP)
 	ServiceTypeNodePort           = (ServiceType)(corev1.ServiceTypeNodePort)
 	KubeconfigSecretKeyAnnotation = "kamaji.clastix.io/kubeconfig-secret-key"
+	ClientCASecretAnnotation      = "kamaji.clastix.io/client-ca-secret"
 )
 
 // +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer

--- a/controllers/kubeconfiggenerator_controller.go
+++ b/controllers/kubeconfiggenerator_controller.go
@@ -172,6 +172,19 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 		return &statusErr
 	}
 
+	var caSecret corev1.Secret
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: tcp.Namespace, Name: tcp.Status.Certificates.CA.SecretName}, &caSecret); err != nil {
+		statusErr.Message = fmt.Sprintf("cannot retrieve Certificate Authority: %s", err.Error())
+
+		return &statusErr
+	}
+	clientSignerSecret, err := resources.GetClientSignerSecret(ctx, r.Client, &tcp, &caSecret)
+	if err != nil {
+		statusErr.Message = fmt.Sprintf("cannot retrieve client certificate signer: %s", err.Error())
+
+		return &statusErr
+	}
+
 	uMap, uErr := runtime.DefaultUnstructuredConverter.ToUnstructured(&tcp)
 	if uErr != nil {
 		statusErr.Message = fmt.Sprintf("cannot convert the resource to a map: %s", uErr)
@@ -244,7 +257,7 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 			return &statusErr
 		}
 
-		if generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, groups, user); generateErr != nil {
+		if generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, clientSignerSecret, groups, user); generateErr != nil {
 			statusErr.Message = fmt.Sprintf("an error occurred generating the %q Secret: %s", objectKey.String(), generateErr.Error())
 
 			return &statusErr
@@ -253,10 +266,16 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 		return nil
 	}
 
-	isValid, validateErr := r.isValid(&resultSecret, kubeconfigTmpl, groups, user)
+	isValid, validateErr := r.isValid(
+		&resultSecret,
+		kubeconfigTmpl,
+		groups,
+		user,
+		clientSignerSecret.Data[kubeadmconstants.CACertName],
+	)
 	switch {
 	case !isValid:
-		if generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, groups, user); generateErr != nil {
+		if generateErr := r.generate(ctx, generator, &resultSecret, kubeconfigTmpl, &tcp, clientSignerSecret, groups, user); generateErr != nil {
 			statusErr.Message = fmt.Sprintf("an error occurred regenerating the %q Secret: %s", objectKey.String(), generateErr.Error())
 
 			return &statusErr
@@ -272,7 +291,7 @@ func (r *KubeconfigGeneratorReconciler) process(ctx context.Context, generator *
 	}
 }
 
-func (r *KubeconfigGeneratorReconciler) generate(ctx context.Context, generator *kamajiv1alpha1.KubeconfigGenerator, secret *corev1.Secret, tmpl *clientcmdapiv1.Config, tcp *kamajiv1alpha1.TenantControlPlane, groups sets.Set[string], user string) error {
+func (r *KubeconfigGeneratorReconciler) generate(ctx context.Context, generator *kamajiv1alpha1.KubeconfigGenerator, secret *corev1.Secret, tmpl *clientcmdapiv1.Config, tcp *kamajiv1alpha1.TenantControlPlane, clientSignerSecret *corev1.Secret, groups sets.Set[string], user string) error {
 	_, config, err := resources.GetKubeadmManifestDeps(ctx, r.Client, tcp)
 	if err != nil {
 		return err
@@ -288,17 +307,12 @@ func (r *KubeconfigGeneratorReconciler) generate(ctx context.Context, generator 
 		EncryptionAlgorithm: config.InitConfiguration.ClusterConfiguration.EncryptionAlgorithmType(),
 	}
 
-	var caSecret corev1.Secret
-	if caErr := r.Client.Get(ctx, types.NamespacedName{Namespace: tcp.Namespace, Name: tcp.Status.Certificates.CA.SecretName}, &caSecret); caErr != nil {
-		return fmt.Errorf("cannot retrieve Certificate Authority: %w", caErr)
-	}
-
-	caCert, crtErr := crypto.ParseCertificateBytes(caSecret.Data[kubeadmconstants.CACertName])
+	caCert, crtErr := crypto.ParseCertificateBytes(clientSignerSecret.Data[kubeadmconstants.CACertName])
 	if crtErr != nil {
 		return fmt.Errorf("cannot parse Certificate Authority certificate: %w", crtErr)
 	}
 
-	caKey, keyErr := crypto.ParsePrivateKeyBytes(caSecret.Data[kubeadmconstants.CAKeyName])
+	caKey, keyErr := crypto.ParsePrivateKeyBytes(clientSignerSecret.Data[kubeadmconstants.CAKeyName])
 	if keyErr != nil {
 		return fmt.Errorf("cannot parse Certificate Authority key: %w", keyErr)
 	}
@@ -361,7 +375,7 @@ func (r *KubeconfigGeneratorReconciler) generate(ctx context.Context, generator 
 	return nil
 }
 
-func (r *KubeconfigGeneratorReconciler) isValid(secret *corev1.Secret, tmpl *clientcmdapiv1.Config, groups sets.Set[string], user string) (bool, error) {
+func (r *KubeconfigGeneratorReconciler) isValid(secret *corev1.Secret, tmpl *clientcmdapiv1.Config, groups sets.Set[string], user string, clientCA []byte) (bool, error) {
 	if utilities.IsRotationRequested(secret) {
 		return false, nil
 	}
@@ -405,6 +419,11 @@ func (r *KubeconfigGeneratorReconciler) isValid(secret *corev1.Secret, tmpl *cli
 		}
 
 		if !sets.New[string](crt.Subject.Organization...).Equal(groups) {
+			return false, nil
+		}
+
+		signedByClientCA, _ := crypto.VerifyCertificate(auth.AuthInfo.ClientCertificateData, clientCA, x509.ExtKeyUsageClientAuth)
+		if !signedByClientCA {
 			return false, nil
 		}
 	}

--- a/controllers/kubeconfiggenerator_controller_test.go
+++ b/controllers/kubeconfiggenerator_controller_test.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	certutil "k8s.io/client-go/util/cert"
+	keyutil "k8s.io/client-go/util/keyutil"
+	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	"github.com/clastix/kamaji/internal/utilities"
+)
+
+func TestGeneratedKubeconfigRejectsStaleClientIssuer(t *testing.T) {
+	t.Parallel()
+
+	const user = "test-user"
+	groups := sets.New("test-group")
+	oldClientCA, oldClientCAKey := certstestutil.SetupCertificateAuthority(t)
+	newClientCA, _ := certstestutil.SetupCertificateAuthority(t)
+	clientCertificate, clientKey, err := pkiutil.NewCertAndKey(
+		oldClientCA,
+		oldClientCAKey,
+		&pkiutil.CertConfig{
+			Config: certutil.Config{
+				CommonName:   user,
+				Organization: groups.UnsortedList(),
+				Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			},
+			NotAfter: time.Now().Add(time.Hour),
+		},
+	)
+	if err != nil {
+		t.Fatalf("create client certificate: %v", err)
+	}
+	clientKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientKey)
+	if err != nil {
+		t.Fatalf("marshal client key: %v", err)
+	}
+
+	serverCA, _ := certstestutil.SetupCertificateAuthority(t)
+	template := kubeconfigForCertificate(nil, nil, pkiutil.EncodeCertPEM(serverCA), user)
+	concrete := kubeconfigForCertificate(
+		pkiutil.EncodeCertPEM(clientCertificate),
+		clientKeyPEM,
+		pkiutil.EncodeCertPEM(serverCA),
+		user,
+	)
+	concreteBytes, err := utilities.EncodeToYaml(concrete)
+	if err != nil {
+		t.Fatalf("encode kubeconfig: %v", err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "generated-kubeconfig"},
+		Data:       map[string][]byte{"value": concreteBytes},
+	}
+
+	reconciler := &KubeconfigGeneratorReconciler{}
+	valid, err := reconciler.isValid(
+		secret,
+		template,
+		groups,
+		user,
+		pkiutil.EncodeCertPEM(newClientCA),
+	)
+	if err != nil {
+		t.Fatalf("validate generated kubeconfig: %v", err)
+	}
+	if valid {
+		t.Fatal("expected a kubeconfig signed by the stale client CA to be invalid")
+	}
+}
+
+func kubeconfigForCertificate(clientCertificate, clientKey, serverCA []byte, user string) *clientcmdapiv1.Config {
+	const cluster = "tenant"
+
+	return &clientcmdapiv1.Config{
+		Kind:       "Config",
+		APIVersion: "v1",
+		AuthInfos: []clientcmdapiv1.NamedAuthInfo{
+			{
+				Name: user,
+				AuthInfo: clientcmdapiv1.AuthInfo{
+					ClientCertificateData: clientCertificate,
+					ClientKeyData:         clientKey,
+				},
+			},
+		},
+		Clusters: []clientcmdapiv1.NamedCluster{
+			{
+				Name: cluster,
+				Cluster: clientcmdapiv1.Cluster{
+					Server:                   "https://tenant.example.com:6443",
+					CertificateAuthorityData: serverCA,
+				},
+			},
+		},
+		Contexts: []clientcmdapiv1.NamedContext{
+			{
+				Name: user,
+				Context: clientcmdapiv1.Context{
+					Cluster:  cluster,
+					AuthInfo: user,
+				},
+			},
+		},
+		CurrentContext: user,
+	}
+}

--- a/controllers/tenantcontrolplane_controller.go
+++ b/controllers/tenantcontrolplane_controller.go
@@ -315,6 +315,27 @@ func (r *TenantControlPlaneReconciler) mutexSpec(obj client.Object) mutex.Spec {
 	}
 }
 
+func (r *TenantControlPlaneReconciler) clientCASecretToTenantControlPlanes(ctx context.Context, object client.Object) []reconcile.Request {
+	var tenantControlPlanes kamajiv1alpha1.TenantControlPlaneList
+	if err := r.Client.List(ctx, &tenantControlPlanes, client.InNamespace(object.GetNamespace())); err != nil {
+		log.FromContext(ctx).Error(err, "cannot list TenantControlPlanes referencing client CA Secret")
+
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for i := range tenantControlPlanes.Items {
+		tenantControlPlane := &tenantControlPlanes.Items[i]
+		if tenantControlPlane.GetAnnotations()[kamajiv1alpha1.ClientCASecretAnnotation] != object.GetName() {
+			continue
+		}
+
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tenantControlPlane)})
+	}
+
+	return requests
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *TenantControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	r.clock = clock.RealClock{}
@@ -351,6 +372,7 @@ func (r *TenantControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr
 		}})).
 		For(&kamajiv1alpha1.TenantControlPlane{}).
 		Owns(&corev1.Secret{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.clientCASecretToTenantControlPlanes)).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).

--- a/controllers/tenantcontrolplane_controller_metrics_test.go
+++ b/controllers/tenantcontrolplane_controller_metrics_test.go
@@ -6,6 +6,11 @@ package controllers
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 )
 
@@ -36,5 +41,54 @@ func TestResolveTenantControlPlaneAddressReturnsEmptyWhenUnresolvable(t *testing
 	address := resolveTenantControlPlaneAddress(tcp)
 	if address != "" {
 		t.Fatalf("expected empty address fallback, got %q", address)
+	}
+}
+
+func TestClientCASecretEnqueuesReferencingTenantControlPlane(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := kamajiv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add Kamaji scheme: %v", err)
+	}
+
+	const (
+		namespace      = "tenant"
+		clientCASecret = "client-ca"
+	)
+	referencingTCP := &kamajiv1alpha1.TenantControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "references-client-ca",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				kamajiv1alpha1.ClientCASecretAnnotation: clientCASecret,
+			},
+		},
+	}
+	unrelatedTCP := &kamajiv1alpha1.TenantControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unrelated",
+			Namespace: namespace,
+		},
+	}
+	reconciler := &TenantControlPlaneReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(referencingTCP, unrelatedTCP).
+			Build(),
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: clientCASecret, Namespace: namespace},
+	}
+
+	requests := reconciler.clientCASecretToTenantControlPlanes(t.Context(), secret)
+	if len(requests) != 1 {
+		t.Fatalf("expected one reconcile request, got %d", len(requests))
+	}
+	if requests[0].Namespace != namespace || requests[0].Name != referencingTCP.Name {
+		t.Fatalf("unexpected reconcile request: %#v", requests[0])
 	}
 }

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -689,6 +689,7 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 	// Opinionated defaults: applied only when the user didn't provide the same flag in ExtraArgs.
 	safeDefaults := map[string]string{
 		"--allow-privileged":                   "true",
+		"--client-ca-file":                     path.Join(v1beta3.DefaultCertificatesDir, constants.CACertName),
 		"--enable-bootstrap-token-auth":        "true",
 		"--requestheader-extra-headers-prefix": "X-Remote-Extra-",
 		"--requestheader-group-headers":        "X-Remote-Group",
@@ -708,7 +709,6 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 	// Managed flags: derived from the TCP spec, always applied, override any user duplicate.
 	managed := map[string]string{
 		"--advertise-address":                apiAdvertiseAddress,
-		"--client-ca-file":                   path.Join(v1beta3.DefaultCertificatesDir, constants.CACertName),
 		"--enable-admission-plugins":         strings.Join(tenantControlPlane.Spec.Kubernetes.AdmissionControllers.ToSlice(), ","),
 		"--service-cluster-ip-range":         strings.Join(serviceCIDRs, ","),
 		"--kubelet-client-certificate":       path.Join(v1beta3.DefaultCertificatesDir, constants.APIServerKubeletClientCertName),

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -49,6 +49,9 @@ const (
 	schedulerContainerName    = "kube-scheduler"
 	kineContainerName         = "kine"
 	kineInitContainerName     = "chmod"
+
+	clientCARotationReadinessPeriodSeconds    = int32(2)
+	clientCARotationReadinessFailureThreshold = int32(1)
 )
 
 var perPurposeControllerManagerSignerFlags = sets.New(
@@ -626,6 +629,11 @@ func (d Deployment) buildKubeAPIServer(podSpec *corev1.PodSpec, tenantControlPla
 	podSpec.Containers[index].LivenessProbe = defaultProbe("/livez", tenantControlPlane.Spec.NetworkProfile.Port)
 	podSpec.Containers[index].ReadinessProbe = defaultProbe("/readyz", tenantControlPlane.Spec.NetworkProfile.Port)
 	podSpec.Containers[index].StartupProbe = defaultProbe("/livez", tenantControlPlane.Spec.NetworkProfile.Port)
+
+	if tenantControlPlane.GetAnnotations()[kamajiv1alpha1.ClientCASecretAnnotation] != "" {
+		podSpec.Containers[index].ReadinessProbe.PeriodSeconds = clientCARotationReadinessPeriodSeconds
+		podSpec.Containers[index].ReadinessProbe.FailureThreshold = clientCARotationReadinessFailureThreshold
+	}
 
 	if probes := tenantControlPlane.Spec.ControlPlane.Deployment.Probes; probes != nil {
 		applyProbeSetOverrides(&podSpec.Containers[index], probes, probes.APIServer)

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -712,7 +712,6 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 	// Opinionated defaults: applied only when the user didn't provide the same flag in ExtraArgs.
 	safeDefaults := map[string]string{
 		"--allow-privileged":                   "true",
-		"--client-ca-file":                     path.Join(v1beta3.DefaultCertificatesDir, constants.CACertName),
 		"--enable-bootstrap-token-auth":        "true",
 		"--requestheader-extra-headers-prefix": "X-Remote-Extra-",
 		"--requestheader-group-headers":        "X-Remote-Group",
@@ -732,6 +731,7 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 	// Managed flags: derived from the TCP spec, always applied, override any user duplicate.
 	managed := map[string]string{
 		"--advertise-address":                apiAdvertiseAddress,
+		"--client-ca-file":                   path.Join(v1beta3.DefaultCertificatesDir, constants.CACertName),
 		"--enable-admission-plugins":         strings.Join(tenantControlPlane.Spec.Kubernetes.AdmissionControllers.ToSlice(), ","),
 		"--service-cluster-ip-range":         strings.Join(serviceCIDRs, ","),
 		"--kubelet-client-certificate":       path.Join(v1beta3.DefaultCertificatesDir, constants.APIServerKubeletClientCertName),
@@ -746,6 +746,10 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 		"--service-account-signing-key-file": path.Join(v1beta3.DefaultCertificatesDir, constants.ServiceAccountPrivateKeyName),
 		"--tls-cert-file":                    path.Join(v1beta3.DefaultCertificatesDir, constants.APIServerCertName),
 		"--tls-private-key-file":             path.Join(v1beta3.DefaultCertificatesDir, constants.APIServerKeyName),
+	}
+	if tenantControlPlane.GetAnnotations()[kamajiv1alpha1.ClientCASecretAnnotation] != "" {
+		safeDefaults["--client-ca-file"] = managed["--client-ca-file"]
+		delete(managed, "--client-ca-file")
 	}
 
 	switch d.DataStore.Spec.Driver {
@@ -1137,6 +1141,13 @@ func (d Deployment) templateLabels(ctx context.Context, tenantControlPlane *kama
 		"component.kamaji.clastix.io/service-account":                       hash(ctx, tenantControlPlane.GetNamespace(), tenantControlPlane.Status.Certificates.SA.SecretName),
 		"component.kamaji.clastix.io/scheduler-kubeconfig":                  hash(ctx, tenantControlPlane.GetNamespace(), tenantControlPlane.Status.KubeConfig.Scheduler.SecretName),
 		"component.kamaji.clastix.io/datastore":                             tenantControlPlane.Status.Storage.DataStoreName,
+	}
+	if tenantControlPlane.GetAnnotations()[kamajiv1alpha1.ClientCASecretAnnotation] != "" {
+		labels["component.kamaji.clastix.io/konnectivity-kubeconfig"] = hash(
+			ctx,
+			tenantControlPlane.GetNamespace(),
+			tenantControlPlane.Status.Addons.Konnectivity.Kubeconfig.SecretName,
+		)
 	}
 
 	return labels

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -506,6 +506,8 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 			if perPurposeControllerManagerSignerFlags.Has(flag) {
 				delete(args, "--cluster-signing-cert-file")
 				delete(args, "--cluster-signing-key-file")
+				delete(extraArgsMap, "--cluster-signing-cert-file")
+				delete(extraArgsMap, "--cluster-signing-key-file")
 
 				break
 			}

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -51,6 +51,17 @@ const (
 	kineInitContainerName     = "chmod"
 )
 
+var perPurposeControllerManagerSignerFlags = sets.New(
+	"--cluster-signing-kube-apiserver-client-cert-file",
+	"--cluster-signing-kube-apiserver-client-key-file",
+	"--cluster-signing-kubelet-client-cert-file",
+	"--cluster-signing-kubelet-client-key-file",
+	"--cluster-signing-kubelet-serving-cert-file",
+	"--cluster-signing-kubelet-serving-key-file",
+	"--cluster-signing-legacy-unknown-cert-file",
+	"--cluster-signing-legacy-unknown-key-file",
+)
+
 func applyProbeOverrides(probe *corev1.Probe, spec *kamajiv1alpha1.ProbeSpec) {
 	if probe == nil || spec == nil {
 		return
@@ -490,7 +501,17 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 	}
 
 	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil && len(extraArgs.ControllerManager) > 0 {
-		args = utilities.MergeMaps(args, utilities.ArgsFromSliceToMap(extraArgs.ControllerManager))
+		extraArgsMap := utilities.ArgsFromSliceToMap(extraArgs.ControllerManager)
+		for flag := range extraArgsMap {
+			if perPurposeControllerManagerSignerFlags.Has(flag) {
+				delete(args, "--cluster-signing-cert-file")
+				delete(args, "--cluster-signing-key-file")
+
+				break
+			}
+		}
+
+		args = utilities.MergeMaps(args, extraArgsMap)
 	}
 
 	podSpec.Containers[index].Name = "kube-controller-manager"

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -208,6 +208,33 @@ var _ = Describe("Controlplane Deployment", func() {
 			))
 		})
 
+		It("omits global signer flags when per-purpose signers are configured", func() {
+			perPurposeArgs := []string{
+				"--cluster-signing-kube-apiserver-client-cert-file=/etc/kubernetes/client-ca/ca.crt",
+				"--cluster-signing-kube-apiserver-client-key-file=/etc/kubernetes/client-ca/ca.key",
+				"--cluster-signing-kubelet-client-cert-file=/etc/kubernetes/client-ca/ca.crt",
+				"--cluster-signing-kubelet-client-key-file=/etc/kubernetes/client-ca/ca.key",
+				"--cluster-signing-kubelet-serving-cert-file=/etc/kubernetes/pki/ca.crt",
+				"--cluster-signing-kubelet-serving-key-file=/etc/kubernetes/pki/ca.key",
+				"--cluster-signing-legacy-unknown-cert-file=/etc/kubernetes/client-ca/ca.crt",
+				"--cluster-signing-legacy-unknown-key-file=/etc/kubernetes/client-ca/ca.key",
+			}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
+				ControllerManager: perPurposeArgs,
+			}
+			podSpec := &corev1.PodSpec{}
+
+			d.buildControllerManager(podSpec, tcp)
+
+			Expect(podSpec.Containers).To(HaveLen(1))
+			Expect(podSpec.Containers[0].Args).To(ContainElements(perPurposeArgs))
+			Expect(podSpec.Containers[0].Args).NotTo(ContainElements(
+				"--cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt",
+				"--cluster-signing-key-file=/etc/kubernetes/pki/ca.key",
+			))
+		})
+
 		It("mounts client trust and signer secrets into only the components that need them", func() {
 			clientTrustVolume := corev1.Volume{
 				Name: "client-ca-bundle",

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -461,6 +461,56 @@ var _ = Describe("Controlplane Deployment", func() {
 			Expect(c.ReadinessProbe.HTTPGet.Path).To(Equal("/readyz"))
 			Expect(c.StartupProbe.HTTPGet.Path).To(Equal("/livez"))
 			Expect(c.ReadinessProbe.HTTPGet.Port.IntValue()).To(Equal(6443))
+			Expect(c.ReadinessProbe.PeriodSeconds).To(Equal(int32(10)))
+			Expect(c.ReadinessProbe.FailureThreshold).To(Equal(int32(3)))
+		})
+
+		It("uses fast readiness detection for client CA rollouts", func() {
+			const (
+				clientCARotationReadinessPeriodSeconds    = int32(2)
+				clientCARotationReadinessFailureThreshold = int32(1)
+			)
+
+			podSpec := &corev1.PodSpec{}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.SetAnnotations(map[string]string{
+				kamajiv1alpha1.ClientCASecretAnnotation: "client-ca",
+			})
+			tcp.Spec.NetworkProfile.Port = 6443
+
+			d.buildKubeAPIServer(podSpec, tcp, "")
+
+			c := containerByName(podSpec, "kube-apiserver")
+			Expect(c.ReadinessProbe.PeriodSeconds).To(Equal(clientCARotationReadinessPeriodSeconds))
+			Expect(c.ReadinessProbe.FailureThreshold).To(Equal(clientCARotationReadinessFailureThreshold))
+		})
+
+		It("lets explicit probe configuration override client CA rollout defaults", func() {
+			const (
+				configuredReadinessPeriodSeconds    = int32(5)
+				configuredReadinessFailureThreshold = int32(2)
+			)
+
+			podSpec := &corev1.PodSpec{}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.SetAnnotations(map[string]string{
+				kamajiv1alpha1.ClientCASecretAnnotation: "client-ca",
+			})
+			tcp.Spec.NetworkProfile.Port = 6443
+			tcp.Spec.ControlPlane.Deployment.Probes = &kamajiv1alpha1.ControlPlaneProbes{
+				APIServer: &kamajiv1alpha1.ProbeSet{
+					Readiness: &kamajiv1alpha1.ProbeSpec{
+						PeriodSeconds:    pointer.To(configuredReadinessPeriodSeconds),
+						FailureThreshold: pointer.To(configuredReadinessFailureThreshold),
+					},
+				},
+			}
+
+			d.buildKubeAPIServer(podSpec, tcp, "")
+
+			c := containerByName(podSpec, "kube-apiserver")
+			Expect(c.ReadinessProbe.PeriodSeconds).To(Equal(configuredReadinessPeriodSeconds))
+			Expect(c.ReadinessProbe.FailureThreshold).To(Equal(configuredReadinessFailureThreshold))
 		})
 	})
 

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -4,12 +4,16 @@
 package controlplane
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	pointer "k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/utilities"
@@ -170,6 +174,9 @@ var _ = Describe("Controlplane Deployment", func() {
 			const clientCAPath = "/etc/kubernetes/client-ca/client-ca-bundle.crt"
 
 			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.SetAnnotations(map[string]string{
+				kamajiv1alpha1.ClientCASecretAnnotation: "client-ca",
+			})
 			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
 				APIServer: []string{"--client-ca-file=" + clientCAPath},
 			}
@@ -178,6 +185,57 @@ var _ = Describe("Controlplane Deployment", func() {
 
 			Expect(got).To(ContainElement("--client-ca-file=" + clientCAPath))
 			Expect(got).NotTo(ContainElement("--client-ca-file=/etc/kubernetes/pki/ca.crt"))
+		})
+
+		It("keeps client CA trust managed for an unannotated tenant control plane", func() {
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
+				APIServer: []string{"--client-ca-file=/etc/kubernetes/unmounted/ca.crt"},
+			}
+
+			got := d.buildKubeAPIServerCommand(tcp, "10.0.0.1", nil)
+
+			Expect(got).To(ContainElement("--client-ca-file=/etc/kubernetes/pki/ca.crt"))
+			Expect(got).NotTo(ContainElement("--client-ca-file=/etc/kubernetes/unmounted/ca.crt"))
+		})
+
+		It("rolls an opted-in control plane when its Konnectivity kubeconfig changes", func() {
+			const (
+				namespace      = "tenant"
+				kubeconfigName = "konnectivity-kubeconfig"
+				kubeconfigHash = "component.kamaji.clastix.io/konnectivity-kubeconfig"
+			)
+
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			kubeconfigSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: kubeconfigName, Namespace: namespace},
+				Data:       map[string][]byte{"konnectivity-server.conf": []byte("old")},
+			}
+			d.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(kubeconfigSecret).Build()
+			tcp := &kamajiv1alpha1.TenantControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Annotations: map[string]string{
+						kamajiv1alpha1.ClientCASecretAnnotation: "client-ca",
+					},
+				},
+				Status: kamajiv1alpha1.TenantControlPlaneStatus{
+					Addons: kamajiv1alpha1.AddonsStatus{
+						Konnectivity: kamajiv1alpha1.KonnectivityStatus{
+							Kubeconfig: kamajiv1alpha1.KubeconfigStatus{SecretName: kubeconfigName},
+						},
+					},
+				},
+			}
+
+			before := d.templateLabels(context.Background(), tcp)[kubeconfigHash]
+			kubeconfigSecret.Data["konnectivity-server.conf"] = []byte("new")
+			Expect(d.Client.Update(context.Background(), kubeconfigSecret)).To(Succeed())
+			after := d.templateLabels(context.Background(), tcp)[kubeconfigHash]
+
+			Expect(before).NotTo(BeEmpty())
+			Expect(after).NotTo(Equal(before))
 		})
 
 		It("lets the user select a dedicated client certificate signer", func() {

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -166,6 +166,94 @@ var _ = Describe("Controlplane Deployment", func() {
 			Expect(got).NotTo(ContainElement("--secure-port=9443"))
 		})
 
+		It("lets the user select a dedicated client CA bundle", func() {
+			const clientCAPath = "/etc/kubernetes/client-ca/client-ca-bundle.crt"
+
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
+				APIServer: []string{"--client-ca-file=" + clientCAPath},
+			}
+
+			got := d.buildKubeAPIServerCommand(tcp, "10.0.0.1", nil)
+
+			Expect(got).To(ContainElement("--client-ca-file=" + clientCAPath))
+			Expect(got).NotTo(ContainElement("--client-ca-file=/etc/kubernetes/pki/ca.crt"))
+		})
+
+		It("lets the user select a dedicated client certificate signer", func() {
+			const (
+				signerCertPath = "/etc/kubernetes/client-ca/client-ca.crt"
+				signerKeyPath  = "/etc/kubernetes/client-ca/client-ca.key"
+			)
+
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
+				ControllerManager: []string{
+					"--cluster-signing-cert-file=" + signerCertPath,
+					"--cluster-signing-key-file=" + signerKeyPath,
+				},
+			}
+			podSpec := &corev1.PodSpec{}
+
+			d.buildControllerManager(podSpec, tcp)
+
+			Expect(podSpec.Containers).To(HaveLen(1))
+			Expect(podSpec.Containers[0].Args).To(ContainElements(
+				"--cluster-signing-cert-file="+signerCertPath,
+				"--cluster-signing-key-file="+signerKeyPath,
+			))
+			Expect(podSpec.Containers[0].Args).NotTo(ContainElements(
+				"--cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt",
+				"--cluster-signing-key-file=/etc/kubernetes/pki/ca.key",
+			))
+		})
+
+		It("mounts client trust and signer secrets into only the components that need them", func() {
+			clientTrustVolume := corev1.Volume{
+				Name: "client-ca-bundle",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "tenant-client-ca-bundle",
+					},
+				},
+			}
+			clientSignerVolume := corev1.Volume{
+				Name: "client-ca-signer",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "tenant-client-ca-signer",
+					},
+				},
+			}
+			clientTrustMount := corev1.VolumeMount{
+				Name:      clientTrustVolume.Name,
+				MountPath: "/etc/kubernetes/client-ca",
+				ReadOnly:  true,
+			}
+			clientSignerMount := corev1.VolumeMount{
+				Name:      clientSignerVolume.Name,
+				MountPath: "/etc/kubernetes/client-signer",
+				ReadOnly:  true,
+			}
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.AdditionalVolumes = []corev1.Volume{clientTrustVolume, clientSignerVolume}
+			tcp.Spec.ControlPlane.Deployment.AdditionalVolumeMounts = &kamajiv1alpha1.AdditionalVolumeMounts{
+				APIServer:         []corev1.VolumeMount{clientTrustMount},
+				ControllerManager: []corev1.VolumeMount{clientSignerMount},
+			}
+			podSpec := &corev1.PodSpec{}
+
+			d.setAdditionalVolumes(podSpec, tcp)
+			d.buildKubeAPIServer(podSpec, tcp, "10.0.0.1")
+			d.buildControllerManager(podSpec, tcp)
+
+			Expect(podSpec.Volumes).To(ContainElements(clientTrustVolume, clientSignerVolume))
+			Expect(podSpec.Containers[0].VolumeMounts).To(ContainElement(clientTrustMount))
+			Expect(podSpec.Containers[0].VolumeMounts).NotTo(ContainElement(clientSignerMount))
+			Expect(podSpec.Containers[1].VolumeMounts).To(ContainElement(clientSignerMount))
+			Expect(podSpec.Containers[1].VolumeMounts).NotTo(ContainElement(clientTrustMount))
+		})
+
 		It("preserves multiple user values for a repeatable flag", func() {
 			user := []string{
 				"--service-account-issuer=https://issuer-one.example.com",

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -219,9 +219,13 @@ var _ = Describe("Controlplane Deployment", func() {
 				"--cluster-signing-legacy-unknown-cert-file=/etc/kubernetes/client-ca/ca.crt",
 				"--cluster-signing-legacy-unknown-key-file=/etc/kubernetes/client-ca/ca.key",
 			}
+			globalArgs := []string{
+				"--cluster-signing-cert-file=/etc/kubernetes/other-ca/ca.crt",
+				"--cluster-signing-key-file=/etc/kubernetes/other-ca/ca.key",
+			}
 			tcp := kamajiv1alpha1.TenantControlPlane{}
 			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
-				ControllerManager: perPurposeArgs,
+				ControllerManager: append(perPurposeArgs, globalArgs...),
 			}
 			podSpec := &corev1.PodSpec{}
 
@@ -233,6 +237,7 @@ var _ = Describe("Controlplane Deployment", func() {
 				"--cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt",
 				"--cluster-signing-key-file=/etc/kubernetes/pki/ca.key",
 			))
+			Expect(podSpec.Containers[0].Args).NotTo(ContainElements(globalArgs))
 		})
 
 		It("mounts client trust and signer secrets into only the components that need them", func() {

--- a/internal/kubeadm/kubeconfig.go
+++ b/internal/kubeadm/kubeconfig.go
@@ -5,6 +5,7 @@ package kubeadm
 
 import (
 	"bytes"
+	"crypto/x509"
 	"os"
 	"path"
 	"path/filepath"
@@ -80,6 +81,26 @@ func IsKubeconfigCAValid(in, caCrt []byte) bool {
 
 	for _, cluster := range kc.Clusters {
 		if !bytes.Equal(cluster.Cluster.CertificateAuthorityData, caCrt) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func IsKubeconfigClientCertificateValid(in, clientCA []byte) bool {
+	kc, err := utilities.DecodeKubeconfigYAML(in)
+	if err != nil || len(kc.AuthInfos) == 0 {
+		return false
+	}
+
+	for _, authInfo := range kc.AuthInfos {
+		valid, verifyErr := crypto.VerifyCertificate(
+			authInfo.AuthInfo.ClientCertificateData,
+			clientCA,
+			x509.ExtKeyUsageClientAuth,
+		)
+		if verifyErr != nil || !valid {
 			return false
 		}
 	}

--- a/internal/kubeadm/kubeconfig.go
+++ b/internal/kubeadm/kubeconfig.go
@@ -48,6 +48,30 @@ func CreateKubeconfig(kubeconfigName string, ca CertificatePrivateKeyPair, confi
 	return os.ReadFile(path)
 }
 
+// CreateKubeconfigWithClientSigner embeds the server CA while signing client credentials with a separate CA.
+func CreateKubeconfigWithClientSigner(
+	kubeconfigName string,
+	serverCA []byte,
+	clientSigner CertificatePrivateKeyPair,
+	config *Configuration,
+) ([]byte, error) {
+	kubeconfigBytes, err := CreateKubeconfig(kubeconfigName, clientSigner, config)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfigConfig, err := utilities.DecodeKubeconfigYAML(kubeconfigBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range kubeconfigConfig.Clusters {
+		kubeconfigConfig.Clusters[i].Cluster.CertificateAuthorityData = serverCA
+	}
+
+	return utilities.EncodeToYaml(kubeconfigConfig)
+}
+
 func IsKubeconfigCAValid(in, caCrt []byte) bool {
 	kc, err := utilities.DecodeKubeconfigYAML(in)
 	if err != nil {

--- a/internal/kubeadm/kubeconfig_test.go
+++ b/internal/kubeadm/kubeconfig_test.go
@@ -67,3 +67,52 @@ func TestCreateKubeconfigWithClientSigner(t *testing.T) {
 		t.Fatal("client certificate is unexpectedly signed by server CA")
 	}
 }
+
+func TestIsKubeconfigClientCertificateValid(t *testing.T) {
+	t.Parallel()
+
+	serverCA, _ := certstestutil.SetupCertificateAuthority(t)
+	oldClientCA, oldClientCAKey := certstestutil.SetupCertificateAuthority(t)
+	newClientCA, _ := certstestutil.SetupCertificateAuthority(t)
+
+	oldClientCAKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(oldClientCAKey)
+	if err != nil {
+		t.Fatalf("marshal old client CA key: %v", err)
+	}
+
+	for _, kubeconfigName := range []string{
+		kubeadmconstants.AdminKubeConfigFileName,
+		kubeadmconstants.SuperAdminKubeConfigFileName,
+	} {
+		t.Run(kubeconfigName, func(t *testing.T) {
+			t.Parallel()
+
+			config, configErr := kubeadmconfig.DefaultedStaticInitConfiguration()
+			if configErr != nil {
+				t.Fatalf("create kubeadm configuration: %v", configErr)
+			}
+
+			config.CertificatesDir = t.TempDir()
+			config.ClusterName = "tenant"
+			config.ControlPlaneEndpoint = "127.0.0.1:6443"
+
+			oldClientCAPEM := pkiutil.EncodeCertPEM(oldClientCA)
+			kubeconfig, createErr := CreateKubeconfigWithClientSigner(
+				kubeconfigName,
+				pkiutil.EncodeCertPEM(serverCA),
+				CertificatePrivateKeyPair{Certificate: oldClientCAPEM, PrivateKey: oldClientCAKeyPEM},
+				&Configuration{InitConfiguration: *config},
+			)
+			if createErr != nil {
+				t.Fatalf("create kubeconfig: %v", createErr)
+			}
+
+			if !IsKubeconfigClientCertificateValid(kubeconfig, oldClientCAPEM) {
+				t.Fatal("expected the current client signer to validate the kubeconfig")
+			}
+			if IsKubeconfigClientCertificateValid(kubeconfig, pkiutil.EncodeCertPEM(newClientCA)) {
+				t.Fatal("expected a stale client signer to invalidate the kubeconfig")
+			}
+		})
+	}
+}

--- a/internal/kubeadm/kubeconfig_test.go
+++ b/internal/kubeadm/kubeconfig_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeadm
+
+import (
+	"bytes"
+	"crypto/x509"
+	"testing"
+
+	keyutil "k8s.io/client-go/util/keyutil"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
+	kubeadmconfig "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+
+	kamajicrypto "github.com/clastix/kamaji/internal/crypto"
+	"github.com/clastix/kamaji/internal/utilities"
+)
+
+func TestCreateKubeconfigWithClientSigner(t *testing.T) {
+	serverCA, _ := certstestutil.SetupCertificateAuthority(t)
+	clientCA, clientCAKey := certstestutil.SetupCertificateAuthority(t)
+
+	clientCAKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientCAKey)
+	if err != nil {
+		t.Fatalf("marshal client CA key: %v", err)
+	}
+
+	config, err := kubeadmconfig.DefaultedStaticInitConfiguration()
+	if err != nil {
+		t.Fatalf("create kubeadm configuration: %v", err)
+	}
+
+	config.CertificatesDir = t.TempDir()
+	config.ClusterName = "tenant"
+	config.ControlPlaneEndpoint = "127.0.0.1:6443"
+
+	serverCAPEM := pkiutil.EncodeCertPEM(serverCA)
+	clientCAPEM := pkiutil.EncodeCertPEM(clientCA)
+	kubeconfig, err := CreateKubeconfigWithClientSigner(
+		kubeadmconstants.AdminKubeConfigFileName,
+		serverCAPEM,
+		CertificatePrivateKeyPair{Certificate: clientCAPEM, PrivateKey: clientCAKeyPEM},
+		&Configuration{InitConfiguration: *config},
+	)
+	if err != nil {
+		t.Fatalf("create kubeconfig: %v", err)
+	}
+
+	decoded, err := utilities.DecodeKubeconfigYAML(kubeconfig)
+	if err != nil {
+		t.Fatalf("decode kubeconfig: %v", err)
+	}
+	if len(decoded.Clusters) != 1 || len(decoded.AuthInfos) != 1 {
+		t.Fatalf("unexpected kubeconfig shape: %d clusters, %d auth infos", len(decoded.Clusters), len(decoded.AuthInfos))
+	}
+	if !bytes.Equal(decoded.Clusters[0].Cluster.CertificateAuthorityData, serverCAPEM) {
+		t.Fatal("kubeconfig does not trust the server CA")
+	}
+
+	clientCertificate := decoded.AuthInfos[0].AuthInfo.ClientCertificateData
+	if valid, verifyErr := kamajicrypto.VerifyCertificate(clientCertificate, clientCAPEM, x509.ExtKeyUsageClientAuth); !valid || verifyErr != nil {
+		t.Fatalf("client certificate is not signed by client CA: %v", verifyErr)
+	}
+	if valid, _ := kamajicrypto.VerifyCertificate(clientCertificate, serverCAPEM, x509.ExtKeyUsageClientAuth); valid {
+		t.Fatal("client certificate is unexpectedly signed by server CA")
+	}
+}

--- a/internal/resources/konnectivity/certificate_resource.go
+++ b/internal/resources/konnectivity/certificate_resource.go
@@ -156,7 +156,16 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 			PrivateKey:  clientSignerSecret.Data[kubeadmconstants.CAKeyName],
 		}
 
-		cert, privKey, err := crypto.GenerateCertificatePrivateKeyPair(crypto.NewCertificateTemplate(CertCommonName), ca.Certificate, ca.PrivateKey)
+		certificateTemplate := crypto.NewCertificateTemplate(CertCommonName)
+		signerCertificate, err := crypto.ParseCertificateBytes(ca.Certificate)
+		if err != nil {
+			return fmt.Errorf("cannot parse client signer certificate: %w", err)
+		}
+		if certificateTemplate.NotAfter.After(signerCertificate.NotAfter) {
+			certificateTemplate.NotAfter = signerCertificate.NotAfter
+		}
+
+		cert, privKey, err := crypto.GenerateCertificatePrivateKeyPair(certificateTemplate, ca.Certificate, ca.PrivateKey)
 		if err != nil {
 			logger.Error(err, "unable to generate certificate and private key")
 

--- a/internal/resources/konnectivity/certificate_resource.go
+++ b/internal/resources/konnectivity/certificate_resource.go
@@ -112,6 +112,12 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 
 			return err
 		}
+		clientSignerSecret, err := resources.GetClientSignerSecret(ctx, r.Client, tenantControlPlane, secretCA)
+		if err != nil {
+			logger.Error(err, "cannot retrieve the client certificate signer")
+
+			return err
+		}
 
 		r.resource.SetLabels(utilities.MergeMaps(
 			r.resource.GetLabels(),
@@ -130,7 +136,7 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 		isRotationRequested := utilities.IsRotationRequested(r.resource)
 
 		if checksum := tenantControlPlane.Status.Addons.Konnectivity.Certificate.Checksum; !isRotationRequested && (len(checksum) > 0 && checksum == utilities.CalculateMapChecksum(r.resource.Data)) {
-			isCAValid, err := crypto.VerifyCertificate(r.resource.Data[corev1.TLSCertKey], secretCA.Data[kubeadmconstants.CACertName], x509.ExtKeyUsageServerAuth)
+			isCAValid, err := crypto.VerifyCertificate(r.resource.Data[corev1.TLSCertKey], clientSignerSecret.Data[kubeadmconstants.CACertName], x509.ExtKeyUsageClientAuth)
 			if err != nil {
 				logger.Info(fmt.Sprintf("certificate-authority verify failed: %s", err.Error()))
 			}
@@ -146,8 +152,8 @@ func (r *CertificateResource) mutate(ctx context.Context, tenantControlPlane *ka
 
 		ca := kubeadm.CertificatePrivateKeyPair{
 			Name:        kubeadmconstants.CACertAndKeyBaseName,
-			Certificate: secretCA.Data[kubeadmconstants.CACertName],
-			PrivateKey:  secretCA.Data[kubeadmconstants.CAKeyName],
+			Certificate: clientSignerSecret.Data[kubeadmconstants.CACertName],
+			PrivateKey:  clientSignerSecret.Data[kubeadmconstants.CAKeyName],
 		}
 
 		cert, privKey, err := crypto.GenerateCertificatePrivateKeyPair(crypto.NewCertificateTemplate(CertCommonName), ca.Certificate, ca.PrivateKey)

--- a/internal/resources/konnectivity/kubeconfig_resource.go
+++ b/internal/resources/konnectivity/kubeconfig_resource.go
@@ -4,6 +4,7 @@
 package konnectivity
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -124,18 +125,19 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 			return err
 		}
 
-		checksum := tenantControlPlane.Status.Addons.Konnectivity.Kubeconfig.Checksum
-		if len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) && !isRotationRequested &&
-			kubeadm.IsKubeconfigCAValid(r.resource.Data[konnectivityKubeconfigFileName], secretCA.Data[kubeadmconstants.CACertName]) {
-			return nil
-		}
-
 		certificateNamespacedName := k8stypes.NamespacedName{Namespace: tenantControlPlane.GetNamespace(), Name: tenantControlPlane.Status.Addons.Konnectivity.Certificate.SecretName}
 		secretCertificate := &corev1.Secret{}
 		if err := r.Client.Get(ctx, certificateNamespacedName, secretCertificate); err != nil {
 			logger.Error(err, "cannot retrieve the Konnectivity Certificate secret")
 
 			return err
+		}
+
+		checksum := tenantControlPlane.Status.Addons.Konnectivity.Kubeconfig.Checksum
+		if len(checksum) > 0 && checksum == utilities.GetObjectChecksum(r.resource) && !isRotationRequested &&
+			kubeadm.IsKubeconfigCAValid(r.resource.Data[konnectivityKubeconfigFileName], secretCA.Data[kubeadmconstants.CACertName]) &&
+			isKubeconfigClientCertificateCurrent(r.resource, secretCertificate) {
+			return nil
 		}
 
 		userName := CertCommonName
@@ -192,4 +194,16 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 
 		return nil
 	}
+}
+
+func isKubeconfigClientCertificateCurrent(kubeconfigSecret, certificateSecret *corev1.Secret) bool {
+	kubeconfig, err := utilities.DecodeKubeconfig(*kubeconfigSecret, konnectivityKubeconfigFileName)
+	if err != nil || len(kubeconfig.AuthInfos) == 0 {
+		return false
+	}
+
+	authInfo := kubeconfig.AuthInfos[0].AuthInfo
+
+	return bytes.Equal(authInfo.ClientCertificateData, certificateSecret.Data[corev1.TLSCertKey]) &&
+		bytes.Equal(authInfo.ClientKeyData, certificateSecret.Data[corev1.TLSPrivateKeyKey])
 }

--- a/internal/resources/konnectivity/kubeconfig_resource_test.go
+++ b/internal/resources/konnectivity/kubeconfig_resource_test.go
@@ -29,14 +29,15 @@ import (
 )
 
 var _ = Describe("KonnectivityKubeconfigResource", func() {
-	It("regenerates kubeconfig when embedded CA is stale", func() {
+	It("regenerates kubeconfig when its client certificate is stale", func() {
 		ctx := context.Background()
 
-		oldCACert, oldCAKey := createSelfSignedCA("old-ca")
-		newCACert, newCAKey := createSelfSignedCA("new-ca")
+		serverCACert, serverCAKey := createSelfSignedCA("server-ca")
+		oldClientCACert, oldClientCAKey := createSelfSignedCA("old-client-ca")
+		newClientCACert, newClientCAKey := createSelfSignedCA("new-client-ca")
 
-		oldClientCert, oldClientKey := createSignedKonnectivityCert(oldCACert, oldCAKey)
-		newClientCert, newClientKey := createSignedKonnectivityCert(newCACert, newCAKey)
+		oldClientCert, oldClientKey := createSignedKonnectivityCert(oldClientCACert, oldClientCAKey)
+		newClientCert, newClientKey := createSignedKonnectivityCert(newClientCACert, newClientCAKey)
 
 		tcp := &kamajiv1alpha1.TenantControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
@@ -61,7 +62,7 @@ var _ = Describe("KonnectivityKubeconfigResource", func() {
 			},
 		}
 
-		staleKubeconfig := renderKubeconfig(oldCACert, oldClientCert, oldClientKey)
+		staleKubeconfig := renderKubeconfig(serverCACert, oldClientCert, oldClientKey)
 
 		kubeconfigSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -78,8 +79,8 @@ var _ = Describe("KonnectivityKubeconfigResource", func() {
 		caSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "tenant-01-ca", Namespace: "default"},
 			Data: map[string][]byte{
-				kubeadmconstants.CACertName: newCACert,
-				kubeadmconstants.CAKeyName:  newCAKey,
+				kubeadmconstants.CACertName: serverCACert,
+				kubeadmconstants.CAKeyName:  serverCAKey,
 			},
 		}
 
@@ -107,10 +108,67 @@ var _ = Describe("KonnectivityKubeconfigResource", func() {
 
 		reconciledKubeconfig := decodeKubeconfig(reconciled.Data["konnectivity-server.conf"])
 		Expect(reconciledKubeconfig.Clusters).To(HaveLen(1))
-		Expect(reconciledKubeconfig.Clusters[0].Cluster.CertificateAuthorityData).To(Equal(newCACert))
+		Expect(reconciledKubeconfig.Clusters[0].Cluster.CertificateAuthorityData).To(Equal(serverCACert))
 		Expect(reconciledKubeconfig.AuthInfos).To(HaveLen(1))
 		Expect(reconciledKubeconfig.AuthInfos[0].AuthInfo.ClientCertificateData).To(Equal(newClientCert))
 		Expect(reconciledKubeconfig.AuthInfos[0].AuthInfo.ClientKeyData).To(Equal(newClientKey))
+	})
+
+	It("signs the konnectivity client certificate with the dedicated client CA", func() {
+		ctx := context.Background()
+
+		serverCACert, serverCAKey := createSelfSignedCA("server-ca")
+		clientCACert, clientCAKey := createSelfSignedCA("client-ca")
+		tcp := &kamajiv1alpha1.TenantControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tenant-01",
+				Namespace: "default",
+				Annotations: map[string]string{
+					kamajiv1alpha1.ClientCASecretAnnotation: "tenant-01-client-ca",
+				},
+			},
+			Spec: kamajiv1alpha1.TenantControlPlaneSpec{
+				Addons: kamajiv1alpha1.AddonsSpec{
+					Konnectivity: &kamajiv1alpha1.KonnectivitySpec{},
+				},
+			},
+			Status: kamajiv1alpha1.TenantControlPlaneStatus{
+				Certificates: kamajiv1alpha1.CertificatesStatus{
+					CA: kamajiv1alpha1.CertificatePrivateKeyPairStatus{SecretName: "tenant-01-ca"},
+				},
+			},
+		}
+		serverCASecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "tenant-01-ca", Namespace: "default"},
+			Data: map[string][]byte{
+				kubeadmconstants.CACertName: serverCACert,
+				kubeadmconstants.CAKeyName:  serverCAKey,
+			},
+		}
+		clientCASecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "tenant-01-client-ca", Namespace: "default"},
+			Data: map[string][]byte{
+				kubeadmconstants.CACertName: clientCACert,
+				kubeadmconstants.CAKeyName:  clientCAKey,
+			},
+		}
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(runtimeScheme).
+			WithObjects(serverCASecret, clientCASecret).
+			Build()
+		resource := &konnectivity.CertificateResource{Client: fakeClient}
+		Expect(resource.Define(ctx, tcp)).To(Succeed())
+
+		_, err := resource.CreateOrUpdate(ctx, tcp)
+		Expect(err).NotTo(HaveOccurred())
+
+		reconciled := &corev1.Secret{}
+		Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "tenant-01-konnectivity-certificate", Namespace: "default"}, reconciled)).To(Succeed())
+		valid, err := crypto.VerifyCertificate(reconciled.Data[corev1.TLSCertKey], clientCACert, x509.ExtKeyUsageClientAuth)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(valid).To(BeTrue())
+		valid, _ = crypto.VerifyCertificate(reconciled.Data[corev1.TLSCertKey], serverCACert, x509.ExtKeyUsageClientAuth)
+		Expect(valid).To(BeFalse())
 	})
 })
 

--- a/internal/resources/konnectivity/kubeconfig_resource_test.go
+++ b/internal/resources/konnectivity/kubeconfig_resource_test.go
@@ -167,10 +167,17 @@ var _ = Describe("KonnectivityKubeconfigResource", func() {
 		valid, err := crypto.VerifyCertificate(reconciled.Data[corev1.TLSCertKey], clientCACert, x509.ExtKeyUsageClientAuth)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valid).To(BeTrue())
+		clientCertificate, err := crypto.ParseCertificateBytes(reconciled.Data[corev1.TLSCertKey])
+		Expect(err).NotTo(HaveOccurred())
+		clientCertificateAuthority, err := crypto.ParseCertificateBytes(clientCACert)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clientCertificate.NotAfter.After(clientCertificateAuthority.NotAfter)).To(BeFalse())
 		valid, _ = crypto.VerifyCertificate(reconciled.Data[corev1.TLSCertKey], serverCACert, x509.ExtKeyUsageClientAuth)
 		Expect(valid).To(BeFalse())
 	})
 })
+
+const testCAValidityYears = 2
 
 func createSelfSignedCA(commonName string) ([]byte, []byte) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -182,7 +189,7 @@ func createSelfSignedCA(commonName string) ([]byte, []byte) {
 			CommonName: commonName,
 		},
 		NotBefore:             time.Now().Add(-1 * time.Minute),
-		NotAfter:              time.Now().Add(24 * time.Hour),
+		NotAfter:              time.Now().AddDate(testCAValidityYears, 0, 0),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
 		IsCA:                  true,

--- a/internal/resources/kubeadm_phases.go
+++ b/internal/resources/kubeadm_phases.go
@@ -187,15 +187,24 @@ func (r *KubeadmPhase) GetKubeadmFunction(ctx context.Context, tcp *kamajiv1alph
 				return nil, err
 			}
 
-			crtKeyPair := kubeadm.CertificatePrivateKeyPair{
-				Certificate: caSecret.Data[kubeadmconstants.CACertName],
-				PrivateKey:  caSecret.Data[kubeadmconstants.CAKeyName],
+			clientSignerSecret, err := GetClientSignerSecret(ctx, r.Client, tcp, &caSecret)
+			if err != nil {
+				return nil, err
+			}
+			clientSigner := kubeadm.CertificatePrivateKeyPair{
+				Certificate: clientSignerSecret.Data[kubeadmconstants.CACertName],
+				PrivateKey:  clientSignerSecret.Data[kubeadmconstants.CAKeyName],
 			}
 
 			for _, i := range []string{AdminKubeConfigFileName, SuperAdminKubeConfigFileName} {
 				configuration.InitConfiguration.CertificatesDir, _ = os.MkdirTemp(tmp, "")
 
-				kubeconfigValue, err := kubeadm.CreateKubeconfig(SuperAdminKubeConfigFileName, crtKeyPair, configuration)
+				kubeconfigValue, err := kubeadm.CreateKubeconfigWithClientSigner(
+					SuperAdminKubeConfigFileName,
+					caSecret.Data[kubeadmconstants.CACertName],
+					clientSigner,
+					configuration,
+				)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"time"
@@ -195,6 +196,9 @@ func GetClientSignerSecret(
 	}
 	if !certificate.IsCA {
 		return nil, fmt.Errorf("client CA secret %s certificate is not a certificate authority", secretName)
+	}
+	if certificate.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return nil, fmt.Errorf("client CA secret %s certificate does not permit certificate signing", secretName)
 	}
 
 	return clientSignerSecret, nil

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -33,6 +33,7 @@ const (
 	ControllerManagerKubeConfigFileName = kubeadmconstants.ControllerManagerKubeConfigFileName
 	SchedulerKubeConfigFileName         = kubeadmconstants.SchedulerKubeConfigFileName
 	localhost                           = "127.0.0.1"
+	clientSignerValidityBuffer          = 24 * time.Hour
 )
 
 type KubeconfigResource struct {
@@ -200,8 +201,29 @@ func GetClientSignerSecret(
 	if certificate.KeyUsage&x509.KeyUsageCertSign == 0 {
 		return nil, fmt.Errorf("client CA secret %s certificate does not permit certificate signing", secretName)
 	}
+	if !allowsClientAuthentication(certificate) {
+		return nil, fmt.Errorf("client CA secret %s certificate does not permit client authentication", secretName)
+	}
+	minimumValidity := kubeadmconstants.CertificateValidityPeriod + clientSignerValidityBuffer
+	if !certificate.NotAfter.After(time.Now().Add(minimumValidity)) {
+		return nil, fmt.Errorf("client CA secret %s certificate expires before the minimum client credential lifetime", secretName)
+	}
 
 	return clientSignerSecret, nil
+}
+
+func allowsClientAuthentication(certificate *x509.Certificate) bool {
+	if len(certificate.ExtKeyUsage) == 0 && len(certificate.UnknownExtKeyUsage) == 0 {
+		return true
+	}
+
+	for _, usage := range certificate.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageAny || usage == x509.ExtKeyUsageClientAuth {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (r *KubeconfigResource) createKubeconfig(

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -21,6 +21,7 @@ import (
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/clastix/kamaji/internal/constants"
+	"github.com/clastix/kamaji/internal/crypto"
 	"github.com/clastix/kamaji/internal/kubeadm"
 	"github.com/clastix/kamaji/internal/utilities"
 )
@@ -128,13 +129,98 @@ func (r *KubeconfigResource) CreateOrUpdate(ctx context.Context, tenantControlPl
 	return utilities.CreateOrUpdateWithConflict(ctx, r.Client, r.resource, r.mutate(ctx, tenantControlPlane))
 }
 
-func (r *KubeconfigResource) checksum(caCertificatesSecret *corev1.Secret, kubeadmChecksum string, checksum string) string {
-	return utilities.CalculateMapChecksum(map[string][]byte{
+func (r *KubeconfigResource) checksum(
+	caCertificatesSecret *corev1.Secret,
+	clientSignerSecret *corev1.Secret,
+	kubeadmChecksum string,
+	checksum string,
+) string {
+	data := map[string][]byte{
 		"ca-cert-checksum": caCertificatesSecret.Data[kubeadmconstants.CACertName],
 		"ca-key-checksum":  caCertificatesSecret.Data[kubeadmconstants.CAKeyName],
 		"kubeadmconfig":    []byte(kubeadmChecksum),
 		"kubeconfig":       []byte(checksum),
-	})
+	}
+
+	if clientSignerSecret != caCertificatesSecret {
+		data["client-ca-cert-checksum"] = clientSignerSecret.Data[kubeadmconstants.CACertName]
+		data["client-ca-key-checksum"] = clientSignerSecret.Data[kubeadmconstants.CAKeyName]
+	}
+
+	return utilities.CalculateMapChecksum(data)
+}
+
+// GetClientSignerSecret returns the dedicated client certificate signer, or the server CA when none is configured.
+func GetClientSignerSecret(
+	ctx context.Context,
+	k8sClient client.Client,
+	tenantControlPlane *kamajiv1alpha1.TenantControlPlane,
+	defaultCASecret *corev1.Secret,
+) (*corev1.Secret, error) {
+	secretName := tenantControlPlane.GetAnnotations()[kamajiv1alpha1.ClientCASecretAnnotation]
+	if secretName == "" {
+		return defaultCASecret, nil
+	}
+
+	clientSignerSecret := &corev1.Secret{}
+	namespacedName := k8stypes.NamespacedName{
+		Namespace: tenantControlPlane.GetNamespace(),
+		Name:      secretName,
+	}
+	if err := k8sClient.Get(ctx, namespacedName, clientSignerSecret); err != nil {
+		return nil, fmt.Errorf("cannot retrieve client CA secret %s: %w", secretName, err)
+	}
+	if len(clientSignerSecret.Data[kubeadmconstants.CACertName]) == 0 {
+		return nil, fmt.Errorf("client CA secret %s is missing %s", secretName, kubeadmconstants.CACertName)
+	}
+	if len(clientSignerSecret.Data[kubeadmconstants.CAKeyName]) == 0 {
+		return nil, fmt.Errorf("client CA secret %s is missing %s", secretName, kubeadmconstants.CAKeyName)
+	}
+
+	isValid, err := crypto.CheckCertificateAndPrivateKeyPairValidity(
+		clientSignerSecret.Data[kubeadmconstants.CACertName],
+		clientSignerSecret.Data[kubeadmconstants.CAKeyName],
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("client CA secret %s is invalid: %w", secretName, err)
+	}
+	if !isValid {
+		return nil, fmt.Errorf("client CA secret %s does not contain a valid certificate and private key", secretName)
+	}
+
+	certificate, err := crypto.ParseCertificateBytes(clientSignerSecret.Data[kubeadmconstants.CACertName])
+	if err != nil {
+		return nil, fmt.Errorf("client CA secret %s certificate cannot be parsed: %w", secretName, err)
+	}
+	if !certificate.IsCA {
+		return nil, fmt.Errorf("client CA secret %s certificate is not a certificate authority", secretName)
+	}
+
+	return clientSignerSecret, nil
+}
+
+func (r *KubeconfigResource) createKubeconfig(
+	kubeconfigName string,
+	caCertificatesSecret *corev1.Secret,
+	clientSignerSecret *corev1.Secret,
+	config *kubeadm.Configuration,
+) ([]byte, error) {
+	clientSigner := kubeadm.CertificatePrivateKeyPair{
+		Certificate: clientSignerSecret.Data[kubeadmconstants.CACertName],
+		PrivateKey:  clientSignerSecret.Data[kubeadmconstants.CAKeyName],
+	}
+
+	if clientSignerSecret == caCertificatesSecret {
+		return kubeadm.CreateKubeconfig(kubeconfigName, clientSigner, config)
+	}
+
+	return kubeadm.CreateKubeconfigWithClientSigner(
+		kubeconfigName,
+		caCertificatesSecret.Data[kubeadmconstants.CACertName],
+		clientSigner,
+		config,
+	)
 }
 
 //nolint:gocognit
@@ -163,7 +249,19 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 			return err
 		}
 
-		checksum := r.checksum(caCertificatesSecret, config.Checksum(), utilities.CalculateMapChecksum(r.resource.Data))
+		clientSignerSecret, err := GetClientSignerSecret(ctx, r.Client, tenantControlPlane, caCertificatesSecret)
+		if err != nil {
+			logger.Error(err, "cannot retrieve the client certificate signer")
+
+			return err
+		}
+
+		checksum := r.checksum(
+			caCertificatesSecret,
+			clientSignerSecret,
+			config.Checksum(),
+			utilities.CalculateMapChecksum(r.resource.Data),
+		)
 
 		status, err := r.getKubeconfigStatus(tenantControlPlane)
 		if err != nil {
@@ -204,16 +302,16 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 		}
 
 		if shouldCreate || shouldRotate {
-			crtKeyPair := kubeadm.CertificatePrivateKeyPair{
-				Certificate: caCertificatesSecret.Data[kubeadmconstants.CACertName],
-				PrivateKey:  caCertificatesSecret.Data[kubeadmconstants.CAKeyName],
-			}
-
 			if r.resource.Data == nil {
 				r.resource.Data = map[string][]byte{}
 			}
 
-			kubeconfig, kcErr := kubeadm.CreateKubeconfig(r.KubeConfigFileName, crtKeyPair, config)
+			kubeconfig, kcErr := r.createKubeconfig(
+				r.KubeConfigFileName,
+				caCertificatesSecret,
+				clientSignerSecret,
+				config,
+			)
 			if kcErr != nil {
 				logger.Error(kcErr, "cannot create a valid kubeconfig")
 
@@ -233,7 +331,12 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 				key := strings.ReplaceAll(r.KubeConfigFileName, ".conf", ".svc")
 
 				config.InitConfiguration.ControlPlaneEndpoint = fmt.Sprintf("%s.%s.svc:%d", tenantControlPlane.Name, tenantControlPlane.Namespace, tenantControlPlane.Spec.NetworkProfile.Port)
-				kubeconfig, kcErr = kubeadm.CreateKubeconfig(r.KubeConfigFileName, crtKeyPair, config)
+				kubeconfig, kcErr = r.createKubeconfig(
+					r.KubeConfigFileName,
+					caCertificatesSecret,
+					clientSignerSecret,
+					config,
+				)
 				if kcErr != nil {
 					logger.Error(kcErr, "cannot create a valid kubeconfig")
 
@@ -243,7 +346,12 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 				r.resource.Data[key] = kubeconfig
 			}
 
-			checksum = r.checksum(caCertificatesSecret, config.Checksum(), utilities.CalculateMapChecksum(r.resource.Data))
+			checksum = r.checksum(
+				caCertificatesSecret,
+				clientSignerSecret,
+				config.Checksum(),
+				utilities.CalculateMapChecksum(r.resource.Data),
+			)
 			r.resource.SetAnnotations(utilities.MergeMaps(r.resource.GetAnnotations(), map[string]string{constants.Checksum: checksum}))
 		}
 

--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -317,6 +317,7 @@ func (r *KubeconfigResource) mutate(ctx context.Context, tenantControlPlane *kam
 		shouldCreate = shouldCreate || len(r.resource.Data) == 0                       // Missing data key
 		shouldCreate = shouldCreate || len(r.resource.Data[r.KubeConfigFileName]) == 0 // Missing kubeconfig file, must be generated
 		shouldCreate = shouldCreate || !kubeadm.IsKubeconfigCAValid(r.resource.Data[r.KubeConfigFileName], caCertificatesSecret.Data[kubeadmconstants.CACertName])
+		shouldCreate = shouldCreate || !kubeadm.IsKubeconfigClientCertificateValid(r.resource.Data[r.KubeConfigFileName], clientSignerSecret.Data[kubeadmconstants.CACertName])
 		shouldCreate = shouldCreate || !kubeadm.IsKubeconfigValid(r.resource.Data[r.KubeConfigFileName], r.CertExpirationThreshold) // invalid kubeconfig, or expired client certificate
 		shouldCreate = shouldCreate || status.Checksum != checksum || len(r.resource.UID) == 0                                      // Wrong checksum
 

--- a/internal/resources/kubeconfig_client_signer_test.go
+++ b/internal/resources/kubeconfig_client_signer_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	keyutil "k8s.io/client-go/util/keyutil"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
+	pkiutil "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+)
+
+func TestGetClientSignerSecret(t *testing.T) {
+	t.Parallel()
+
+	clientCACert, clientCAKey := certstestutil.SetupCertificateAuthority(t)
+	clientCAKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientCAKey)
+	if err != nil {
+		t.Fatalf("marshal client CA key: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err = corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	const (
+		namespace          = "tenant"
+		clientCASecret     = "client-ca"
+		defaultCASecret    = "server-ca"
+		tenantControlPlane = "tenant-control-plane"
+	)
+	dedicatedSigner := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: clientCASecret, Namespace: namespace},
+		Data: map[string][]byte{
+			kubeadmconstants.CACertName: pkiutil.EncodeCertPEM(clientCACert),
+			kubeadmconstants.CAKeyName:  clientCAKeyPEM,
+		},
+	}
+	defaultSigner := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: defaultCASecret, Namespace: namespace},
+	}
+	tcp := &kamajiv1alpha1.TenantControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tenantControlPlane,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				kamajiv1alpha1.ClientCASecretAnnotation: clientCASecret,
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dedicatedSigner).Build()
+
+	got, err := GetClientSignerSecret(t.Context(), k8sClient, tcp, defaultSigner)
+	if err != nil {
+		t.Fatalf("get client signer: %v", err)
+	}
+	if got.Name != clientCASecret {
+		t.Fatalf("expected signer %q, got %q", clientCASecret, got.Name)
+	}
+}
+
+func TestGetClientSignerSecretDefaultsToServerCA(t *testing.T) {
+	t.Parallel()
+
+	defaultSigner := &corev1.Secret{}
+	got, err := GetClientSignerSecret(
+		t.Context(),
+		fake.NewClientBuilder().Build(),
+		&kamajiv1alpha1.TenantControlPlane{},
+		defaultSigner,
+	)
+	if err != nil {
+		t.Fatalf("get default client signer: %v", err)
+	}
+	if got != defaultSigner {
+		t.Fatal("expected the server CA secret to remain the default signer")
+	}
+}

--- a/internal/resources/kubeconfig_client_signer_test.go
+++ b/internal/resources/kubeconfig_client_signer_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,57 +73,91 @@ func TestGetClientSignerSecret(t *testing.T) {
 	}
 }
 
-func TestGetClientSignerSecretRejectsCAWithoutCertSignUsage(t *testing.T) {
+func TestGetClientSignerSecretRejectsInvalidCAConstraints(t *testing.T) {
 	t.Parallel()
 
-	clientCACert, clientCAKey := certstestutil.SetupCertificateAuthority(t)
-	clientCACert.KeyUsage = x509.KeyUsageDigitalSignature
-	clientCACertDER, err := x509.CreateCertificate(
-		rand.Reader,
-		clientCACert,
-		clientCACert,
-		clientCAKey.Public(),
-		clientCAKey,
-	)
-	if err != nil {
-		t.Fatalf("create client CA certificate: %v", err)
-	}
-	clientCAKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientCAKey)
-	if err != nil {
-		t.Fatalf("marshal client CA key: %v", err)
-	}
-
-	scheme := runtime.NewScheme()
-	if err = corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add core scheme: %v", err)
-	}
-
-	const (
-		namespace          = "tenant"
-		clientCASecret     = "client-ca"
-		tenantControlPlane = "tenant-control-plane"
-	)
-	dedicatedSigner := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: clientCASecret, Namespace: namespace},
-		Data: map[string][]byte{
-			kubeadmconstants.CACertName: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCACertDER}),
-			kubeadmconstants.CAKeyName:  clientCAKeyPEM,
-		},
-	}
-	tcp := &kamajiv1alpha1.TenantControlPlane{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tenantControlPlane,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				kamajiv1alpha1.ClientCASecretAnnotation: clientCASecret,
+	testCases := []struct {
+		name      string
+		mutate    func(*x509.Certificate)
+		wantError string
+	}{
+		{
+			name: "certificate signing key usage is absent",
+			mutate: func(certificate *x509.Certificate) {
+				certificate.KeyUsage = x509.KeyUsageDigitalSignature
 			},
+			wantError: "does not permit certificate signing",
+		},
+		{
+			name: "extended key usage excludes client authentication",
+			mutate: func(certificate *x509.Certificate) {
+				certificate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+			},
+			wantError: "does not permit client authentication",
+		},
+		{
+			name: "certificate expires before generated client credentials",
+			mutate: func(certificate *x509.Certificate) {
+				certificate.NotAfter = time.Now().Add(clientSignerValidityBuffer)
+			},
+			wantError: "expires before the minimum client credential lifetime",
 		},
 	}
-	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dedicatedSigner).Build()
 
-	_, err = GetClientSignerSecret(t.Context(), k8sClient, tcp, &corev1.Secret{})
-	if err == nil || !strings.Contains(err.Error(), "does not permit certificate signing") {
-		t.Fatalf("expected certificate signing key usage error, got %v", err)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientCACert, clientCAKey := certstestutil.SetupCertificateAuthority(t)
+			testCase.mutate(clientCACert)
+			clientCACertDER, err := x509.CreateCertificate(
+				rand.Reader,
+				clientCACert,
+				clientCACert,
+				clientCAKey.Public(),
+				clientCAKey,
+			)
+			if err != nil {
+				t.Fatalf("create client CA certificate: %v", err)
+			}
+			clientCAKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientCAKey)
+			if err != nil {
+				t.Fatalf("marshal client CA key: %v", err)
+			}
+
+			scheme := runtime.NewScheme()
+			if err = corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add core scheme: %v", err)
+			}
+
+			const (
+				namespace          = "tenant"
+				clientCASecret     = "client-ca"
+				tenantControlPlane = "tenant-control-plane"
+			)
+			dedicatedSigner := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: clientCASecret, Namespace: namespace},
+				Data: map[string][]byte{
+					kubeadmconstants.CACertName: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCACertDER}),
+					kubeadmconstants.CAKeyName:  clientCAKeyPEM,
+				},
+			}
+			tcp := &kamajiv1alpha1.TenantControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tenantControlPlane,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						kamajiv1alpha1.ClientCASecretAnnotation: clientCASecret,
+					},
+				},
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dedicatedSigner).Build()
+
+			_, err = GetClientSignerSecret(t.Context(), k8sClient, tcp, &corev1.Secret{})
+			if err == nil || !strings.Contains(err.Error(), testCase.wantError) {
+				t.Fatalf("expected %q error, got %v", testCase.wantError, err)
+			}
+		})
 	}
 }
 

--- a/internal/resources/kubeconfig_client_signer_test.go
+++ b/internal/resources/kubeconfig_client_signer_test.go
@@ -4,6 +4,10 @@
 package resources
 
 import (
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +69,60 @@ func TestGetClientSignerSecret(t *testing.T) {
 	}
 	if got.Name != clientCASecret {
 		t.Fatalf("expected signer %q, got %q", clientCASecret, got.Name)
+	}
+}
+
+func TestGetClientSignerSecretRejectsCAWithoutCertSignUsage(t *testing.T) {
+	t.Parallel()
+
+	clientCACert, clientCAKey := certstestutil.SetupCertificateAuthority(t)
+	clientCACert.KeyUsage = x509.KeyUsageDigitalSignature
+	clientCACertDER, err := x509.CreateCertificate(
+		rand.Reader,
+		clientCACert,
+		clientCACert,
+		clientCAKey.Public(),
+		clientCAKey,
+	)
+	if err != nil {
+		t.Fatalf("create client CA certificate: %v", err)
+	}
+	clientCAKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(clientCAKey)
+	if err != nil {
+		t.Fatalf("marshal client CA key: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err = corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	const (
+		namespace          = "tenant"
+		clientCASecret     = "client-ca"
+		tenantControlPlane = "tenant-control-plane"
+	)
+	dedicatedSigner := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: clientCASecret, Namespace: namespace},
+		Data: map[string][]byte{
+			kubeadmconstants.CACertName: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCACertDER}),
+			kubeadmconstants.CAKeyName:  clientCAKeyPEM,
+		},
+	}
+	tcp := &kamajiv1alpha1.TenantControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tenantControlPlane,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				kamajiv1alpha1.ClientCASecretAnnotation: clientCASecret,
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dedicatedSigner).Build()
+
+	_, err = GetClientSignerSecret(t.Context(), k8sClient, tcp, &corev1.Secret{})
+	if err == nil || !strings.Contains(err.Error(), "does not permit certificate signing") {
+		t.Fatalf("expected certificate signing key usage error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- let a tenant control plane opt into a dedicated client certificate signer while preserving the shared-CA default
- keep the API serving CA in kubeconfigs while signing managed, generated, and Konnectivity client credentials with the dedicated signer
- validate signer constraints and make signer-driven credential changes roll safely

## Safety
- the feature is disabled unless `kamaji.clastix.io/client-ca-secret` names a signer Secret
- unannotated tenant control planes keep `--client-ca-file` as a managed shared-CA flag, so stale user overrides cannot become active on upgrade
- mixed global and per-purpose controller-manager signer flags are reduced to the per-purpose form because Kubernetes treats the forms as mutually exclusive
- dedicated signers must be a matching CA keypair, permit certificate signing and client authentication, and remain valid longer than generated kubeconfig clients
- every kubeconfig entry validates its own client issuer, including the shared Secret's `admin.conf` and `super-admin.conf`
- opted-in control planes roll when their embedded Konnectivity kubeconfig changes; generated Konnectivity credentials cannot outlive the signer
- CAPK/TCCO ownership and external distribution remain downstream concerns

## Linear
Part of [TCL-9312](https://linear.app/together-ai/issue/TCL-9312/validate-and-rotate-kubeconfigs-for-all-tcloud-inference-clusters)

## Test plan
- [x] `go test ./internal/builders/controlplane ./internal/resources ./internal/resources/konnectivity`
- [x] `make test`
- [x] `go test ./controllers/...`
- [x] `make golint`
- [x] `gitleaks git --no-banner --log-opts='origin/master..HEAD'`
- [x] prior 9-node, 16-GPU QA canary on the minimal `26.6.5-edge` prototype: all kubelets moved to the dedicated issuer, old credentials were rejected, no VM or workload restarted, and the unannotated peer remained unchanged
- [ ] repeat the live QA canary on the exact traceable backport (`jhu-svg/kamaji@7700611249ad`, image digest `sha256:9e208efaac8895c6c982ac1e4c7ceb1028c553a56cc7753196d70e7127ea71c3`)

## Dependency scan
`govulncheck ./...` reports nine reachable vulnerabilities inherited from the current base; this PR changes no dependencies.
