### PR TITLE
fix(konnectivity): render egress selector flag in deterministic position

### DIFF
--- a/internal/builders/controlplane/deployment.go
+++ b/internal/builders/controlplane/deployment.go
@@ -763,6 +763,13 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 	if len(d.DataStoreOverrides) != 0 {
 		managed["--etcd-servers-overrides"] = d.etcdServersOverrides()
 	}
+	// The Konnectivity addon flag is rendered together with the managed flags,
+	// in sorted position, so that the argument list is deterministic from the
+	// first reconcile pass. Appending it later (as done previously) caused a
+	// second, no-op rollout of every TenantControlPlane (clastix/kamaji#1281).
+	if tenantControlPlane.Spec.Addons.Konnectivity != nil {
+		managed[egressSelectorConfigurationFlag] = konnectivityEgressSelectorConfigurationPath
+	}
 
 	return mergeAPIServerArgs(current, userExtras, safeDefaults, managed)
 }
@@ -772,8 +779,8 @@ func (d Deployment) buildKubeAPIServerCommand(tenantControlPlane kamajiv1alpha1.
 // - user ExtraArgs are preserved verbatim, duplicates included for repeatable flags;
 // - safe defaults fill in only for flag names the user didn't provide.
 //
-// Flags already on the container that Kamaji doesn't own and the user didn't set are kept
-// (e.g. --egress-selector-config-file injected by the Konnectivity addon).
+// Flags already on the container that Kamaji doesn't own and the user didn't set are kept,
+// e.g. flags injected by addons on a previous pass.
 func mergeAPIServerArgs(current, userExtras []string, safeDefaults, managed map[string]string) []string {
 	userFlags := sets.New[string]()
 	// sanitizedExtras will contain the userExtras arguments,

--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -4,6 +4,7 @@
 package controlplane
 
 import (
+	"slices"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -204,6 +205,46 @@ var _ = Describe("Controlplane Deployment", func() {
 				"--service-account-issuer=https://kubernetes.default.svc.cluster.local",
 				"--service-cluster-ip-range=10.96.0.0/12",
 			}))
+		})
+	})
+
+	Describe("Konnectivity egress selector flag", func() {
+		var tcp kamajiv1alpha1.TenantControlPlane
+
+		JustBeforeEach(func() {
+			tcp = kamajiv1alpha1.TenantControlPlane{}
+			tcp.Spec.Addons.Konnectivity = &kamajiv1alpha1.KonnectivitySpec{}
+			tcp.Spec.NetworkProfile.Port = 7443
+		})
+
+		It("renders the flag in sorted position when the addon is enabled", func() {
+			got := d.buildKubeAPIServerCommand(tcp, "1.2.3.4", nil)
+
+			Expect(got).To(ContainElement(egressSelectorConfigurationFlag + "=" + konnectivityEgressSelectorConfigurationPath))
+			Expect(slices.IsSorted(got)).To(BeTrue())
+			// In the sorted segment, the egress selector flag lands between
+			// --client-ca-file and --enable-admission-plugins.
+			Expect(utilities.ArgsFromSliceToMap(got)).To(HaveKey(egressSelectorConfigurationFlag))
+		})
+
+		It("omits the flag when the addon is disabled", func() {
+			tcp.Spec.Addons.Konnectivity = nil
+
+			got := d.buildKubeAPIServerCommand(tcp, "1.2.3.4", nil)
+
+			Expect(got).NotTo(ContainElement(ContainSubstring(egressSelectorConfigurationFlag + "=")))
+		})
+
+		It("is deterministic across reconciler passes, regardless of the current args ordering", func() {
+			first := d.buildKubeAPIServerCommand(tcp, "1.2.3.4", nil)
+			// Simulate the previous buggy flow: the addon appended the flag at
+			// the end of the rendered args on a second pass.
+			dst := slices.Clone(first)
+			dst = append(dst, egressSelectorConfigurationFlag+"="+konnectivityEgressSelectorConfigurationPath)
+			// The next reconcile must not reorder the flags: same spec, same args.
+			second := d.buildKubeAPIServerCommand(tcp, "1.2.3.4", dst)
+
+			Expect(second).To(Equal(first))
 		})
 	})
 

