### PR TITLE
fix(api): preferredAddressTypes is an ordered list

### DIFF
--- a/api/v1alpha1/kubelet_preferred_address_types_test.go
+++ b/api/v1alpha1/kubelet_preferred_address_types_test.go
@@ -1,0 +1,101 @@
+// Copyright 2022 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Kubelet preferredAddressTypes", func() {
+	var (
+		ctx context.Context
+		tcp *TenantControlPlane
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		tcp = &TenantControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tcp-preferred-address-types",
+				Namespace: "default",
+			},
+			Spec: TenantControlPlaneSpec{},
+		}
+		tcp.Spec.ControlPlane.Service.ServiceType = ServiceTypeClusterIP
+	})
+
+	AfterEach(func() {
+		if err := k8sClient.Delete(ctx, tcp); err != nil && !apierrors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	It("defaults to InternalIP, ExternalIP, Hostname in that order", func() {
+		Expect(k8sClient.Create(ctx, tcp)).ToNot(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: tcp.Name, Namespace: tcp.Namespace}, tcp)).ToNot(HaveOccurred())
+		Expect(tcp.Spec.Kubernetes.Kubelet.PreferredAddressTypes).To(Equal([]KubeletPreferredAddressType{
+			NodeInternalIP, NodeExternalIP, NodeHostName,
+		}))
+	})
+
+	It("stores a non-default order verbatim", func() {
+		// The API server takes the first address type a node reports, so the order
+		// is part of the meaning of this field and must survive a round-trip.
+		tcp.Spec.Kubernetes.Kubelet.PreferredAddressTypes = []KubeletPreferredAddressType{
+			NodeHostName, NodeInternalIP,
+		}
+
+		Expect(k8sClient.Create(ctx, tcp)).ToNot(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: tcp.Name, Namespace: tcp.Namespace}, tcp)).ToNot(HaveOccurred())
+		Expect(tcp.Spec.Kubernetes.Kubelet.PreferredAddressTypes).To(Equal([]KubeletPreferredAddressType{
+			NodeHostName, NodeInternalIP,
+		}))
+	})
+
+	It("keeps the applied order when a second field manager owns entries too", func() {
+		// listType=set declares the entries unordered, and structured-merge-diff then
+		// interleaves the two sides rather than taking the applier's list: a second
+		// manager applying [Hostname, InternalDNS] used to end up with
+		// [InternalIP, ExternalIP, Hostname, InternalDNS] stored. Since the API server
+		// takes the first address type a node reports, that silently changes which
+		// address kubelet connections are attempted on.
+		apply := func(manager string, addressTypes ...KubeletPreferredAddressType) {
+			obj := &TenantControlPlane{
+				TypeMeta:   metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "TenantControlPlane"},
+				ObjectMeta: metav1.ObjectMeta{Name: tcp.Name, Namespace: tcp.Namespace},
+			}
+			obj.Spec.ControlPlane.Service.ServiceType = ServiceTypeClusterIP
+			obj.Spec.Kubernetes.Kubelet.PreferredAddressTypes = addressTypes
+
+			Expect(k8sClient.Patch(ctx, obj, client.Apply, client.FieldOwner(manager), client.ForceOwnership)).ToNot(HaveOccurred())
+		}
+
+		apply("manager-a", NodeInternalIP, NodeExternalIP, NodeHostName)
+		apply("manager-b", NodeHostName, NodeInternalDNS)
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: tcp.Name, Namespace: tcp.Namespace}, tcp)).ToNot(HaveOccurred())
+		Expect(tcp.Spec.Kubernetes.Kubelet.PreferredAddressTypes).To(Equal([]KubeletPreferredAddressType{
+			NodeHostName, NodeInternalDNS,
+		}))
+	})
+
+	It("rejects duplicated entries", func() {
+		tcp.Spec.Kubernetes.Kubelet.PreferredAddressTypes = []KubeletPreferredAddressType{
+			NodeInternalIP, NodeExternalIP, NodeInternalIP,
+		}
+
+		err := k8sClient.Create(ctx, tcp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("preferredAddressTypes entries must be unique"))
+	})
+})

