### PR TITLE
fix(e2e): watch the migration freeze webhook instead of polling for it

### DIFF
--- a/e2e/tcp_migration_test.go
+++ b/e2e/tcp_migration_test.go
@@ -6,21 +6,19 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
-	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/retry"
 	pointer "k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -29,72 +27,31 @@ import (
 	"github.com/clastix/kamaji/internal/utilities"
 )
 
-// Seed size for the migration: enough objects to slow etcd's per-key Put loop, and enough
-// bytes to slow PostgreSQL's bulk COPY. Tunable.
-const (
-	migrationSeedObjects      = 400
-	migrationSeedPayloadBytes = 128 * 1024
-	migrationSeedConcurrency  = 10
-)
+// migrationFixtures is kept small on purpose: objects written here land in the Kamaji
+// manager's soot cache, which shares that process's 100Mi limit.
+const migrationFixtures = 5
 
-// migrationSeedBackoff outlasts the multi-second API server stalls that retry.DefaultBackoff does not.
-var migrationSeedBackoff = wait.Backoff{
-	Duration: 100 * time.Millisecond,
-	Factor:   2.0,
-	Jitter:   0.1,
-	Steps:    6,
-}
+// awaitFreezeWebhook drains freeze webhook events until the object is seen. The watch must
+// already be open before the migration is triggered: the webhook exists only while the
+// migration Job runs, and polling for it loses the race whenever the tenant API server is
+// contended, which on a 2-vCPU runner is most of that window.
+func awaitFreezeWebhook(w watch.Interface, timeout time.Duration) error {
+	deadline := time.After(timeout)
 
-// seedMigrationData fills the tenant cluster with ConfigMaps, returning their names.
-func seedMigrationData(ctx context.Context, tcpClient ctrlclient.Client, namespace string) []string {
-	GinkgoHelper()
-
-	payload := strings.Repeat("k", migrationSeedPayloadBytes)
-
-	names := make([]string, 0, migrationSeedObjects)
-	for i := range migrationSeedObjects {
-		names = append(names, fmt.Sprintf("migration-seed-%04d", i))
-	}
-
-	work := make(chan string)
-	errs := make(chan error, migrationSeedObjects)
-
-	var wg sync.WaitGroup
-
-	for range migrationSeedConcurrency {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
-			for name := range work {
-				cm := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-					Data:       map[string]string{"name": name, "payload": payload},
-				}
-				// The API server is contended: a create can need more than one attempt.
-				if err := retry.OnError(migrationSeedBackoff, func(error) bool { return true }, func() error {
-					return ctrlclient.IgnoreAlreadyExists(tcpClient.Create(ctx, cm))
-				}); err != nil {
-					errs <- fmt.Errorf("unable to seed ConfigMap %s/%s: %w", namespace, name, err)
-				}
+	for {
+		select {
+		case event, open := <-w.ResultChan():
+			if !open {
+				return fmt.Errorf("watch closed before %s was observed", ds.FreezeWebhookName)
 			}
-		}()
+
+			if event.Type == watch.Added || event.Type == watch.Modified {
+				return nil
+			}
+		case <-deadline:
+			return fmt.Errorf("timed out waiting for %s", ds.FreezeWebhookName)
+		}
 	}
-
-	for _, name := range names {
-		work <- name
-	}
-
-	close(work)
-	wg.Wait()
-	close(errs)
-
-	for err := range errs {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	return names
 }
 
 func featureTestMigration(driver string) {
@@ -156,12 +113,33 @@ func featureTestMigration(driver string) {
 		tcpClient, err := ctrlclient.New(restConfig, ctrlclient.Options{})
 		Expect(err).ToNot(HaveOccurred())
 
+		tcpClientset, err := kubernetes.NewForConfig(restConfig)
+		Expect(err).ToNot(HaveOccurred())
+
 		ns := &corev1.Namespace{}
 		ns.SetName("kamaji-test")
 		Expect(tcpClient.Create(context.Background(), ns)).ToNot(HaveOccurred())
 
-		By("seeding the source DataStore so the migration takes observable time")
-		seeded := seedMigrationData(context.Background(), tcpClient, ns.GetName())
+		By("writing fixtures the migration has to carry across")
+		fixtures := make([]string, 0, migrationFixtures)
+
+		for i := range migrationFixtures {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("migration-fixture-%d", i), Namespace: ns.GetName()},
+				Data:       map[string]string{"payload": rand.String(256)},
+			}
+			Expect(tcpClient.Create(context.Background(), cm)).ToNot(HaveOccurred())
+
+			fixtures = append(fixtures, cm.GetName())
+		}
+
+		By("opening a watch on the freeze webhook before the migration can install it")
+		freezeWatch, err := tcpClientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Watch(context.Background(), metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("metadata.name", ds.FreezeWebhookName).String(),
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		defer freezeWatch.Stop()
 
 		By("start migration to a new DataStore")
 		Eventually(func() error {
@@ -178,27 +156,15 @@ func featureTestMigration(driver string) {
 		StatusMustEqualTo(tcp, kamajiv1alpha1.VersionMigrating)
 
 		By("waiting for the webhook installation")
-		// The webhook only exists while the migration Job runs: once it completes the API
-		// server is repointed at the target DataStore and the webhook, being tenant data,
-		// is gone. So this is a window to sample, not a state to wait for, and a longer
-		// timeout cannot help once it has shut. The counters separate samples that reached
-		// the API server from those lost to it being starved.
-		var reachable, unreachable int
-
-		Eventually(func() error {
-			err := tcpClient.Get(context.Background(), types.NamespacedName{Name: ds.FreezeWebhookName}, &admissionregistrationv1.ValidatingWebhookConfiguration{})
-
-			switch {
-			case err == nil || apierrors.IsNotFound(err):
-				reachable++
-			default:
-				unreachable++
-			}
-
-			return err
-		}, 5*time.Minute, 500*time.Millisecond).Should(Succeed(), func() string {
-			return fmt.Sprintf("never observed %s in the tenant cluster: %d samples reached the API server, %d were lost to it being unreachable", ds.FreezeWebhookName, reachable, unreachable)
-		})
+		// The webhook is pushed to the watch opened above the instant Kamaji installs it,
+		// so a contended API server delays the event rather than hiding it. If the watch
+		// drops - the API server is restarted at the end of the migration - fall back to
+		// a direct read, which still succeeds while the window is open.
+		if err := awaitFreezeWebhook(freezeWatch, 5*time.Minute); err != nil {
+			Eventually(func() error {
+				return tcpClient.Get(context.Background(), types.NamespacedName{Name: ds.FreezeWebhookName}, &admissionregistrationv1.ValidatingWebhookConfiguration{})
+			}, time.Minute, time.Second).Should(Succeed(), "%s never observed: %s", ds.FreezeWebhookName, err)
+		}
 
 		By("ensuring changes are not allowed")
 		Consistently(func() error {
@@ -222,17 +188,17 @@ func featureTestMigration(driver string) {
 			return tcpClient.Get(context.Background(), types.NamespacedName{Name: ns.GetName()}, &corev1.Namespace{})
 		}).ShouldNot(HaveOccurred())
 
-		By("checking every seeded object survived the migration")
+		By("checking every fixture survived the migration")
 		// Makes this spec assert its own name, rather than just the one Namespace.
 		Eventually(func() error {
-			for _, name := range seeded {
+			for _, name := range fixtures {
 				if err := tcpClient.Get(context.Background(), types.NamespacedName{Namespace: ns.GetName(), Name: name}, &corev1.ConfigMap{}); err != nil {
-					return fmt.Errorf("seeded ConfigMap %s/%s did not survive the migration: %w", ns.GetName(), name, err)
+					return err
 				}
 			}
 
 			return nil
-		}, 5*time.Minute, time.Second).Should(Succeed())
+		}, time.Minute, time.Second).Should(Succeed())
 		// The Freeze ValidatingWebhookConfiguration should have been removed successfully:
 		// we're checking write operations are allowed.
 		By("checking the changes are newly allowed")

--- a/e2e/tcp_migration_test.go
+++ b/e2e/tcp_migration_test.go
@@ -6,22 +6,96 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 	pointer "k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
+	ds "github.com/clastix/kamaji/internal/resources/datastore"
 	"github.com/clastix/kamaji/internal/utilities"
 )
+
+// Seed size for the migration: enough objects to slow etcd's per-key Put loop, and enough
+// bytes to slow PostgreSQL's bulk COPY. Tunable.
+const (
+	migrationSeedObjects      = 400
+	migrationSeedPayloadBytes = 128 * 1024
+	migrationSeedConcurrency  = 10
+)
+
+// migrationSeedBackoff outlasts the multi-second API server stalls that retry.DefaultBackoff does not.
+var migrationSeedBackoff = wait.Backoff{
+	Duration: 100 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Steps:    6,
+}
+
+// seedMigrationData fills the tenant cluster with ConfigMaps, returning their names.
+func seedMigrationData(ctx context.Context, tcpClient ctrlclient.Client, namespace string) []string {
+	GinkgoHelper()
+
+	payload := strings.Repeat("k", migrationSeedPayloadBytes)
+
+	names := make([]string, 0, migrationSeedObjects)
+	for i := range migrationSeedObjects {
+		names = append(names, fmt.Sprintf("migration-seed-%04d", i))
+	}
+
+	work := make(chan string)
+	errs := make(chan error, migrationSeedObjects)
+
+	var wg sync.WaitGroup
+
+	for range migrationSeedConcurrency {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for name := range work {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       map[string]string{"name": name, "payload": payload},
+				}
+				// The API server is contended: a create can need more than one attempt.
+				if err := retry.OnError(migrationSeedBackoff, func(error) bool { return true }, func() error {
+					return ctrlclient.IgnoreAlreadyExists(tcpClient.Create(ctx, cm))
+				}); err != nil {
+					errs <- fmt.Errorf("unable to seed ConfigMap %s/%s: %w", namespace, name, err)
+				}
+			}
+		}()
+	}
+
+	for _, name := range names {
+		work <- name
+	}
+
+	close(work)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return names
+}
 
 func featureTestMigration(driver string) {
 	var tcp *kamajiv1alpha1.TenantControlPlane
@@ -86,6 +160,9 @@ func featureTestMigration(driver string) {
 		ns.SetName("kamaji-test")
 		Expect(tcpClient.Create(context.Background(), ns)).ToNot(HaveOccurred())
 
+		By("seeding the source DataStore so the migration takes observable time")
+		seeded := seedMigrationData(context.Background(), tcpClient, ns.GetName())
+
 		By("start migration to a new DataStore")
 		Eventually(func() error {
 			if err := k8sClient.Get(context.Background(), types.NamespacedName{Namespace: tcp.GetNamespace(), Name: tcp.GetName()}, tcp); err != nil {
@@ -101,17 +178,27 @@ func featureTestMigration(driver string) {
 		StatusMustEqualTo(tcp, kamajiv1alpha1.VersionMigrating)
 
 		By("waiting for the webhook installation")
-		// Measured directly in CI (GitHub Actions run 30307341733): the whole manager
-		// process - the host-side tenantcontrolplane controller across every TCP in the
-		// suite, plus this tenant's own soot sub-manager - went completely silent for
-		// 2m16s (21:45:45 to 21:48:01 UTC) with no errors logged, consistent with the
-		// process being starved of CPU on the 2-vCPU runner rather than any Kamaji-side
-		// bug: many tenant control planes, datastores, and their apiservers all compete
-		// for the same two cores. One minute sits well inside that observed stall, so
-		// the wait is widened to five for headroom above it.
+		// The webhook only exists while the migration Job runs: once it completes the API
+		// server is repointed at the target DataStore and the webhook, being tenant data,
+		// is gone. So this is a window to sample, not a state to wait for, and a longer
+		// timeout cannot help once it has shut. The counters separate samples that reached
+		// the API server from those lost to it being starved.
+		var reachable, unreachable int
+
 		Eventually(func() error {
-			return tcpClient.Get(context.Background(), types.NamespacedName{Name: "kamaji-freeze"}, &admissionregistrationv1.ValidatingWebhookConfiguration{})
-		}, 5*time.Minute, time.Second).Should(Succeed())
+			err := tcpClient.Get(context.Background(), types.NamespacedName{Name: ds.FreezeWebhookName}, &admissionregistrationv1.ValidatingWebhookConfiguration{})
+
+			switch {
+			case err == nil || apierrors.IsNotFound(err):
+				reachable++
+			default:
+				unreachable++
+			}
+
+			return err
+		}, 5*time.Minute, 500*time.Millisecond).Should(Succeed(), func() string {
+			return fmt.Sprintf("never observed %s in the tenant cluster: %d samples reached the API server, %d were lost to it being unreachable", ds.FreezeWebhookName, reachable, unreachable)
+		})
 
 		By("ensuring changes are not allowed")
 		Consistently(func() error {
@@ -134,6 +221,18 @@ func featureTestMigration(driver string) {
 		Eventually(func() error {
 			return tcpClient.Get(context.Background(), types.NamespacedName{Name: ns.GetName()}, &corev1.Namespace{})
 		}).ShouldNot(HaveOccurred())
+
+		By("checking every seeded object survived the migration")
+		// Makes this spec assert its own name, rather than just the one Namespace.
+		Eventually(func() error {
+			for _, name := range seeded {
+				if err := tcpClient.Get(context.Background(), types.NamespacedName{Namespace: ns.GetName(), Name: name}, &corev1.ConfigMap{}); err != nil {
+					return fmt.Errorf("seeded ConfigMap %s/%s did not survive the migration: %w", ns.GetName(), name, err)
+				}
+			}
+
+			return nil
+		}, 5*time.Minute, time.Second).Should(Succeed())
 		// The Freeze ValidatingWebhookConfiguration should have been removed successfully:
 		// we're checking write operations are allowed.
 		By("checking the changes are newly allowed")


### PR DESCRIPTION
## Why are we doing this work?

The `Kubernetes` (e2e) stage fails intermittently on `When migrating a Tenant Control Plane to another datastore (postgresql) [It] Should contain all the migrated data`:

```
[FAILED] Timed out after 300.000s.
Expected success, but got an error:
    validatingwebhookconfigurations.admissionregistration.k8s.io "kamaji-freeze" not found
```

It is not specific to any branch. [Run 33677525122](https://github.com/clastix/kamaji/actions/runs/33677525122) and [run 34161116165](https://github.com/clastix/kamaji/actions/runs/34161116165) fail identically within an hour of each other, and the second is `8e5429e` — master tip `80f32ba` plus a diff touching only `go.mod` and `go.sum`. A dependency bump cannot break the migration path, so this is a live flake rather than a broken commit.

**The spec was polling for a transient object.** `kamaji-freeze` exists only while the migration Job runs. `MigrationInProcessError` short-circuits the reconcile chain for the duration, so the tenant API server is not repointed at the target DataStore until the copy is done, and the host-side installer from #1277 re-asserts the webhook every second until then. Once the Job reports `Complete` the chain proceeds, the API server moves to the target, and the webhook — which lives in the tenant's own data — is gone, correctly: nothing needs freezing once writes land on the live datastore.

Polling that window is the problem. Inside it the tenant API server is being starved on a 2-vCPU runner shared by every TCP in the suite — the manager itself logs `context deadline exceeded`, `http2: server sent GOAWAY and closed the connection` and `unexpected EOF` against that endpoint. Outside it, the object is absent by design. Every sample lands in one of those two categories and the spec burns its full five minutes. On a green run the first poll finds it in **3 ms**; this is all-or-nothing, not slow, which is why widening the timeout in #1260 could not have helped.

## What does this PR change?

Test-only, `e2e/tcp_migration_test.go`:

1. **Opens a watch on `kamaji-freeze` before the migration is triggered.** Kamaji installs the webhook synchronously ahead of the Job, so the event is pushed the instant the object exists and waits on the channel until the spec reads it. A contended API server now delays the event rather than hiding it, and there is no sampling gap to lose.
2. **Keeps a direct read as a fallback**, for the case where the watch itself drops.
3. **Writes five small fixtures and checks they survived**, so the spec asserts what its name claims rather than checking a single Namespace.
4. Replaces the `"kamaji-freeze"` literal with `ds.FreezeWebhookName`.

Nothing is weakened: the webhook must still be observed, so the spec still fails if the freeze genuinely lapses.

## What gaps remain in the solution to this problem? What step is this in the sequence?

1. **One residual failure mode.** If the watch connection dies before delivering the event and the window has already shut, the fallback read finds nothing and the spec fails. That case is genuinely unobservable from outside the cluster, and it is much narrower than a sampling gap.
2. **The freeze guarantee itself is host-side and synchronous since #1277, so it is unit-testable** with no timing at all. If this spec keeps proving awkward, moving that assertion down to a unit test and leaving e2e to assert data migration is the better end state. Not bundled here.
3. The fixtures are deliberately tiny — see below for why that matters.

## How was this tested? Demonstrate it with a Loom or with posted input / output logs.

```
$ gofmt -l e2e/
$ go vet ./e2e/...
$ go build ./...
$ go test -c -o /dev/null ./e2e/
$ make golint
bin/golangci-lint run -c .golangci.yml
0 issues.
```

`kind` is not available in my environment, so the suite itself has to be exercised by CI.

**The first attempt on this branch is the useful evidence.** It tried to widen the window by seeding the source DataStore, and [run 34249422711](https://github.com/clastix/kamaji/actions/runs/34249422711) collapsed with **24 failures**, which pinned down two things worth recording:

- **Writing bulk data to a tenant cluster OOMKills the Kamaji manager.** 400 ConfigMaps of 128 KiB is 50 MiB; the soot manager calls `controllerruntime.NewManager` with no `Cache` option, so it caches ConfigMaps cluster-wide, and that process runs under the chart's default `memory: 100Mi`. The manager restarted mid-suite (`setup starting manager` at 09:24:30) and every subsequent spec failed in `JustBeforeEach` with `dial tcp 10.96.100.74:443: connect: connection refused`, 66 times.
- **Seeding degrades the very reachability the assertion depends on.** The etcd spec spent 74 s failing to read a webhook that had been installed before `Migrating` was even observable, and the copy overran the migration Job's five-minute default timeout, leaving the TCP stuck `Migrating`.

So widening the window is self-defeating, and the watch is the approach that actually holds. That is also why the fixtures here are five 256-byte objects rather than anything substantial.

## What else should a reviewer know?

This is the fourth attempt at this spec, after #1203, #1260 and #1277.

**#1260 widened this wait from one minute to five and could not have worked.** Once the window shuts the object is absent by design, so extra waiting only accumulates more `NotFound`s — which is exactly what the 300 s of failure above consists of. Its comment, attributing the flake to a 2m16s manager stall, is replaced.

**There is no product bug here.** I went looking for one first, on the theory that the freeze was being lost mid-migration. It is not: `MigrationInProcessError` holds the chain until the Job completes and the host-side installer re-asserts the webhook throughout, so #1277's guarantee holds over exactly the interval where the source DataStore is still authoritative.

**Two things left deliberately untouched.** The soot migrate controller races to re-create the freeze webhook after the switch-over, when it is no longer needed, and logs an `ERROR` when that `Post` fails — misleading log noise on every migration. And the soot manager's unfiltered cluster-wide ConfigMap cache against a 100Mi limit is a real scaling characteristic that a tenant with many large ConfigMaps would hit in production, not just in this suite. Both are out of scope for a test fix; happy to raise either separately.
