### PR TITLE
fix(networking)!: dual-stack / IPv6 correctness fixes (bind-address, CoreDNS, endpoint & CIDR validation)

### DIFF
--- a/api/v1alpha1/cidr_families_test.go
+++ b/api/v1alpha1/cidr_families_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ServiceCIDRs and PodCIDRs IP families", func() {
+	var (
+		ctx context.Context
+		tcp *TenantControlPlane
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		tcp = &TenantControlPlane{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "cidr-families-", Namespace: "default"},
+			Spec:       TenantControlPlaneSpec{},
+		}
+		tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeClusterIP
+	})
+
+	AfterEach(func() {
+		if tcp.GetName() != "" {
+			if err := k8sClient.Delete(ctx, tcp); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+	})
+
+	It("accepts a single-stack serviceCidrs", func() {
+		tcp.Spec.NetworkProfile.ServiceCIDRs = []string{"10.96.0.0/16"}
+		Expect(k8sClient.Create(ctx, tcp)).To(Succeed())
+	})
+
+	It("accepts a dual-stack serviceCidrs", func() {
+		tcp.Spec.NetworkProfile.ServiceCIDRs = []string{"10.96.0.0/16", "fd00::/108"}
+		Expect(k8sClient.Create(ctx, tcp)).To(Succeed())
+	})
+
+	It("denies two same-family serviceCidrs", func() {
+		tcp.Spec.NetworkProfile.ServiceCIDRs = []string{"10.96.0.0/16", "10.97.0.0/16"}
+
+		err := k8sClient.Create(ctx, tcp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("serviceCidrs must not contain two CIDRs of the same IP family"))
+	})
+
+	It("accepts a dual-stack podCidrs", func() {
+		tcp.Spec.NetworkProfile.PodCIDRs = []string{"10.244.0.0/16", "fd00:244::/56"}
+		Expect(k8sClient.Create(ctx, tcp)).To(Succeed())
+	})
+
+	It("denies two same-family podCidrs", func() {
+		tcp.Spec.NetworkProfile.PodCIDRs = []string{"fd00:244::/56", "fd00:245::/56"}
+
+		err := k8sClient.Create(ctx, tcp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("podCidrs must not contain two CIDRs of the same IP family"))
+	})
+})

--- a/api/v1alpha1/datastore_types.go
+++ b/api/v1alpha1/datastore_types.go
@@ -23,7 +23,7 @@ var (
 //+kubebuilder:validation:MinItems=1
 //+kubebuilder:validation:MaxItems=64
 //+kubebuilder:validation:items:MaxLength=256
-//+kubebuilder:validation:XValidation:rule="self.all(e, e.startsWith('[') || e.split(':').size() <= 2)",message="each endpoint must be host:port; an IPv6 address must be bracketed, e.g. [2001:db8::1]:2379"
+//+kubebuilder:validation:XValidation:rule="self.all(e, e.startsWith('[') || e.split(':').size() <= 2)",message="an IPv6 endpoint address must be bracketed, e.g. [2001:db8::1]:2379"
 
 type Endpoints []string
 

--- a/api/v1alpha1/datastore_types.go
+++ b/api/v1alpha1/datastore_types.go
@@ -21,6 +21,9 @@ var (
 )
 
 //+kubebuilder:validation:MinItems=1
+//+kubebuilder:validation:MaxItems=64
+//+kubebuilder:validation:items:MaxLength=256
+//+kubebuilder:validation:XValidation:rule="self.all(e, e.startsWith('[') || e.split(':').size() <= 2)",message="each endpoint must be host:port; an IPv6 address must be bracketed, e.g. [2001:db8::1]:2379"
 
 type Endpoints []string
 

--- a/api/v1alpha1/datastore_types_test.go
+++ b/api/v1alpha1/datastore_types_test.go
@@ -61,6 +61,6 @@ var _ = Describe("DataStore endpoints validation", func() {
 
 		err := k8sClient.Create(ctx, ds)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("each endpoint must be host:port"))
+		Expect(err.Error()).To(ContainSubstring("an IPv6 endpoint address must be bracketed"))
 	})
 })

