### PR TITLE
fix(konnectivity): stable kube-apiserver arg order

### DIFF
--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -194,6 +194,27 @@ var _ = Describe("Controlplane Deployment", func() {
 			}))
 		})
 
+		It("keeps the Konnectivity egress flag in place across reconciles", func() {
+			// Regression for #1281: the addon used to append its flag after the user
+			// extras, and the next reconcile sorted it back into the Kamaji-owned
+			// segment. Same flags, different order, hence an extra no-op rollout.
+			userExtras := []string{"--audit-log-path=/var/log/audit.log"}
+
+			first := mergeAPIServerArgs(nil, userExtras, safeDefaults, managed)
+
+			podSpec := &corev1.PodSpec{Containers: []corev1.Container{{
+				Name: apiServerContainerName,
+				Args: first,
+			}}}
+			Konnectivity{}.buildVolumeMounts(podSpec, userExtras)
+
+			withKonnectivity := podSpec.Containers[0].Args
+			Expect(withKonnectivity).To(ContainElement(HavePrefix("--egress-selector-config-file=")))
+
+			// A subsequent reconcile of the Deployment builder must be a no-op.
+			Expect(mergeAPIServerArgs(withKonnectivity, userExtras, safeDefaults, managed)).To(Equal(withKonnectivity))
+		})
+
 		It("preserves foreign flags from current, sorted within the Kamaji-owned segment", func() {
 			current := []string{"--egress-selector-config-file=/etc/kubernetes/konnectivity/egress.yaml"}
 			got := mergeAPIServerArgs(current, nil, safeDefaults, managed)

--- a/internal/builders/controlplane/konnectivity_server.go
+++ b/internal/builders/controlplane/konnectivity_server.go
@@ -200,7 +200,7 @@ func (k Konnectivity) RemovingContainer(podSpec *corev1.PodSpec) {
 	}
 }
 
-func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec) {
+func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec, apiServerExtraArgs []string) {
 	found, index := utilities.HasNamedContainer(podSpec.Containers, apiServerContainerName)
 	if !found {
 		return
@@ -225,7 +225,9 @@ func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec) {
 	}
 
 	if !foundFlag {
-		podSpec.Containers[index].Args = append(podSpec.Containers[index].Args, egressConfigFlag)
+		// The flag must land in the position the Deployment builder would sort it into,
+		// otherwise the next reconcile reorders the args and rolls the control plane again.
+		podSpec.Containers[index].Args = utilities.InsertArgInSortedSegment(podSpec.Containers[index].Args, apiServerExtraArgs, egressConfigFlag)
 	}
 
 	vFound, vIndex := false, 0 //nolint:wastedassign
@@ -297,7 +299,13 @@ func (k Konnectivity) buildVolumes(status kamajiv1alpha1.KonnectivityStatus, pod
 
 func (k Konnectivity) Build(deployment *appsv1.Deployment, tenantControlPlane kamajiv1alpha1.TenantControlPlane) {
 	k.buildKonnectivityContainer(tenantControlPlane.Spec.Kubernetes.Version, tenantControlPlane.Spec.Addons.Konnectivity, *tenantControlPlane.Spec.ControlPlane.Deployment.Replicas, &deployment.Spec.Template.Spec)
-	k.buildVolumeMounts(&deployment.Spec.Template.Spec)
+
+	var apiServerExtraArgs []string
+	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil {
+		apiServerExtraArgs = extraArgs.APIServer
+	}
+
+	k.buildVolumeMounts(&deployment.Spec.Template.Spec, apiServerExtraArgs)
 	k.buildVolumes(tenantControlPlane.Status.Addons.Konnectivity, &deployment.Spec.Template.Spec)
 
 	k.Scheme.Default(deployment)

--- a/internal/utilities/args.go
+++ b/internal/utilities/args.go
@@ -39,3 +39,42 @@ func ArgsFromMapToSlice(args map[string]string) (slice []string) {
 
 	return slice
 }
+
+// InsertArgInSortedSegment inserts arg into the leading, sorted segment of args,
+// leaving the trailing segment — the user-provided extra args, deliberately kept
+// in their original order — untouched at the end.
+//
+// The kube-apiserver argument list is rendered as a sorted, Kamaji-owned segment
+// followed by the user's ExtraArgs verbatim. An addon flag appended to the very
+// end would land after the user extras, and the next reconcile would move it back
+// into the sorted segment: the same flags in a different order, hence a different
+// pod-template hash and an extra, no-op rollout of the whole control plane.
+// Inserting the flag at its final position the first time it is written keeps the
+// rendered pod spec a deterministic function of the TenantControlPlane spec.
+func InsertArgInSortedSegment(args, userExtras []string, arg string) []string {
+	boundary := sortedSegmentLen(args, userExtras)
+	index := sort.SearchStrings(args[:boundary], arg)
+
+	out := make([]string, 0, len(args)+1)
+	out = append(out, args[:index]...)
+	out = append(out, arg)
+	out = append(out, args[index:]...)
+
+	return out
+}
+
+// sortedSegmentLen reports how many leading elements of args belong to the sorted,
+// Kamaji-owned segment, by matching the user extra args off the tail of args.
+// Extras the merge dropped (duplicates of Kamaji-managed flags) are simply skipped,
+// since the rendered tail is a subsequence of userExtras preserving its order.
+func sortedSegmentLen(args, userExtras []string) int {
+	boundary := len(args)
+
+	for i := len(userExtras) - 1; i >= 0 && boundary > 0; i-- {
+		if args[boundary-1] == userExtras[i] {
+			boundary--
+		}
+	}
+
+	return boundary
+}

--- a/internal/utilities/args_test.go
+++ b/internal/utilities/args_test.go
@@ -5,6 +5,7 @@ package utilities
 
 import (
 	"maps"
+	"slices"
 	"testing"
 )
 
@@ -25,6 +26,64 @@ func TestArgsFromSliceToMap(t *testing.T) {
 		got := ArgsFromSliceToMap([]string{arg})
 		if !maps.Equal(expect, got) {
 			t.Errorf("expected input %q to result in %+v, but got %+v", arg, expect, got)
+		}
+	}
+}
+
+func TestInsertArgInSortedSegment(t *testing.T) {
+	const egress = "--egress-selector-config-file=/etc/kubernetes/konnectivity/egress.yaml"
+
+	tests := map[string]struct {
+		args       []string
+		userExtras []string
+		expect     []string
+	}{
+		"empty args": {
+			args:   nil,
+			expect: []string{egress},
+		},
+		"sorts into a Kamaji-owned only list": {
+			args:   []string{"--advertise-address=10.0.0.1", "--secure-port=6443"},
+			expect: []string{"--advertise-address=10.0.0.1", egress, "--secure-port=6443"},
+		},
+		"keeps user extras at the end": {
+			args:       []string{"--advertise-address=10.0.0.1", "--secure-port=6443", "--audit-log-path=/x"},
+			userExtras: []string{"--audit-log-path=/x"},
+			expect:     []string{"--advertise-address=10.0.0.1", egress, "--secure-port=6443", "--audit-log-path=/x"},
+		},
+		"does not sort into user extras that continue the sorted run": {
+			args:       []string{"--advertise-address=10.0.0.1", "--zzz=1"},
+			userExtras: []string{"--zzz=1"},
+			expect:     []string{"--advertise-address=10.0.0.1", egress, "--zzz=1"},
+		},
+		"handles repeated user extras": {
+			args: []string{
+				"--advertise-address=10.0.0.1",
+				"--service-account-issuer=https://one.example.com",
+				"--service-account-issuer=https://two.example.com",
+			},
+			userExtras: []string{
+				"--service-account-issuer=https://one.example.com",
+				"--service-account-issuer=https://two.example.com",
+			},
+			expect: []string{
+				"--advertise-address=10.0.0.1",
+				egress,
+				"--service-account-issuer=https://one.example.com",
+				"--service-account-issuer=https://two.example.com",
+			},
+		},
+		"skips user extras the merge dropped": {
+			args:       []string{"--advertise-address=10.0.0.1", "--audit-log-path=/x"},
+			userExtras: []string{"--advertise-address=192.168.0.1", "--audit-log-path=/x"},
+			expect:     []string{"--advertise-address=10.0.0.1", egress, "--audit-log-path=/x"},
+		},
+	}
+
+	for name, tc := range tests {
+		got := InsertArgInSortedSegment(tc.args, tc.userExtras, egress)
+		if !slices.Equal(got, tc.expect) {
+			t.Errorf("%s: expected %+v, but got %+v", name, tc.expect, got)
 		}
 	}
 }


### PR DESCRIPTION
Closes #1281.

## Problem

The Konnectivity addon appends `--egress-selector-config-file` to the **end** of the `kube-apiserver` container args:

```go
podSpec.Containers[index].Args = append(podSpec.Containers[index].Args, egressConfigFlag)
```

That is past the user's `ExtraArgs`, which `mergeAPIServerArgs` deliberately keeps unsorted at the tail. On the next reconcile the Deployment builder sees the flag in `current`, classifies it as a preserved foreign flag, and sorts it into the Kamaji-owned segment.

Same flags, same values, two different serialisations — so two pod-template hashes, so the Deployment controller rolls every control-plane pod a second time for no functional change. On a 2-replica control plane this discards pods that have already been scheduled and started.

## Fix

Insert the flag at the position the Deployment builder would sort it into, so it lands in its final place the first time it is written. The rendered pod spec then stays a deterministic function of the `TenantControlPlane` spec.

The insertion point is derived by matching the user's `ExtraArgs.APIServer` off the tail of the arg list, which locates the boundary between the sorted Kamaji-owned segment and the verbatim user segment exactly — including when an extra was dropped as a duplicate of a managed flag, and when the user's extras happen to continue the sorted run.

This PR addresses only the arg-ordering rollout. Collapsing revision 1 into revision 2 by rendering the addon containers in the initial Deployment is the larger, separate change the issue mentions.

## Verification

A test written against the unpatched code reproduces the report exactly:

```
rev2 (konnectivity appended): [... --tls-cert-file=... --egress-selector-config-file=...]
rev3 (re-sorted):             [... --egress-selector-config-file=... --tls-cert-file=...]
ISSUE 1281 REPRODUCED: args reordered at index 2
```

With the patch, `rev2` and `rev3` are byte-identical. The new spec in `deployment_test.go` fails on `master` and passes here.

Covered `ExtraArgs` shapes: none, sorting before/after the Kamaji segment, extras that continue the sorted run, repeated flags (`--service-account-issuer` twice), an extra dropped as a duplicate of a managed flag, and extras sorting either side of the egress flag.

- `go test ./internal/...` — all 11 packages pass
- `make golint` (`golangci-lint run -c .golangci.yml`) — 0 issues

`api/v1alpha1` was not run: it needs envtest binaries I don't have locally.

## Note

I don't have a cluster to reproduce the rollout end to end — the verification above is at the builder level, against the exact arg lists from the issue. The reporter offered to test a patch, so a confirmation on a real `TenantControlPlane` with konnectivity enabled and 2 replicas would be worth having before merge.
