### PR TITLE
fix(konnectivity): stable kube-apiserver arg order

### DIFF
--- a/internal/builders/controlplane/deployment_test.go
+++ b/internal/builders/controlplane/deployment_test.go
@@ -194,6 +194,20 @@ var _ = Describe("Controlplane Deployment", func() {
 			}))
 		})
 
+		It("keeps the Konnectivity egress flag in place across reconciles", func() {
+			userExtras := []string{"--audit-log-path=/var/log/audit.log"}
+
+			podSpec := &corev1.PodSpec{Containers: []corev1.Container{{
+				Name: apiServerContainerName,
+				Args: mergeAPIServerArgs(nil, userExtras, safeDefaults, managed),
+			}}}
+			Konnectivity{}.buildVolumeMounts(podSpec, userExtras)
+
+			args := podSpec.Containers[0].Args
+			// A subsequent reconcile of the Deployment builder must not reorder them.
+			Expect(mergeAPIServerArgs(args, userExtras, safeDefaults, managed)).To(Equal(args))
+		})
+
 		It("preserves foreign flags from current, sorted within the Kamaji-owned segment", func() {
 			current := []string{"--egress-selector-config-file=/etc/kubernetes/konnectivity/egress.yaml"}
 			got := mergeAPIServerArgs(current, nil, safeDefaults, managed)

--- a/internal/builders/controlplane/konnectivity_server.go
+++ b/internal/builders/controlplane/konnectivity_server.go
@@ -200,7 +200,7 @@ func (k Konnectivity) RemovingContainer(podSpec *corev1.PodSpec) {
 	}
 }
 
-func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec) {
+func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec, apiServerExtraArgs []string) {
 	found, index := utilities.HasNamedContainer(podSpec.Containers, apiServerContainerName)
 	if !found {
 		return
@@ -225,7 +225,7 @@ func (k Konnectivity) buildVolumeMounts(podSpec *corev1.PodSpec) {
 	}
 
 	if !foundFlag {
-		podSpec.Containers[index].Args = append(podSpec.Containers[index].Args, egressConfigFlag)
+		podSpec.Containers[index].Args = utilities.InsertArgInSortedSegment(podSpec.Containers[index].Args, apiServerExtraArgs, egressConfigFlag)
 	}
 
 	vFound, vIndex := false, 0 //nolint:wastedassign
@@ -297,7 +297,12 @@ func (k Konnectivity) buildVolumes(status kamajiv1alpha1.KonnectivityStatus, pod
 
 func (k Konnectivity) Build(deployment *appsv1.Deployment, tenantControlPlane kamajiv1alpha1.TenantControlPlane) {
 	k.buildKonnectivityContainer(tenantControlPlane.Spec.Kubernetes.Version, tenantControlPlane.Spec.Addons.Konnectivity, *tenantControlPlane.Spec.ControlPlane.Deployment.Replicas, &deployment.Spec.Template.Spec)
-	k.buildVolumeMounts(&deployment.Spec.Template.Spec)
+	var apiServerExtraArgs []string
+	if extraArgs := tenantControlPlane.Spec.ControlPlane.Deployment.ExtraArgs; extraArgs != nil {
+		apiServerExtraArgs = extraArgs.APIServer
+	}
+
+	k.buildVolumeMounts(&deployment.Spec.Template.Spec, apiServerExtraArgs)
 	k.buildVolumes(tenantControlPlane.Status.Addons.Konnectivity, &deployment.Spec.Template.Spec)
 
 	k.Scheme.Default(deployment)

--- a/internal/utilities/args.go
+++ b/internal/utilities/args.go
@@ -39,3 +39,31 @@ func ArgsFromMapToSlice(args map[string]string) (slice []string) {
 
 	return slice
 }
+
+// InsertArgInSortedSegment inserts arg into the sorted, Kamaji-owned head of args,
+// leaving the user's extra args at the tail in their original order.
+//
+// kube-apiserver args are rendered as a sorted segment followed by the user's
+// ExtraArgs verbatim. An addon flag appended past the extras would be sorted back
+// into the segment on the next reconcile: same flags, different order, a new
+// pod-template hash, and a redundant rollout of the control plane.
+func InsertArgInSortedSegment(args, userExtras []string, arg string) []string {
+	// The end of the sorted segment is found by matching the extras off the tail of
+	// args; extras the merge dropped as duplicates of managed flags are skipped.
+	boundary := len(args)
+
+	for i := len(userExtras) - 1; i >= 0 && boundary > 0; i-- {
+		if args[boundary-1] == userExtras[i] {
+			boundary--
+		}
+	}
+
+	index := sort.SearchStrings(args[:boundary], arg)
+
+	out := make([]string, 0, len(args)+1)
+	out = append(out, args[:index]...)
+	out = append(out, arg)
+	out = append(out, args[index:]...)
+
+	return out
+}

--- a/internal/utilities/args_test.go
+++ b/internal/utilities/args_test.go
@@ -5,6 +5,7 @@ package utilities
 
 import (
 	"maps"
+	"slices"
 	"testing"
 )
 
@@ -25,6 +26,42 @@ func TestArgsFromSliceToMap(t *testing.T) {
 		got := ArgsFromSliceToMap([]string{arg})
 		if !maps.Equal(expect, got) {
 			t.Errorf("expected input %q to result in %+v, but got %+v", arg, expect, got)
+		}
+	}
+}
+
+func TestInsertArgInSortedSegment(t *testing.T) {
+	const egress = "--egress-selector-config-file=/etc/kubernetes/konnectivity/egress.yaml"
+
+	tests := map[string]struct {
+		args       []string
+		userExtras []string
+		expect     []string
+	}{
+		"sorts into the Kamaji-owned segment": {
+			args:   []string{"--advertise-address=10.0.0.1", "--secure-port=6443"},
+			expect: []string{"--advertise-address=10.0.0.1", egress, "--secure-port=6443"},
+		},
+		"leaves user extras at the tail": {
+			args:       []string{"--advertise-address=10.0.0.1", "--secure-port=6443", "--audit-log-path=/x"},
+			userExtras: []string{"--audit-log-path=/x"},
+			expect:     []string{"--advertise-address=10.0.0.1", egress, "--secure-port=6443", "--audit-log-path=/x"},
+		},
+		"does not sort into extras that continue the sorted run": {
+			args:       []string{"--advertise-address=10.0.0.1", "--zzz=1"},
+			userExtras: []string{"--zzz=1"},
+			expect:     []string{"--advertise-address=10.0.0.1", egress, "--zzz=1"},
+		},
+		"skips extras the merge dropped as managed duplicates": {
+			args:       []string{"--advertise-address=10.0.0.1", "--audit-log-path=/x"},
+			userExtras: []string{"--advertise-address=192.168.0.1", "--audit-log-path=/x"},
+			expect:     []string{"--advertise-address=10.0.0.1", egress, "--audit-log-path=/x"},
+		},
+	}
+
+	for name, tc := range tests {
+		if got := InsertArgInSortedSegment(tc.args, tc.userExtras, egress); !slices.Equal(got, tc.expect) {
+			t.Errorf("%s: expected %+v, but got %+v", name, tc.expect, got)
 		}
 	}
 }


### PR DESCRIPTION
Closes #1281.

## Problem

The Konnectivity addon appends its flag to the end of the `kube-apiserver` args:

```go
podSpec.Containers[index].Args = append(podSpec.Containers[index].Args, egressConfigFlag)
```

That is past the user's `ExtraArgs`, which `mergeAPIServerArgs` keeps unsorted at the tail. On the next reconcile the Deployment builder sees the flag in `current`, treats it as a preserved foreign flag, and sorts it into the Kamaji-owned segment.

Same flags, two orderings, two pod-template hashes — so every control-plane pod rolls a second time for no functional change.

## Change

Insert the flag where the builder would sort it, so it lands in its final position the first time it is written. The insertion point is found by matching `ExtraArgs.APIServer` off the tail of the arg list, which locates the boundary between the sorted segment and the verbatim user segment.

Scoped to the arg ordering only. Collapsing revision 1 into revision 2 by rendering addon containers in the initial Deployment is the separate, larger change the issue mentions.

## Verification

The new spec in `deployment_test.go` fails on `master` and passes here.

- `go test ./internal/...` — pass
- `make golint` — 0 issues

`api/v1alpha1` needs envtest binaries and was run separately; it is unaffected by this change.

Also verified on a cluster (EKS 1.36, tenant `v1.30.2`, konnectivity, 2 replicas), building both images from source so they differ only by this commit: `master` produces 3 ReplicaSets at `generation: 3` with the rev2/rev3 arg diff from the issue; this branch produces 2 at `generation: 2`, with the flag written at its sorted position the first time. Full output in the comment below.