--- a/api/v1alpha1/tenantcontrolplane_types.go
+++ b/api/v1alpha1/tenantcontrolplane_types.go
@@ -118,7 +118,9 @@ type KubeletSpec struct {
 	// Default to InternalIP, ExternalIP, Hostname.
 	//+kubebuilder:default={"InternalIP","ExternalIP","Hostname"}
 	//+kubebuilder:validation:MinItems=1
-	//+listType=set
+	//+kubebuilder:validation:MaxItems=5
+	//+kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, y == x))",message="preferredAddressTypes entries must be unique"
+	//+listType=atomic
 	PreferredAddressTypes []KubeletPreferredAddressType `json:"preferredAddressTypes,omitempty"`
 	// CGroupFS defines the cgroup driver for Kubelet
 	// https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/

--- a/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
+++ b/charts/kamaji-crds/hack/kamaji.clastix.io_tenantcontrolplanes_spec.yaml
@@ -8888,9 +8888,13 @@ versions:
                             - InternalDNS
                             - ExternalDNS
                           type: string
+                        maxItems: 5
                         minItems: 1
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                          - message: preferredAddressTypes entries must be unique
+                            rule: self.all(x, self.exists_one(y, y == x))
                     type: object
                   version:
                     description: Kubernetes Version for the tenant control plane

--- a/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -8896,9 +8896,13 @@ spec:
                               - InternalDNS
                               - ExternalDNS
                             type: string
+                          maxItems: 5
                           minItems: 1
                           type: array
-                          x-kubernetes-list-type: set
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                            - message: preferredAddressTypes entries must be unique
+                              rule: self.all(x, self.exists_one(y, y == x))
                       type: object
                     version:
                       description: Kubernetes Version for the tenant control plane


### PR DESCRIPTION
Closes #1282.

## Problem

`kubelet.preferredAddressTypes` is declared `+listType=set`, which tells the API server the entries are an *unordered* collection. The order is part of the field's meaning:

- the godoc says "**Ordered** list of the preferred NodeAddressTypes";
- Kamaji joins it verbatim into `--kubelet-preferred-address-types`;
- the API server returns the **first** address type a node reports;
- #858 deliberately changed the default from `Hostname,InternalIP,ExternalIP` to `InternalIP,ExternalIP,Hostname` because Hostname-first made node connectivity unreliable.

Under server-side apply, `structured-merge-diff` merges a `set` by anchoring on shared entries and interleaving the rest, so an applier does not get its own ordering back once a second field manager owns entries in the same list.

## Demonstrated

The new spec applies the list from two field managers. On `master`:

```
manager-a applies: [InternalIP, ExternalIP, Hostname]
manager-b applies: [Hostname, InternalDNS]
stored:            [InternalIP, ExternalIP, Hostname, InternalDNS]
```

`manager-b` asked for `Hostname` first and got `InternalIP` first, plus two entries it never applied. With this change the stored value is exactly `[Hostname, InternalDNS]`.

This is the quiet failure the issue describes: the spec still looks reasonable, but the address type kubelet connections are attempted on is not the one the applier asked for.

## Change

Follows option 1 from the issue — `atomic` plus a CEL uniqueness rule, so the ordering guarantee is restored without losing the validation that #812 added:

```go
//+kubebuilder:validation:MinItems=1
//+kubebuilder:validation:MaxItems=5
//+kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, y == x))",message="preferredAddressTypes entries must be unique"
//+listType=atomic
```

`+kubebuilder:validation:UniqueItems` is not usable here: apiextensions rejects the resulting schema ("uniqueItems cannot be set to true since the runtime complexity becomes quadratic").

CRDs regenerated with `make manifests`.

## Verification

envtest (Kubernetes 1.31.0, as pinned by `ENVTEST_K8S_VERSION`). Three new specs, all of which **fail on `master` and pass here** where the behaviour differs:

| spec | on `master` | with this change |
|---|---|---|
| default is `InternalIP, ExternalIP, Hostname` in order | passes | passes |
| a non-default order round-trips verbatim | passes | passes |
| a second field manager's order is kept | **fails** — `[InternalIP ExternalIP Hostname InternalDNS]` | passes |
| duplicates are rejected | **fails** — different message | passes |

On duplicates: `master` rejects them with `preferredAddressTypes[2]: Duplicate value: "InternalIP"`; with the CEL rule the message becomes `preferredAddressTypes entries must be unique`. Uniqueness is still enforced — only the message changes. Worth flagging in case anything matches on that string.

- `go test ./api/v1alpha1/` — 61 specs pass
- `go test ./internal/...` — all pass
- `make golint` — 0 issues

## Migration

Schema-only; stored objects are untouched. As the issue notes, `managedFields` bookkeeping for this field changes shape once (set entries are tracked per value, atomic as a single field), so expect a one-time ownership churn on the next apply.