--- a/api/v1alpha1/datastore_types_test.go
+++ b/api/v1alpha1/datastore_types_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("DataStore endpoints validation", func() {
+	var (
+		ctx context.Context
+		ds  *DataStore
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ds = &DataStore{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "ds-endpoints-"},
+			Spec: DataStoreSpec{
+				Driver: KinePostgreSQLDriver,
+				// basicAuth with inline content satisfies the non-etcd auth CEL rules.
+				BasicAuth: &BasicAuth{
+					Username: ContentRef{Content: []byte("user")},
+					Password: ContentRef{Content: []byte("pass")},
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		if ds.GetName() != "" {
+			if err := k8sClient.Delete(ctx, ds); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+	})
+
+	It("accepts an IPv4 host:port endpoint", func() {
+		ds.Spec.Endpoints = Endpoints{"10.0.0.1:2379"}
+		Expect(k8sClient.Create(ctx, ds)).To(Succeed())
+	})
+
+	It("accepts an FQDN host:port endpoint", func() {
+		ds.Spec.Endpoints = Endpoints{"postgresql.example.com:5432"}
+		Expect(k8sClient.Create(ctx, ds)).To(Succeed())
+	})
+
+	It("accepts a bracketed IPv6 host:port endpoint", func() {
+		ds.Spec.Endpoints = Endpoints{"[2001:db8::1]:2379"}
+		Expect(k8sClient.Create(ctx, ds)).To(Succeed())
+	})
+
+	It("denies a bare (unbracketed) IPv6 endpoint", func() {
+		ds.Spec.Endpoints = Endpoints{"2001:db8::1:2379"}
+
+		err := k8sClient.Create(ctx, ds)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("each endpoint must be host:port"))
+	})
+})

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -70,6 +70,7 @@ type NetworkProfileSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="self.all(x, isCIDR(x))",message="all serviceCidrs entries must be valid CIDRs"
+	// +kubebuilder:validation:XValidation:rule="size(self) < 2 || cidr(self[0]).ip().family() != cidr(self[1]).ip().family()",message="serviceCidrs must not contain two CIDRs of the same IP family"
 	ServiceCIDRs []string `json:"serviceCidrs,omitempty"`
 	// CIDR for Kubernetes Pods: if empty, defaulted to 10.244.0.0/16.
 	// Deprecated: use PodCIDRs instead.
@@ -84,6 +85,7 @@ type NetworkProfileSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="self.all(x, isCIDR(x))",message="all podCidrs entries must be valid CIDRs"
+	// +kubebuilder:validation:XValidation:rule="size(self) < 2 || cidr(self[0]).ip().family() != cidr(self[1]).ip().family()",message="podCidrs must not contain two CIDRs of the same IP family"
 	PodCIDRs []string `json:"podCidrs,omitempty"`
 	// The DNS Service for internal resolution, it must match the Service CIDR.
 	// In case of an empty value, it is automatically computed according to the Service CIDR, e.g.:

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -343,10 +343,17 @@ type AdditionalVolumeMounts struct {
 }
 
 // ControlPlaneExtraArgs allows specifying additional arguments to the Control Plane components.
+// Extra arguments are applied last and override the defaults Kamaji sets.
 type ControlPlaneExtraArgs struct {
-	APIServer         []string `json:"apiServer,omitempty"`
+	APIServer []string `json:"apiServer,omitempty"`
+	// ControllerManager extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+	// (which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+	// kernel, override it to "0.0.0.0" here.
 	ControllerManager []string `json:"controllerManager,omitempty"`
-	Scheduler         []string `json:"scheduler,omitempty"`
+	// Scheduler extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+	// (which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+	// kernel, override it to "0.0.0.0" here.
+	Scheduler []string `json:"scheduler,omitempty"`
 	// Available only if Kamaji is running using Kine as backing storage.
 	Kine []string `json:"kine,omitempty"`
 }

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_datastores_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_datastores_spec.yaml
@@ -129,7 +129,7 @@ versions:
                 minItems: 1
                 type: array
                 x-kubernetes-validations:
-                  - message: each endpoint must be host:port; an IPv6 address must be bracketed, e.g. [2001:db8::1]:2379
+                  - message: an IPv6 endpoint address must be bracketed, e.g. [2001:db8::1]:2379
                     rule: self.all(e, e.startsWith('[') || e.split(':').size() <= 2)
               tlsConfig:
                 description: |-

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_datastores_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_datastores_spec.yaml
@@ -123,9 +123,14 @@ versions:
                   List of the endpoints to connect to the shared datastore.
                   No need for protocol, just bare IP/FQDN and port.
                 items:
+                  maxLength: 256
                   type: string
+                maxItems: 64
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                  - message: each endpoint must be host:port; an IPv6 address must be bracketed, e.g. [2001:db8::1]:2379
+                    rule: self.all(e, e.startsWith('[') || e.split(':').size() <= 2)
               tlsConfig:
                 description: |-
                   Defines the TLS/SSL configuration required to connect to the data store in a secure way.

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -7188,6 +7188,10 @@ versions:
                               type: string
                             type: array
                           controllerManager:
+                            description: |-
+                              ControllerManager extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+                              (which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+                              kernel, override it to "0.0.0.0" here.
                             items:
                               type: string
                             type: array
@@ -7197,6 +7201,10 @@ versions:
                               type: string
                             type: array
                           scheduler:
+                            description: |-
+                              Scheduler extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+                              (which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+                              kernel, override it to "0.0.0.0" here.
                             items:
                               type: string
                             type: array

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -9000,6 +9000,8 @@ versions:
                     x-kubernetes-validations:
                       - message: all podCidrs entries must be valid CIDRs
                         rule: self.all(x, isCIDR(x))
+                      - message: podCidrs must not contain two CIDRs of the same IP family
+                        rule: size(self) < 2 || cidr(self[0]).ip().family() != cidr(self[1]).ip().family()
                   port:
                     default: 6443
                     description: Port where API server will be exposed
@@ -9027,6 +9029,8 @@ versions:
                     x-kubernetes-validations:
                       - message: all serviceCidrs entries must be valid CIDRs
                         rule: self.all(x, isCIDR(x))
+                      - message: serviceCidrs must not contain two CIDRs of the same IP family
+                        rule: size(self) < 2 || cidr(self[0]).ip().family() != cidr(self[1]).ip().family()
                 type: object
               writePermissions:
                 description: |-

--- a/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
@@ -132,9 +132,14 @@ spec:
                     List of the endpoints to connect to the shared datastore.
                     No need for protocol, just bare IP/FQDN and port.
                   items:
+                    maxLength: 256
                     type: string
+                  maxItems: 64
                   minItems: 1
                   type: array
+                  x-kubernetes-validations:
+                    - message: each endpoint must be host:port; an IPv6 address must be bracketed, e.g. [2001:db8::1]:2379
+                      rule: self.all(e, e.startsWith('[') || e.split(':').size() <= 2)
                 tlsConfig:
                   description: |-
                     Defines the TLS/SSL configuration required to connect to the data store in a secure way.

--- a/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
@@ -138,7 +138,7 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-validations:
-                    - message: each endpoint must be host:port; an IPv6 address must be bracketed, e.g. [2001:db8::1]:2379
+                    - message: an IPv6 endpoint address must be bracketed, e.g. [2001:db8::1]:2379
                       rule: self.all(e, e.startsWith('[') || e.split(':').size() <= 2)
                 tlsConfig:
                   description: |-

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -9008,6 +9008,8 @@ spec:
                       x-kubernetes-validations:
                         - message: all podCidrs entries must be valid CIDRs
                           rule: self.all(x, isCIDR(x))
+                        - message: podCidrs must not contain two CIDRs of the same IP family
+                          rule: size(self) < 2 || cidr(self[0]).ip().family() != cidr(self[1]).ip().family()
                     port:
                       default: 6443
                       description: Port where API server will be exposed
@@ -9035,6 +9037,8 @@ spec:
                       x-kubernetes-validations:
                         - message: all serviceCidrs entries must be valid CIDRs
                           rule: self.all(x, isCIDR(x))
+                        - message: serviceCidrs must not contain two CIDRs of the same IP family
+                          rule: size(self) < 2 || cidr(self[0]).ip().family() != cidr(self[1]).ip().family()
                   type: object
                 writePermissions:
                   description: |-

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -7196,6 +7196,10 @@ spec:
                                 type: string
                               type: array
                             controllerManager:
+                              description: |-
+                                ControllerManager extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+                                (which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+                                kernel, override it to "0.0.0.0" here.
                               items:
                                 type: string
                               type: array
@@ -7205,6 +7209,10 @@ spec:
                                 type: string
                               type: array
                             scheduler:
+                              description: |-
+                                Scheduler extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+                                (which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+                                kernel, override it to "0.0.0.0" here.
                               items:
                                 type: string
                               type: array

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -44615,7 +44615,9 @@ Only modify if you know what you are doing.
         <td><b>controllerManager</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          ControllerManager extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+(which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+kernel, override it to "0.0.0.0" here.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -44629,7 +44631,9 @@ Only modify if you know what you are doing.
         <td><b>scheduler</b></td>
         <td>[]string</td>
         <td>
-          <br/>
+          Scheduler extra args. Kamaji sets --bind-address to the IPv6 wildcard "::"
+(which also serves IPv4 on a dual-stack pod); on hosts with IPv6 disabled in the
+kernel, override it to "0.0.0.0" here.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -402,19 +402,24 @@ func (d Deployment) buildScheduler(podSpec *corev1.PodSpec, tenantControlPlane k
 		podSpec.Containers = append(podSpec.Containers, corev1.Container{})
 	}
 
-	args := map[string]string{}
-
-	if tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs != nil {
-		args = utilities.ArgsFromSliceToMap(tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs.Scheduler)
-	}
-
 	kubeconfig := "/etc/kubernetes/scheduler.conf"
 
-	args["--authentication-kubeconfig"] = kubeconfig
-	args["--authorization-kubeconfig"] = kubeconfig
-	args["--bind-address"] = "0.0.0.0"
-	args["--kubeconfig"] = kubeconfig
-	args["--leader-elect"] = "true"
+	// Bind to the IPv6 wildcard so the component serves on both families on a
+	// dual-stack pod (and on IPv4 via v4-mapped addresses when the kernel default
+	// bindv6only=0 applies). Operators on hosts with IPv6 disabled in the kernel
+	// must override this to 0.0.0.0 via extraArgs. ExtraArgs are applied last so
+	// they can override any default, consistent with kube-controller-manager.
+	args := map[string]string{
+		"--authentication-kubeconfig": kubeconfig,
+		"--authorization-kubeconfig":  kubeconfig,
+		"--bind-address":              "::",
+		"--kubeconfig":                kubeconfig,
+		"--leader-elect":              "true",
+	}
+
+	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil {
+		args = utilities.MergeMaps(args, utilities.ArgsFromSliceToMap(extraArgs.Scheduler))
+	}
 
 	podSpec.Containers[index].Name = schedulerContainerName
 	podSpec.Containers[index].Image = tenantControlPlane.Spec.ControlPlane.Deployment.RegistrySettings.KubeSchedulerImage(tenantControlPlane.Spec.Kubernetes.Version)
@@ -477,7 +482,7 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 		"--allocate-node-cidrs":              "true",
 		"--authentication-kubeconfig":        kubeconfig,
 		"--authorization-kubeconfig":         kubeconfig,
-		"--bind-address":                     "0.0.0.0",
+		"--bind-address":                     "::",
 		"--client-ca-file":                   path.Join(kubernetesPKIPath, constants.CACertName),
 		"--cluster-name":                     tenantControlPlane.GetName(),
 		"--cluster-signing-cert-file":        path.Join(kubernetesPKIPath, constants.CACertName),
@@ -491,6 +496,14 @@ func (d Deployment) buildControllerManager(podSpec *corev1.PodSpec, tenantContro
 		"--root-ca-file":                     path.Join(kubernetesPKIPath, constants.CACertName),
 		"--service-account-private-key-file": path.Join(kubernetesPKIPath, constants.ServiceAccountPrivateKeyName),
 		"--use-service-account-credentials":  "true",
+	}
+
+	// kube-controller-manager already derives 24/64 for a dual-stack cluster-cidr;
+	// setting them explicitly pins the node CIDR sizes so a change to the upstream
+	// defaults cannot silently resize tenant node CIDRs. Both stay overridable.
+	if len(podCIDRs) > 1 {
+		args["--node-cidr-mask-size-ipv4"] = "24"
+		args["--node-cidr-mask-size-ipv6"] = "64"
 	}
 
 	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil && len(extraArgs.ControllerManager) > 0 {

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -389,4 +389,69 @@ var _ = Describe("Controlplane Deployment", func() {
 			Expect(podSpec.Containers[index].Image).To(Equal("custom-kine:latest"))
 		})
 	})
+
+	Describe("component network flags", func() {
+		containerByName := func(spec *corev1.PodSpec, name string) corev1.Container {
+			for _, c := range spec.Containers {
+				if c.Name == name {
+					return c
+				}
+			}
+			Fail("container not found: " + name)
+
+			return corev1.Container{}
+		}
+
+		It("defaults the scheduler bind-address to the IPv6 wildcard", func() {
+			podSpec := &corev1.PodSpec{}
+			d.buildScheduler(podSpec, kamajiv1alpha1.TenantControlPlane{})
+
+			Expect(containerByName(podSpec, "kube-scheduler").Args).To(ContainElement("--bind-address=::"))
+		})
+
+		It("defaults the controller-manager bind-address to the IPv6 wildcard", func() {
+			podSpec := &corev1.PodSpec{}
+			d.buildControllerManager(podSpec, kamajiv1alpha1.TenantControlPlane{})
+
+			Expect(containerByName(podSpec, "kube-controller-manager").Args).To(ContainElement("--bind-address=::"))
+		})
+
+		It("lets scheduler extraArgs override the bind-address", func() {
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.ControlPlane.Deployment.ExtraArgs = &kamajiv1alpha1.ControlPlaneExtraArgs{
+				Scheduler: []string{"--bind-address=0.0.0.0"},
+			}
+
+			podSpec := &corev1.PodSpec{}
+			d.buildScheduler(podSpec, tcp)
+
+			args := containerByName(podSpec, "kube-scheduler").Args
+			Expect(args).To(ContainElement("--bind-address=0.0.0.0"))
+			Expect(args).ToNot(ContainElement("--bind-address=::"))
+		})
+
+		It("sets per-family node CIDR masks for a dual-stack pod network", func() {
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.NetworkProfile.PodCIDRs = []string{"10.244.0.0/16", "fd00::/64"}
+
+			podSpec := &corev1.PodSpec{}
+			d.buildControllerManager(podSpec, tcp)
+
+			args := containerByName(podSpec, "kube-controller-manager").Args
+			Expect(args).To(ContainElement("--node-cidr-mask-size-ipv4=24"))
+			Expect(args).To(ContainElement("--node-cidr-mask-size-ipv6=64"))
+		})
+
+		It("omits per-family node CIDR masks for a single-stack pod network", func() {
+			tcp := kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.NetworkProfile.PodCIDRs = []string{"10.244.0.0/16"}
+
+			podSpec := &corev1.PodSpec{}
+			d.buildControllerManager(podSpec, tcp)
+
+			args := containerByName(podSpec, "kube-controller-manager").Args
+			Expect(args).ToNot(ContainElement("--node-cidr-mask-size-ipv4=24"))
+			Expect(args).ToNot(ContainElement("--node-cidr-mask-size-ipv6=64"))
+		})
+	})
 })

--- a/internal/resources/addons/coredns.go
+++ b/internal/resources/addons/coredns.go
@@ -239,7 +239,28 @@ func (c *CoreDNS) decodeManifests(ctx context.Context, tcp *kamajiv1alpha1.Tenan
 		return fmt.Errorf("unable to generate manifests: %w", err)
 	}
 
-	// If multiple service CIDRs are defined, CoreDNS needs to be configured with multiple service addresses, and ip families and dualstack if required.
+	parts := bytes.Split(manifests, []byte("---"))
+
+	if err = utilities.DecodeFromYAML(string(parts[1]), c.deployment); err != nil {
+		return fmt.Errorf("unable to decode Deployment manifest: %w", err)
+	}
+	addons_utils.SetKamajiManagedLabels(c.deployment)
+
+	if err = utilities.DecodeFromYAML(string(parts[2]), c.configMap); err != nil {
+		return fmt.Errorf("unable to decode ConfigMap manifest: %w", err)
+	}
+	addons_utils.SetKamajiManagedLabels(c.configMap)
+
+	if err = utilities.DecodeFromYAML(string(parts[3]), c.service); err != nil {
+		return fmt.Errorf("unable to decode Service manifest: %w", err)
+	}
+	addons_utils.SetKamajiManagedLabels(c.service)
+
+	// If multiple service CIDRs are defined, CoreDNS needs multiple service addresses
+	// with matching IP families. This must run AFTER decoding the kubeadm Service
+	// manifest: that manifest carries a single-family ClusterIP (derived from the
+	// primary service subnet), which would otherwise overwrite ClusterIPs[0] and leave
+	// ClusterIP != ClusterIPs[0] — rejected by the API server for a dual-stack Service.
 	if len(tcp.Spec.NetworkProfile.DNSServiceIPs) > 1 {
 		c.service.Spec.ClusterIP = tcp.Spec.NetworkProfile.DNSServiceIPs[0]
 		c.service.Spec.ClusterIPs = tcp.Spec.NetworkProfile.DNSServiceIPs
@@ -261,23 +282,6 @@ func (c *CoreDNS) decodeManifests(ctx context.Context, tcp *kamajiv1alpha1.Tenan
 		c.service.Spec.IPFamilies = families
 		c.service.Spec.IPFamilyPolicy = &policy
 	}
-
-	parts := bytes.Split(manifests, []byte("---"))
-
-	if err = utilities.DecodeFromYAML(string(parts[1]), c.deployment); err != nil {
-		return fmt.Errorf("unable to decode Deployment manifest: %w", err)
-	}
-	addons_utils.SetKamajiManagedLabels(c.deployment)
-
-	if err = utilities.DecodeFromYAML(string(parts[2]), c.configMap); err != nil {
-		return fmt.Errorf("unable to decode ConfigMap manifest: %w", err)
-	}
-	addons_utils.SetKamajiManagedLabels(c.configMap)
-
-	if err = utilities.DecodeFromYAML(string(parts[3]), c.service); err != nil {
-		return fmt.Errorf("unable to decode Service manifest: %w", err)
-	}
-	addons_utils.SetKamajiManagedLabels(c.service)
 
 	if err = utilities.DecodeFromYAML(string(parts[4]), c.clusterRole); err != nil {
 		return fmt.Errorf("unable to decode ClusterRole manifest: %w", err)


### PR DESCRIPTION
## What

The remaining fixes from #1247, which was closed as superseded by #1284. #1284 covers the first of that PR's six commits — the CIDR family order — and is in master now. The five fixes below are unrelated to CIDR ordering and are still absent from master, so this branch is #1247 rebased with that commit dropped.

They are independent fixes for pre-existing dual-stack / IPv6 gaps found while auditing the codebase after #1246 (control-plane Service IP family).

## Fixes

1. **Default component `--bind-address` to `::`** for kube-scheduler and
   kube-controller-manager (serves both families on a dual-stack pod via v4-mapped
   addresses on the default `bindv6only=0`), so an IPv6-only / dual-stack control plane
   is reachable on its healthz/metrics endpoints. The scheduler now applies `extraArgs`
   last (like kube-controller-manager); previously it loaded them first and then
   overwrote them with the hardcoded defaults, so a scheduler flag could not be
   overridden at all. On hosts with IPv6 disabled in the kernel, set `0.0.0.0` via
   `extraArgs`.

2. **Pin per-family node CIDR masks** for a dual-stack pod network:
   kube-controller-manager gets `--node-cidr-mask-size-ipv4=24` and `-ipv6=64`. These
   are the values it already derives for a dual-stack `--cluster-cidr`; setting them
   explicitly pins the sizes so a change to the upstream defaults cannot silently
   resize tenant node CIDRs. Overridable; untouched for single-stack.

3. **CoreDNS Service ClusterIP** is now set after decoding the kubeadm Service
   manifest. Previously the decode overwrote `ClusterIP` with the primary-subnet DNS IP
   while `ClusterIPs` kept the user's order, leaving `ClusterIP != ClusterIPs[0]` for an
   IPv6-primary dual-stack tenant — rejected by the API server (422). This matters more
   since #1284 merged: an IPv6-first `serviceCidrs` now keeps its order, which is
   exactly the case that triggers the mismatch.

4. **Validate DataStore endpoints** are `host:port` with bracketed IPv6
   (CEL `startsWith('[') || split(':').size() <= 2`), plus `MaxItems` / item `MaxLength`
   bounds (which also keep the rule within the CEL cost budget). A bare
   `2001:db8::1:2379` produced an invalid `--etcd-servers` URL caught only at apiserver
   start; `net.SplitHostPort` already rejected it later, this just surfaces it at
   admission time.

5. **Reject same-family `serviceCidrs`/`podCidrs` pairs** at admission
   (CEL `cidr().ip().family()`), instead of failing opaquely at apiserver bootstrap.

## Notes / deliberate scope

- The `::` bind-address default regresses only hosts with IPv6 fully disabled in the
  kernel; it is documented on the `extraArgs` fields and overridable there. It is marked
  breaking, as agreed on #1247.
- kube-apiserver deliberately keeps its own default and is not switched to `::` here;
  that is a separate, pre-existing question.
- A dropped audit finding (datastore TLS `ServerName` for IP endpoints) was intentionally
  left out as inherent to TLS-over-IP.
- The CoreDNS reorder is guarded by an explanatory comment; it isn't unit-tested because
  `decodeManifests` is integration-only (live client + `kubeadm.AddCoreDNS`).

## Testing

- Unit tests: scheduler/CM flags, DataStore endpoint CEL, serviceCidrs/podCidrs family CEL.
- `make test` green (envtest), `make golint` clean, `make manifests` and `make apidoc`
  regenerated with no drift.
