### PR TITLE
chore(samples): JSONPatch regression fix under TCP sample

### DIFF
--- a/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
+++ b/config/samples/kamaji_v1alpha1_tenantcontrolplane.yaml
@@ -1,9 +1,9 @@
 apiVersion: kamaji.clastix.io/v1alpha1
 kind: TenantControlPlane
 metadata:
-  name: k8s-133
+  name: k8s-136
   labels:
-    tenant.clastix.io: k8s-133
+    tenant.clastix.io: k8s-136
 spec:
   controlPlane:
     deployment:
@@ -11,7 +11,7 @@ spec:
     service:
       serviceType: LoadBalancer
   kubernetes:
-    version: "v1.35.7"
+    version: "v1.36.3"
     kubelet:
       configurationJSONPatches:
         - op: add
@@ -19,7 +19,7 @@ spec:
           value:
             KubeletCrashLoopBackOffMax: false
             KubeletEnsureSecretPulledImages: false
-        - op: replace
+        - op: add
           path: /cgroupDriver
           value: systemd
   networkProfile:


### PR DESCRIPTION
This pull request updates the sample configuration for a `TenantControlPlane` in `kamaji_v1alpha1_tenantcontrolplane.yaml`. The main changes involve updating the tenant name and label, upgrading the Kubernetes version, and adjusting the patch operation for the kubelet configuration.

Configuration updates:

* Updated the `metadata.name` and `labels.tenant.clastix.io` from `k8s-133` to `k8s-136` to reflect a new tenant identifier.
* Upgraded the Kubernetes version in `spec.kubernetes.version` from `v1.35.7` to `v1.36.3`.

Kubelet configuration changes:

* Changed the JSON patch operation for `cgroupDriver` from `replace` to `add` in the `kubelet.configurationJSONPatches` section, ensuring the field is added rather than replaced.