--- a/internal/builders/controlplane/konnectivity_server.go
+++ b/internal/builders/controlplane/konnectivity_server.go
@@ -23,6 +23,7 @@ const (
 	CertCommonName = "system:konnectivity-server"
 
 	konnectivityEgressSelectorConfigurationPath = "/etc/kubernetes/konnectivity/configurations/egress-selector-configuration.yaml"
+	egressSelectorConfigurationFlag             = "--egress-selector-config-file"
 	konnectivityServerName                      = "konnectivity-server"
 	konnectivityServerPath                      = "/run/konnectivity"
 
@@ -179,7 +180,7 @@ func (k Konnectivity) RemovingKubeAPIServerContainerArg(podSpec *corev1.PodSpec)
 	var parsedArgs []string
 
 	for _, v := range podSpec.Containers[index].Args {
-		if strings.HasPrefix(v, "--egress-selector-config-file") || strings.HasPrefix(v, "--egress-selector-config-file=") {
+		if strings.HasPrefix(v, egressSelectorConfigurationFlag) || strings.HasPrefix(v, egressSelectorConfigurationFlag+"=") {
 			continue
 		}
 
@@ -205,28 +206,10 @@ func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec) {
 	if !found {
 		return
 	}
-	// Adding the egress selector config file flag:
-	// we can't rely on maps since not preserving order of arguments,
-	// api-server has sensitive parameters.
-	egressConfigFlag := fmt.Sprintf("--egress-selector-config-file=%s", konnectivityEgressSelectorConfigurationPath)
-
-	var foundFlag bool
-
-	for i, v := range podSpec.Containers[index].Args {
-		if !strings.HasPrefix(v, "--egress-selector-config-file") {
-			continue
-		}
-
-		if v != egressConfigFlag {
-			podSpec.Containers[index].Args[i] = egressConfigFlag
-		}
-
-		foundFlag = true
-	}
-
-	if !foundFlag {
-		podSpec.Containers[index].Args = append(podSpec.Containers[index].Args, egressConfigFlag)
-	}
+	// The --egress-selector-config-file flag is rendered by the kube-apiserver
+	// command builder as a managed flag once the Konnectivity addon is enabled,
+	// so that the resulting argument list stays deterministic from the very
+	// first reconcile pass (no reordering on subsequent reconciles).
 
 	vFound, vIndex := false, 0 //nolint:wastedassign
 	// Patching the volume mounts


### PR DESCRIPTION
Closes #1281

## Problem

When the Konnectivity addon is enabled, the `--egress-selector-config-file` flag was appended at the end of the `kube-apiserver` args by the addon builder (`konnectivity_server.go`), while `mergeAPIServerArgs` re-emits foreign flags inside its sorted Kamaji-owned segment. The two serialisations of the same command line changed the pod template hash on the reconcile following the addon pass, producing a second no-op rollout of every control plane (revision 3 differs from revision 2 only by flag order).

## Fix

Konnectivity's egress selector flag is now rendered as a managed flag in `buildKubeAPIServerCommand`, so it is emitted in sorted position from the very first deployment build. The addon builder no longer mutates the `kube-apiserver` args; it only manages containers, volumes and volume mounts. `RemovingKubeAPIServerContainerArg` now uses the shared flag constant.

The rendered pod spec is now a deterministic function of the spec: building the same control plane twice yields byte-identical args and a single pod template hash.

## Verification

- New regression tests: flag present and sorted when the addon is enabled; absent when disabled; repeated renders (simulating the previous two-pass flow) produce identical args.
- `go build ./...`, `go vet` on touched packages, and `go test ./internal/builders/controlplane/` all pass locally (Go 1.26.5).