### PR TITLE
fix: scope kubeconfig handler histogram to the resource name

### DIFF
--- a/internal/resources/kubeconfig.go
+++ b/internal/resources/kubeconfig.go
@@ -43,9 +43,10 @@ type KubeconfigResource struct {
 }
 
 func (r *KubeconfigResource) GetHistogram() prometheus.Histogram {
-	kubeconfigCollector = LazyLoadHistogramFromResource(kubeconfigCollector, r)
-
-	return kubeconfigCollector
+	// Unlike the other resources, the handler name is per-instance rather than a constant:
+	// caching the observer in a package-level variable would bind every KubeconfigResource
+	// to the name of the first one calling this function.
+	return LazyLoadHistogramFromResource(nil, r)
 }
 
 func (r *KubeconfigResource) ShouldStatusBeUpdated(_ context.Context, tcp *kamajiv1alpha1.TenantControlPlane) bool {

--- a/internal/resources/metrics.go
+++ b/internal/resources/metrics.go
@@ -22,7 +22,6 @@ var (
 	serviceCollector                   prometheus.Histogram
 	kubeadmconfigCollector             prometheus.Histogram
 	kubeadmupgradeCollector            prometheus.Histogram
-	kubeconfigCollector                prometheus.Histogram
 	serviceaccountcertificateCollector prometheus.Histogram
 
 	kubeadmphaseUploadConfigKubeadmCollector prometheus.Histogram

--- a/internal/resources/metrics_test.go
+++ b/internal/resources/metrics_test.go
@@ -62,6 +62,39 @@ func TestHandlerHistogramUsesSingleMetricWithHandlerLabel(t *testing.T) {
 	}
 }
 
+func TestKubeconfigHandlerHistogramIsScopedToResourceName(t *testing.T) {
+	handlerCollector.Reset()
+
+	names := []string{"admin-kubeconfig", "controller-manager-kubeconfig", "scheduler-kubeconfig"}
+
+	for _, name := range names {
+		resource := KubeconfigResource{Name: name}
+
+		resource.GetHistogram().Observe(0.10)
+	}
+
+	families, err := metrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metric families: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "kamaji_handler_time_seconds" {
+			continue
+		}
+
+		for _, name := range names {
+			if !hasLabelValueForFamily(family, "handler", name) {
+				t.Errorf("expected handler label value %s in kamaji_handler_time_seconds", name)
+			}
+		}
+
+		return
+	}
+
+	t.Fatalf("metric family kamaji_handler_time_seconds not found")
+}
+
 func hasLabelValueForFamily(family *io_prometheus_client.MetricFamily, labelName, labelValue string) bool {
 	for _, metric := range family.GetMetric() {
 		for _, label := range metric.GetLabel() {


### PR DESCRIPTION
Fixes #1299.

`KubeconfigResource.GetHistogram()` cached its observer in the package-level `kubeconfigCollector`, but `LazyLoadHistogramFromResource` only consults `resource.GetName()` when the collector passed in is `nil`. The first instance to call it bound the variable to `WithLabelValues` of its own name; every later instance got that same observer back and never had its own name looked at.

`controllers/resources.go` declares four `KubeconfigResource` instances over three distinct names, so `kamaji_handler_time_seconds` never exported `handler="controller-manager-kubeconfig"` or `handler="scheduler-kubeconfig"` — those observations landed on `admin-kubeconfig`, making it report 4x the invocations of every other handler.

The fix returns the vector lookup directly, which is what the existing test's `fakeResource.GetHistogram()` already does, and drops the now-unused package-level variable. `KubeadmPhase` is the only other resource with a per-instance `GetName()`, and it already keeps one collector per phase, so nothing else is affected.

Added `TestKubeconfigHandlerHistogramIsScopedToResourceName`, which fails on `master` with the two labels missing and passes with the change. `make golint` reports 0 issues; `go test ./internal/resources/... -race` passes.

I kept this to the minimal fix. @jriedel-ionos also offered the wider cleanup in the issue — dropping the remaining package-level collectors and the `collector` parameter of `LazyLoadHistogramFromResource` to remove the trap for future per-instance names — happy to follow up with that as a separate PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
